### PR TITLE
fix(packages/infra): address auth code-review findings for issue #38

### DIFF
--- a/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client.Tests.Unit/Authentication/TokenCacheInitializerShould.cs
+++ b/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client.Tests.Unit/Authentication/TokenCacheInitializerShould.cs
@@ -93,6 +93,21 @@ public class TokenCacheInitializerShould
     }
 
     [Fact]
+    public async Task UseSystemAdminAccountId_WhenNoAccountIdProvided()
+    {
+        Func<StorageCreationProperties, ITokenCache, Task> failingKeychain =
+            (_, _) => Task.FromException(new InvalidOperationException("Keychain unavailable."));
+        _consentStore.HasConsented(AuthenticationOptions.SystemAdminAccountId).Returns(false);
+        _consentPrompt.RequestConsentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        var sut = new TokenCacheInitializer(_consentStore, _consentPrompt, failingKeychain);
+
+        await sut.InitializeAsync(_app, _options, cancellationToken: TestContext.Current.CancellationToken);
+
+        _consentStore.Received(1).RecordConsent(AuthenticationOptions.SystemAdminAccountId, true);
+    }
+
+    [Fact]
     public async Task RegisterInsecureCacheCallbacks_WhenConsentGrantedAndKeychainUnavailable()
     {
         Func<StorageCreationProperties, ITokenCache, Task> failingKeychain =

--- a/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/AStar.Dev.OneDrive.Client.xml
+++ b/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/AStar.Dev.OneDrive.Client.xml
@@ -18,6 +18,14 @@
                 Work and school accounts are explicitly excluded.
             </remarks>
         </member>
+        <member name="F:AStar.Dev.OneDrive.Client.Authentication.AuthenticationOptions.SystemAdminAccountId">
+            <summary>
+                Sentinel account identifier used during initial application configuration,
+                before any real Microsoft account has authenticated (AU-03).
+                Consent decisions recorded under this ID apply machine-wide and cover
+                the bootstrap window before the first interactive sign-in.
+            </summary>
+        </member>
         <member name="P:AStar.Dev.OneDrive.Client.Authentication.AuthenticationOptions.ClientId">
             <summary>
                 The MSAL application (client) ID from the Azure app registration.
@@ -193,8 +201,8 @@
                 Registers the MSAL token cache on an <see cref="T:Microsoft.Identity.Client.IPublicClientApplication"/>.
                 On platforms where the OS keychain is available the cache is secured by
                 the keychain.  When the keychain is unavailable (common on headless Linux),
-                explicit user consent is required before falling back to a machine-scoped
-                encrypted local file — tokens are never stored as plain text (AU-02, AU-03).
+                explicit user consent is required before falling back to an unencrypted local
+                file — the user is informed that the file offers no additional protection (AU-02, AU-03).
             </summary>
         </member>
         <member name="M:AStar.Dev.OneDrive.Client.Authentication.TokenCacheInitializer.#ctor(AStar.Dev.OneDrive.Client.Authentication.IConsentStore,AStar.Dev.OneDrive.Client.Authentication.IConsentPrompt)">
@@ -219,6 +227,9 @@
             <param name="options">Authentication options supplying cache path settings.</param>
             <param name="accountId">
                 The unique identifier of the account whose consent record is consulted.
+                Defaults to <see cref="F:AStar.Dev.OneDrive.Client.Authentication.AuthenticationOptions.SystemAdminAccountId"/> for use
+                during initial application configuration, before any real Microsoft account
+                has authenticated (AU-03).
             </param>
             <param name="cancellationToken">Cancellation token.</param>
             <exception cref="T:System.InvalidOperationException">

--- a/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/AuthenticationOptions.cs
+++ b/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/AuthenticationOptions.cs
@@ -15,6 +15,14 @@ public sealed record AuthenticationOptions
     public const string ConsumersTenant = "consumers";
 
     /// <summary>
+    ///     Sentinel account identifier used during initial application configuration,
+    ///     before any real Microsoft account has authenticated (AU-03).
+    ///     Consent decisions recorded under this ID apply machine-wide and cover
+    ///     the bootstrap window before the first interactive sign-in.
+    /// </summary>
+    public const string SystemAdminAccountId = "system-admin";
+
+    /// <summary>
     ///     The MSAL application (client) ID from the Azure app registration.
     /// </summary>
     public required string ClientId { get; init; }

--- a/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/FileConsentStore.cs
+++ b/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/FileConsentStore.cs
@@ -11,6 +11,7 @@ public sealed class FileConsentStore : IConsentStore
 {
     private const string ConsentFileName = "consent.json";
 
+    private readonly Lock _lock = new();
     private readonly string _filePath;
     private Dictionary<string, bool> _consent;
 
@@ -31,7 +32,10 @@ public sealed class FileConsentStore : IConsentStore
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(accountId);
 
-        return _consent.TryGetValue(accountId, out var consented) && consented;
+        lock(_lock)
+        {
+            return _consent.TryGetValue(accountId, out var consented) && consented;
+        }
     }
 
     /// <inheritdoc />
@@ -39,8 +43,11 @@ public sealed class FileConsentStore : IConsentStore
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(accountId);
 
-        _consent[accountId] = consented;
-        Save();
+        lock(_lock)
+        {
+            _consent[accountId] = consented;
+            Save();
+        }
     }
 
     private Dictionary<string, bool> Load()

--- a/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/TokenCacheInitializer.cs
+++ b/packages/infra/astar-dev-onedrive-client/AStar.Dev.OneDrive.Client/Authentication/TokenCacheInitializer.cs
@@ -7,16 +7,16 @@ namespace AStar.Dev.OneDrive.Client.Authentication;
 ///     Registers the MSAL token cache on an <see cref="IPublicClientApplication"/>.
 ///     On platforms where the OS keychain is available the cache is secured by
 ///     the keychain.  When the keychain is unavailable (common on headless Linux),
-///     explicit user consent is required before falling back to a machine-scoped
-///     encrypted local file — tokens are never stored as plain text (AU-02, AU-03).
+///     explicit user consent is required before falling back to an unencrypted local
+///     file — the user is informed that the file offers no additional protection (AU-02, AU-03).
 /// </summary>
 public sealed class TokenCacheInitializer
 {
     private const string ConsentMessage =
         "The secure OS keychain is unavailable on this machine. " +
         "To avoid signing in every time the application starts, your authentication token " +
-        "can be stored in an encrypted local file. " +
-        "The token is protected with a machine-scoped key and is never stored as plain text. " +
+        "can be stored in a local file. " +
+        "Warning: this file is not encrypted and could be read by anyone with access to this machine. " +
         "Would you like to enable this?";
 
     private readonly IConsentStore _consentStore;
@@ -52,13 +52,16 @@ public sealed class TokenCacheInitializer
     /// <param name="options">Authentication options supplying cache path settings.</param>
     /// <param name="accountId">
     ///     The unique identifier of the account whose consent record is consulted.
+    ///     Defaults to <see cref="AuthenticationOptions.SystemAdminAccountId"/> for use
+    ///     during initial application configuration, before any real Microsoft account
+    ///     has authenticated (AU-03).
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">
     ///     Thrown when the OS keychain is unavailable and the user declines
     ///     consent for the insecure fallback store.
     /// </exception>
-    public async Task InitializeAsync(IPublicClientApplication app, AuthenticationOptions options, string accountId, CancellationToken cancellationToken = default)
+    public async Task InitializeAsync(IPublicClientApplication app, AuthenticationOptions options, string accountId = AuthenticationOptions.SystemAdminAccountId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentNullException.ThrowIfNull(options);


### PR DESCRIPTION
- Correct misleading consent message: token file is unencrypted, not machine-key-protected (was a false security claim shown to the user)
- Thread-safe FileConsentStore using C# 14 Lock object (dictionary and file I/O were unprotected against concurrent access)
- Add AuthenticationOptions.SystemAdminAccountId sentinel so TokenCacheInitializer.InitializeAsync can be called before any MSAL account exists (chicken-and-egg on first launch); accountId now defaults to this constant
- Add UseSystemAdminAccountId_WhenNoAccountIdProvided test (18 passing)

# Summary

Please include a brief description of the change and the motivation.

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links
<!-- e.g., Closes #123, Relates to #456 -->

## How was this tested?
- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas
<!-- e.g., libs/MyLib, apps/MyApp, web/Api -->

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [ ] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] The failing-test commit is included in this branch history (the failing test must be present in the PR history before or alongside production code).

If the TDD checklist is not applicable for this PR (e.g., documentation-only or chore), explain why in the description.

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Verify that the PR history includes the failing-test commit (or an explanation why not).
- Ensure CI passed for all OS runners.
