### PR TITLE
fix(desktop/dashboard): prevent last account tile truncation

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardView.axaml
@@ -120,9 +120,9 @@
         <!-- ── Account sections ── -->
         <ScrollViewer Grid.Row="1"
                       IsVisible="{Binding HasAccounts}"
-                      VerticalScrollBarVisibility="Auto"
-                      Padding="20,16">
-            <ItemsControl ItemsSource="{Binding AccountSections}">
+                      VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding AccountSections}"
+                          Padding="20,16">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="dashboard:DashboardAccountViewModel">
 


### PR DESCRIPTION
## Summary
- `Padding` on `ScrollViewer` is consumed by the viewport, not the scrollable area — the bottom 16px clipped the last tile
- Moved `Padding="20,16"` from `ScrollViewer` to the `ItemsControl` so it scrolls with the content

## Test plan
- [ ] Run the app with 3+ accounts connected
- [ ] Scroll to the bottom — last tile should be fully visible with clean 16px gap below it
- [ ] Verify top/side padding still present with fewer accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)