### PR TITLE
fix(desktop/sync): stop HttpMessageHandler cleanup spam after sync

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -269,5 +269,4 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
         public AllowedHostsValidator AllowedHostsValidator { get; } = new(["graph.microsoft.com"]);
     }
 
-    public void Dispose() => uploadService.Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -2,7 +2,7 @@ using AStar.Dev.OneDrive.Sync.Client.Models;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
-public interface IGraphService : IDisposable
+public interface IGraphService
 {
     /// <summary>
     /// Returns the ID of the user's default drive (OneDrive for Business or Personal).

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
@@ -3,29 +3,27 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// <summary>
 /// Handles file downloads with automatic retry on 429 Too Many Requests.
 /// Uses exponential backoff respecting the Retry-After header when present.
-/// A single shared HttpClient instance is used across all downloads.
+/// A new HttpClient is obtained from IHttpClientFactory per download call so the
+/// factory can rotate and dispose handlers freely without this class holding stale references.
 /// </summary>
-public sealed class HttpDownloader : IDisposable, IHttpDownloader
+public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttpDownloader
 {
-    private readonly HttpClient _http;
-
+    private const string UserAgent         = "AStar.Dev.OneDrive.Sync/1.0";
     private const int    MaxRetries        = 5;
     private const double BaseDelaySeconds  = 2.0;
     private const double MaxDelaySeconds   = 120.0;
-
-    public HttpDownloader(IHttpClientFactory httpClientFactory)
-    {
-        _http = httpClientFactory.CreateClient();
-        _http.DefaultRequestHeaders.Add("User-Agent", "AStar.Dev.OneDrive.Sync/1.0");
-    }
 
     /// <summary>
     /// Downloads the file at <paramref name="url"/> to <paramref name="localPath"/>.
     /// Automatically retries on 429 with exponential backoff.
     /// Preserves the remote last-modified timestamp on the local file.
     /// </summary>
+    /// <inheritdoc />
     public async Task DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
     {
+        using var http = httpClientFactory.CreateClient();
+        http.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+
         int attempt = 0;
 
         while(true)
@@ -37,7 +35,7 @@ public sealed class HttpDownloader : IDisposable, IHttpDownloader
 
             try
             {
-                response = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+                response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
 
                 if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
@@ -120,5 +118,4 @@ public sealed class HttpDownloader : IDisposable, IHttpDownloader
     private static double CalculateExponentialBackoff(int attempt)
             => Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
 
-    public void Dispose() => _http.Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IHttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IHttpDownloader.cs
@@ -8,6 +8,4 @@ public interface IHttpDownloader
     /// Preserves the remote last-modified timestamp on the local file.
     /// </summary>
     Task DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default);
-
-    void Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
@@ -9,6 +9,4 @@ public interface IUploadService
     /// Returns the uploaded DriveItem ID on success.
     /// </summary>
     Task<string> UploadAsync(GraphServiceClient client, string driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default);
-
-    void Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
@@ -17,7 +17,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// never loads more than ~4 jobs per worker into memory at once.
 /// With 300k files this means memory stays flat regardless of job count.
 /// </summary>
-public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGraphService graphService, IHttpDownloader downloader, int workerCount = 8) : IDisposable
+public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGraphService graphService, IHttpDownloader downloader, int workerCount = 8)
 {
     private readonly Lock _lock = new();
 
@@ -100,5 +100,4 @@ public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGr
         Serilog.Log.Information("[Pipeline] Complete — {Done}/{Total} jobs processed", done, total);
     }
 
-    public void Dispose() => downloader.Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -16,15 +16,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 ///
 /// Chunk size: 10 MB (must be a multiple of 320 KB per Graph API requirement).
 /// </summary>
-public sealed class UploadService(IHttpClientFactory httpClientFactory): IDisposable, IUploadService
+public sealed class UploadService(IHttpClientFactory httpClientFactory) : IUploadService
 {
     private const int ChunkSize10Mb = 10 * 1024 * 1024;
 
     private const int    MaxRetries       = 5;
     private const double BaseDelaySeconds = 2.0;
     private const double MaxDelaySeconds  = 120.0;
-
-    private readonly HttpClient _http = httpClientFactory.CreateClient();
 
     /// <summary>
     /// Uploads a local file to OneDrive using a resumable upload session.
@@ -86,6 +84,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory): IDispos
 
     private async Task<string> UploadChunksAsync(string sessionUrl, string localPath, long totalBytes, IProgress<long>? progress, CancellationToken ct)
     {
+        using var http = httpClientFactory.CreateClient();
         await using var file = File.OpenRead(localPath);
         byte[] buffer    = new byte[ChunkSize10Mb];
         long uploaded  = 0L;
@@ -102,7 +101,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory): IDispos
                 break;
 
             long rangeEnd  = uploaded + bytesRead - 1;
-            string? itemId    = await UploadChunkWithRetryAsync(sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
+            string? itemId    = await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
 
             uploaded += bytesRead;
             progress?.Report(uploaded);
@@ -114,7 +113,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory): IDispos
         throw new InvalidOperationException("Upload completed without receiving item ID from Graph API.");
     }
 
-    private async Task<string?> UploadChunkWithRetryAsync(string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
+    private static async Task<string?> UploadChunkWithRetryAsync(HttpClient http, string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
     {
         int attempt = 0;
 
@@ -129,7 +128,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory): IDispos
                 content.Headers.Add("Content-Range", $"bytes {rangeStart}-{rangeEnd}/{totalBytes}");
                 content.Headers.Add("Content-Length", chunk.Length.ToString(CultureInfo.CurrentCulture));
 
-                using var response = await _http.PutAsync(sessionUrl, content, ct);
+                using var response = await http.PutAsync(sessionUrl, content, ct);
 
                 if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
@@ -199,5 +198,4 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory): IDispos
         return TimeSpan.FromSeconds(seconds + jitter);
     }
 
-    public void Dispose() => _http.Dispose();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Program.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Program.cs
@@ -6,7 +6,7 @@ using Serilog;
 
 namespace AStar.Dev.OneDrive.Sync.Client;
 
-sealed class Program
+internal sealed class Program
 {
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
@@ -23,7 +23,6 @@ sealed class Program
             string logPath = ApplicationMetadata.ApplicationName.LogsDirectory().CombinePath(ApplicationMetadata.ApplicationLogName);
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
-                .MinimumLevel.Information()
                 .WriteTo.File(
                     formatter: new Serilog.Formatting.Json.JsonFormatter(),
                     path: logPath,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -31,7 +31,13 @@
       "Serilog.Sinks.Console",
       "Serilog.Sinks.File"
     ],
-    "MinimumLevel": "Debug",
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
     "WriteTo": [
       {
         "Name": "Console"


### PR DESCRIPTION
## Summary

- `HttpDownloader` and `UploadService` stored the `HttpClient` from `IHttpClientFactory.CreateClient()` as a singleton-scoped field. After the 2-minute handler rotation window, the factory could not dispose the expired handler because the singletons held strong references — leaving one handler permanently in the cleanup pool and emitting the `HttpMessageHandler cleanup cycle` debug log on every timer tick.
- `appsettings.json` had `"MinimumLevel": "Debug"`, which overrode the code-level `.MinimumLevel.Information()` and let all system library debug messages through.

## Changes

- `HttpDownloader`: obtain `HttpClient` via `using var http = CreateClient()` inside `DownloadAsync`; removed `IDisposable`
- `UploadService`: obtain `HttpClient` via `using var http = CreateClient()` inside `UploadChunksAsync`; removed `IDisposable`
- `IHttpDownloader`, `IUploadService`: removed `void Dispose()` from interfaces
- `IGraphService`: removed `: IDisposable`
- `GraphService`, `ParallelDownloadPipeline`: removed `Dispose()` methods
- `appsettings.json`: changed `MinimumLevel` from flat `"Debug"` to `{ Default: Information, Override: { Microsoft: Warning, System: Warning } }`
- `Program.cs`: removed redundant `.MinimumLevel.Information()` (now config-driven)

## Test plan

- [ ] Run the app through a full sync and confirm the `HttpMessageHandler cleanup cycle` log lines no longer appear after sync completes
- [ ] Confirm no other debug/info messages are suppressed unintentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)