### PR TITLE
feat(desktop/onedrive): extract ISyncEventAggregator — Phase 1 of MainWindowViewModel refactor

### DIFF
--- a/.claude/agents/c-sharp-code-reviewer.md
+++ b/.claude/agents/c-sharp-code-reviewer.md
@@ -11,6 +11,7 @@ You are a senior C# / .NET engineer reviewing code in the AStar.Dev mono-repo.
 ## Repo conventions to enforce
 
 - Target framework: `net10.0`; flag any lower TFM or multi-targeting without justification.
+- Functional paradigms must be followed wherever possible: AStar.Dev.Functional.Extensions has `Result<T>`, `<Option<T>`, `Bind<T>`, `Match<T>` and many more (including `Async` versions). These must be used wherever possible.
 - Nullable reference types are enabled globally — all code must be null-safe; flag missing `?` annotations, unchecked nulls, and missing null guards at public API boundaries.
 - `TreatWarningsAsErrors=true` is set globally — no suppressions without a documented reason.
 - NuGet package naming: `AStar.Dev.[Area].[Name]` — flag deviations.
@@ -24,8 +25,8 @@ You are a senior C# / .NET engineer reviewing code in the AStar.Dev mono-repo.
 ## Code quality checks
 
 - Correctness: logic errors, off-by-one errors, incorrect async/await usage, missing `ConfigureAwait`, fire-and-forget tasks.
-- Security: SQL injection, XSS (in Blazor), command injection, secrets in source, insecure deserialization.
-- Performance: unnecessary allocations, `string` concatenation in loops, blocking async code (`.Result`, `.Wait()`), missing `CancellationToken` propagation.
+- Security: SQL injection, XSS (in Blazor), command injection, secrets in source, insecure deserialization, OWASP Top 10.
+- Performance: unnecessary allocations, `string` concatenation in loops, blocking async code (`.Result`, `.Wait()`), missing `CancellationToken` propagation, N+1 database calls.
 - Design: SOLID violations, inappropriate use of `static`, overly large classes/methods, missing abstractions where code will clearly be reused. Flag any file placed in a technical-type folder (`ViewModels/`, `Commands/`, `Validators/`, etc.) — code must be organised by business feature (see `c-sharp-senior-developer`).
 - Formatting: every `return` statement must be preceded by a blank line — flag any `return` that has code on the immediately preceding line (this applies in production code, tests, and test helpers without exception).
 - Test coverage: public API surface should have tests; flag any public method in a `packages/` project that has no corresponding test.

--- a/.claude/agents/c-sharp-senior-developer.md
+++ b/.claude/agents/c-sharp-senior-developer.md
@@ -12,12 +12,9 @@ You are a senior C# 14 / .NET 10 engineer in the AStar.Dev mono-repo. Follow @CL
 
 > Code is read far more often than it is written.
 
-See @.claude/rules/c-sharp-code-style.md for naming, classes, immutability, record, and control-flow conventions. Additional rules:
+See @/.claude/rules/c-sharp-code-style.md for naming, classes, immutability, record, and control-flow conventions. Additional rules:
 
 - Explicit over clever. Clear `if` beats obscure one-liner.
-- Name for **meaning**: `customerId` not `id`, `isExpired` not `flag`.
-- Every `return` after a statement block must be preceded by a blank line. Returns after `if` etc. must NOT be followed by a blank line / pointless {}
-- Use builders for test setup.
 
 ## C# 14 / .NET 10 — use these, flag their absence
 

--- a/.claude/agents/c-sharp-senior-developer.md
+++ b/.claude/agents/c-sharp-senior-developer.md
@@ -1,7 +1,7 @@
 ---
 name: c-sharp-senior-developer
-description: Senior C# 14 / .NET 10 developer for the AStar.Dev mono-repo. Writes clean, readable, idiomatic code following repo conventions, functional-first patterns via AStar.Dev.Functional.Extensions, and TDD discipline. Use for implementing features, designing APIs, reviewing production code, and architectural guidance.
-tools: Read, Grep, Glob, Bash
+description: Senior C# 14 / .NET 10 developer for the AStar.Dev mono-repo. Writes clean, readable, idiomatic C# code following repo conventions, functional-first patterns via AStar.Dev.Functional.Extensions, and fully-tested discipline. Use for implementing C# features, designing APIs, and extracting C# shared utilities.
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 color: red
 ---
@@ -16,7 +16,7 @@ See @.claude/rules/c-sharp-code-style.md for naming, classes, immutability, reco
 
 - Explicit over clever. Clear `if` beats obscure one-liner.
 - Name for **meaning**: `customerId` not `id`, `isExpired` not `flag`.
-- Every `return` must be preceded by a blank line. No exceptions.
+- Every `return` after a statement block must be preceded by a blank line. Returns after `if` etc. must NOT be followed by a blank line / pointless {}
 - Use builders for test setup.
 
 ## C# 14 / .NET 10 — use these, flag their absence
@@ -39,8 +39,6 @@ See @.claude/rules/c-sharp-code-style.md for naming, classes, immutability, reco
 File-scoped namespaces and implicit usings are global — never add redundant `using` for `Xunit`, `Shouldly`, or `NSubstitute`.
 
 ## Functional patterns (AStar.Dev.Functional.Extensions)
-
-Use when they make intent clearer, not to show off. Imperative beats an obscure chain.
 
 | Scenario                                    | Use                      |
 | ------------------------------------------- | ------------------------ |
@@ -95,13 +93,6 @@ Omitting it causes `AVLN2100` build errors.
 - No HTTP scope — register `DbContext` and ViewModels as `Transient`.
 - Never `AddScoped` outside a web host (maps to app lifetime = singleton).
 
-### MediatR
-
-- Commands → `Result<T>` or `Result`; never `void` or raw domain objects.
-- Queries → `Result<T>`.
-- Handlers are `sealed`; one per request type.
-- Validation via FluentValidation pipeline behaviour, not inline.
-
 ### HTTP (Refit + Polly)
 
 - `[Headers("Accept: application/json")]` at interface level.
@@ -112,6 +103,7 @@ Omitting it causes `AVLN2100` build errors.
 
 - No raw SQL except read-model queries where performance demands it; document why.
 - `AsNoTracking()` on all read-only queries.
+- Entity IDs etc should be strongly-typed wherever possible; do not use GUID, string, int when the entity type is a key part of the domain
 - Migrations in the infra project that owns the `DbContext`.
 - Value objects via `OwnsOne` / `OwnsMany`; no primitive obsession on entity keys.
 - Always `IEntityTypeConfiguration<T>`; always load via `ApplyConfigurationsFromAssembly`.
@@ -127,26 +119,21 @@ Omitting it causes `AVLN2100` build errors.
 - Validators are `sealed`, registered via assembly scanning.
 - Return `Result<T>.Failure(validationErrors)` from pipeline behaviour; never throw.
 
-## TDD
+## Tests
 
-- All new public methods need a failing test before implementation — see @.claude/agents/c-sharp-senior-qa-specialist.md.
-- Stub with `throw new NotImplementedException()` for the failing-test commit.
-- QA agent writes tests; you write minimum production code to make them pass.
-- Refactor only under green.
-- After green + refactor: request QA review; resolve all Blocker/Major issues; raise GitHub issues for the rest.
+- All new public methods must have full unit tests exercising all branches wherever possible.
 
 ## Code review checklist
 
 - [ ] Mid-level dev understands in 30 s without comments?
 - [ ] No inline comments describing **what** — extract a named method instead
 - [ ] No suppressions without a comment
-- [ ] Functional types clarify intent; removed where they obscure it
 - [ ] No `async void` (except Avalonia event handlers — documented)
 - [ ] `CancellationToken` propagated through all async chains
 - [ ] No blocking calls (`.Result`, `.Wait()`, `.GetAwaiter().GetResult()`) in async context
 - [ ] `ConfigureAwait(false)` on all `await` in library code
-- [ ] NO magic strings / numbers etc; use constants or enums.
-- [ ] Every `return` preceded by a blank line
+- [ ] NO magic strings / numbers etc; use constants or enums. Extract to project-level when shared.
 - [ ] Structured log messages (no interpolated strings to Serilog)
 - [ ] New package `.csproj` has required metadata fields
 - [ ] User Story checklist items marked done
+- [ ] One Class / Interface / Record per file

--- a/.claude/agents/c-sharp-senior-qa-specialist.md
+++ b/.claude/agents/c-sharp-senior-qa-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: c-sharp-senior-qa-specialist
-description: Senior QA specialist for C# / .NET 10 code in the AStar.Dev mono-repo. Designs and writes tests following strict TDD discipline — red/green/refactor with failing-test commits. Use when writing new tests, reviewing test quality, or guiding TDD workflows.
+description: Senior QA specialist for C# / .NET 10 code in the AStar.Dev mono-repo. Designs and writes tests - specialising in missing edge-cases but ensure correct testing. Use when writing new tests, reviewing test quality.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 color: orange
@@ -8,14 +8,12 @@ color: orange
 
 You are a senior QA engineer specialising in C# 14 / .NET 10 TDD in the AStar.Dev mono-repo.
 
-## Non-negotiable TDD rules
+## Non-negotiable Test rules
 
-1. **Red first.** Write a failing test before any production code exists or changes. Never write a test that passes on the first run.
-2. **Failing-test commit is mandatory.** Commit the failing test(s) alone — no production code. Commit message: `test(scope): failing test(s) for <feature>`.
-3. **Green minimum.** Assign implementation to the developer agent. DO NOT write production code yourself. Commit message: `feat(scope): implement <feature> to pass tests`.
-4. **Refactor under green.** Only refactor when all tests are passing. Never change behaviour and structure simultaneously.
-5. **One logical concept per test.** A test that asserts more than one distinct behaviour is a design smell — split it.
-6. **Test ADTs, not implementation details.** Test public API and observable behaviour, not private methods or internal state.
+1. **New Code.** New code MUST have tests for all branches.
+2. **Passing Tests.** All tests must pass. No exceptions. This includes tests not affected by the update.
+3. **One logical concept per test.** A test that asserts more than one distinct behaviour is a design smell — split it.
+4. **Test ADTs, not implementation details.** Test public API and observable behaviour, not private methods or internal state.
 
 ## Stack and tooling
 
@@ -82,22 +80,12 @@ public sealed class GivenAServiceWithARepository
 - Every code path (including null/edge cases) covered by a distinct test.
 - `[Skip]` only with a comment and a linked issue — flag any `Skip` without justification.
 
-## TDD commit sequence
-
-```
-1. test(scope): failing test(s) for <feature>          ← RED
-2. feat(scope): implement <feature> to pass tests       ← GREEN
-3. refactor(scope): <what changed and why> (optional)  ← REFACTOR
-```
-
 ## Review checklist
 
-- [ ] Test written before production code (verify via `git log`)
 - [ ] Test class is `sealed` with `Given` prefix
 - [ ] Test method is `when_…_then_…` snake_case
 - [ ] No comments, no XML docs inside test class or methods
 - [ ] AAA separated by a single blank line only — no label comments
-- [ ] Every `return` preceded by a blank line
 - [ ] Assertions use Shouldly, not `Assert.*`
 - [ ] Mocks use NSubstitute; `Received`/`DidNotReceive` for interaction verification
 - [ ] No `Thread.Sleep` / `Task.Delay` — use `TaskCompletionSource` or `ManualResetEventSlim`

--- a/.claude/rules/c-sharp-code-style.md
+++ b/.claude/rules/c-sharp-code-style.md
@@ -32,7 +32,7 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 - Keep classes short; ideally under 300 lines.
 - Use meaningful names for classes and methods that clearly convey their purpose.
 - Put all method / constructor overloads together in the same order as their parameters.
-- Always single-line method / constructor signatures regardless of parameter count. Never split parameters across lines.
+- Single-line method / constructor signatures where possible. Split parameters across lines ONLY if line-length > 200 characters and spilt as close to 200 characters as possible. Use as few lines as possible when splitting parameters across lines.
 - Use expression-bodied members for simple methods and properties.
 - Keep method and constructor parameters to a minimum (ideally <5 parameters); prefer using parameter objects when multiple parameters are needed.
 - Avoid long parameter lists; consider using the Builder pattern for complex object construction.
@@ -42,11 +42,13 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 - Do not use regions or #pragma to hide code; refactor instead.
 - Never comment within methods or private members; if a comment is needed, it likely indicates the method is doing too much and should be refactored into smaller, more focused methods. Instead of comments, strive for self-explanatory code through clear naming and small method sizes.
 - Every `return` statement after a code block must be preceded by a blank line. `return` after an `if` must NOT be followed by a blank line or `{ return; }`.
+- Name for **meaning**: `customerId` not `id`, `isExpired` not `flag`.
+- Use builders for test setup / test data creation.
 
 ## Primitive Obsession
 
 - Don't use string / GUID etc for domain concepts - create a specific type:
-    - Id should be strongly-typed - use AStar.Dev.Source.Generators / AStar.Dev.Source.Generators.Attributes to standardise the generation. The Id CAN be a string / GUID but the property MUST be strongly typed.
+    - Id should be strongly-typed - use AStar.Dev.Source.Generators / AStar.Dev.Source.Generators.Attributes to standardise the generation. The Id value CAN be a string / GUID but the property MUST be strongly typed.
     - File info / Directory info should NOT be represented as a string. Either use the Testably abstraction or create a specific type (i.e. when only 3-5 properties are required)
 
 ## Immutability

--- a/.claude/rules/c-sharp-code-style.md
+++ b/.claude/rules/c-sharp-code-style.md
@@ -1,8 +1,6 @@
 ---
 paths:
-    - "apps/**/*.cs"
-    - "packages/**/*.cs"
-    - "tests/**/*.cs"
+    - "**/*.cs"
 ---
 
 Coding standards and style guidelines / preferences for C# files in this repository that AI must follow.
@@ -11,8 +9,8 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 
 - **Public members**: PascalCase (e.g., `MyClass`, `MyMethod`, `MyProperty`)
 - **Private members**: camelCase (e.g., `myVariable`, `myMethod`)
-- **Private fields**: \_camelCase with underscore prefix (e.g., `_fieldName`)
-- **Constants**: CONSTANT_CASE or PascalCase
+- **Private fields**: camelCase without underscore prefix (e.g., `fieldName`)
+- **Constants**: PascalCase
 - Use meaningful names that clearly convey purpose; avoid abbreviations unless widely understood
 - Use `nameof()` for parameter names in exceptions and logging
 - NEVER use single-letter variable names except for loop indices (e.g., `i`, `j`, `k`).
@@ -21,17 +19,17 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 
 - Use file-scoped namespaces.
 - Namespace names should follow the pattern: Company.Project.Module (e.g., Contoso.Sales.Reporting).
-- Avoid unnecessary nested namespaces; keep the structure flat when possible.
 
 ## Classes and Methods
 
-- Define one class per file, and name the file after the class.
+- Define one class, recored, interface etc. per file, and name the file after the class.
 - Follow SOLID principles for class and method design.
-- Keep classes focused on a single responsibility.
+- Keep classes / methods focused on a SINGLE responsibility.
 - Ensure good cohesion within classes and methods (related functionality grouped together).
 - Ensure low coupling between classes and methods.
 - Ensure methods do one thing and do it well.
 - Keep methods short; ideally under 20 lines.
+- Keep classes short; ideally under 300 lines.
 - Use meaningful names for classes and methods that clearly convey their purpose.
 - Put all method / constructor overloads together in the same order as their parameters.
 - Always single-line method / constructor signatures regardless of parameter count. Never split parameters across lines.
@@ -43,7 +41,7 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 - Avoid deep nesting; use early returns and guard clauses.
 - Do not use regions or #pragma to hide code; refactor instead.
 - Never comment within methods or private members; if a comment is needed, it likely indicates the method is doing too much and should be refactored into smaller, more focused methods. Instead of comments, strive for self-explanatory code through clear naming and small method sizes.
-- Every `return` statement must be preceded by a blank line. No exceptions.
+- Every `return` statement after a code block must be preceded by a blank line. `return` after an `if` must NOT be followed by a blank line or `{ return; }`.
 
 ## Primitive Obsession
 
@@ -64,7 +62,6 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 
 - Define record properties on the same line with the record declaration when possible.
 - Accompany each record `<name>` with a corresponding `<name>Factory` static factory class.
-- Place the factory class in the same file as the record it creates.
 - Expose static `Create` methods on the factory class for constructing instances of the record.
 - Place argument validation logic within the factory methods.
 - Never use the public constructor of a record directly; always use the factory methods.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-Mono-repo containing all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, and ~25 published **NuGet packages**. Solution file: `MonoRepo.slnx`.
+Mono-repo containing all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, and ~25 published **NuGet packages**. Solution file: `AStar.Dev.slnx`.
 
 ## Build Commands
 
@@ -68,7 +68,7 @@ The mono repo contains many NuGet projects that are deployed to both GitHub and 
 
 ```
 apps/
-  web/        # Blazor WebAssembly/Server and Next.js apps
+  web/        # Blazor WebAssembly/Server and astro apps
   desktop/    # Avalonia cross-platform desktop apps
 packages/
   core/       # Domain models, business logic
@@ -122,13 +122,13 @@ For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalon
 ### Conventions
 
 - **Commit messages**: Conventional Commits format — `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
-- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` is always deployable
-- **Test projects**: Named `*.Tests` or `*.IntegrationTests` — automatically set `IsPackable=false`
+- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` is ALWAYS deployable
+- **Test projects**: Named `*.Tests.Unit` or `*.Tests.Integration` — automatically set `IsPackable=false`
 - **Method signatures**: Always single-line regardless of parameter count — `public void Foo(string a, int b, CancellationToken ct = default)`. Never split parameters across lines. This applies to every file type.
-- **Comments**: Never add comments that restate what the code already says — in any file type (`.cs`, `.csproj`, `.axaml`, config files, etc.). Only write a comment when the *reason* behind a decision is not derivable from the code itself.
+- **Comments**: Never add comments that restate what the code already says — in any file type (`.cs`, `.csproj`, `.axaml`, config files, etc.). Refactor to extract the code that needs a comment when appropriate. Only write a comment when the *reason* behind a decision is not derivable from the code itself.
 - **Child `Directory.Build.props`**: Sub-folder overrides must import the parent via `$([MSBuild]::GetPathOfFileAbove(...))`
 - **Naming Conventions**: follow the @.claude/rules/c-sharp-code-style.md for .Net projects or @.claude/rules/javascript-code-style.md for JavaScript projects. Fallback to the official language-specific naming when no local specification exists locally.
-- **XML Comments**: include for public methods / properties
+- **XML Comments**: include for all public methods / properties
     - Classes that implement an interface should rely on interface documentation, not class-level docs. Use `<inheritdoc />` where supported.
 
 ## Before Starting Any Task
@@ -143,7 +143,7 @@ These two steps are **mandatory** before writing a single line of code. No excep
 
     Branch naming: `feature/...`, `bug/...`, `doc/...`. Never commit directly to `main`. See @docs/git-instructions.md.
 
-2. **Tests first (TDD)** — every coding task requires a test project. Write a failing test before writing any production code. Follow the red → green → refactor commit sequence defined in @.claude/agents/c-sharp-senior-qa-specialist.md (C#) or @.claude/agents/javascript-senior-qa-specialist.md (JavaScript/TypeScript).
+2. **Tests are MANDATORY** — every coding task requires a test project. New code MUST have tests covering all branches wherever possible.
 
 ## Definition of Done
 
@@ -151,11 +151,9 @@ Before considering any coding task complete — including commits and PRs — al
 
 1. `dotnet build` the affected project(s) and confirm zero errors and zero warnings
 2. `dotnet test` the affected test project(s) and confirm all tests pass
-3. Request a review from the @.claude/agents/c-sharp-senior-qa-specialist.md for all .Net Projects or @.claude/agents/javascript-senior-qa-specialist.md for JavaScript projects
-4. Resolve ALL `Blocker` and `Major` issues the QA agent reports. Raise GitHub issues for all other issues so they can be addressed later.
-5. Repeat the QA loop until there are no `Blocker` or `Major` isues from the original code or any updates.
-
-Do not raise a PR or claim a task is finished until both steps pass locally.
+3. Request the human reviews the code BEFORE committing it.
+4. If the human requests changes, implement them and then request re-review.
+5. ONLY when the human confirms the code is approved can you commit the code to the branch and raise the GitHub PR.
 
 ## Additional Instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ The mono repo contains many NuGet projects that are deployed to both GitHub and 
 
 ```
 apps/
-  web/        # Blazor WebAssembly/Server and astro apps
-  desktop/    # Avalonia cross-platform desktop apps
+  web/        # Blazor (C#) WebAssembly/Server and astro apps
+  desktop/    # Avalonia (C#) cross-platform desktop apps
 packages/
   core/       # Domain models, business logic
   infra/      # Data access, auth, logging, HTTP clients
@@ -107,9 +107,10 @@ All `bin/` and `obj/` folders redirect to `artifacts/` at the repo root. Do not 
 - **Do not run `dotnet pack` / `dotnet nuget push` manually for releases** — use the tag workflow
 - During local development, use `<ProjectReference>` instead of `<PackageReference>` to avoid publish cycles
 
-### C# / .NET Patterns
+### Avalonia / Blazor / C# / .NET Patterns
 
-For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions), see @.claude/agents/c-sharp-senior-developer.md.
+For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions), see @.claude/agents/c-sharp-senior-developer.md and @.claude/rules/c-sharp-code-style.md
+For all C#-specific updates, use the @.claude/agentsc-sharp-senior-developer.md subagent
 
 ### CI/CD Workflows
 
@@ -133,7 +134,7 @@ For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalon
 
 ## Before Starting Any Task
 
-These two steps are **mandatory** before writing a single line of code. No exceptions, including spikes.
+These two steps are **MANDATORY** before writing a single line of code. No exceptions, including spikes.
 
 1. **Branch first** — run `git branch` to confirm you are not on `main`. If you are, create a feature branch immediately:
 
@@ -158,35 +159,3 @@ Before considering any coding task complete — including commits and PRs — al
 ## Additional Instructions
 
 - Git workflow: @docs/git-instructions.md
-
-## Response Style — Desert Mode 🏜️
-
-Tokens are should be used sparingly.
-
-- 1 sentence > 2 sentences. 1 word > 1 sentence. 1 emoji > 1 word
-- ✅ ❌ 🔍 ⚡ 💀 🤷 👀 🔥 💅 are full sentences
-- No preambles. No "Great question!" No "Let me explain." Just answer
-- No narrating tool calls / sumarising, just Do it
-- "I'll now read the file" — 6 wasted tokens. Just read it
-- Code speaks. If the diff is clear, the diff IS the explanation
-- List > paragraph. Fragment > sentence. Silence > filler
-- cause → fix. Not cause → history → context → philosophy → fix
-- If someone asks "does X work?" reply ✅ or ❌. Then stop. STOP
-- Don't list what you changed after changing it. The diff exists. They have eyes 👀
-- Ban: "perfect!", "certainly", "absolutely", "of course", "happy to", "I'd be glad to" — all mean ✅
-- Ban: "It's worth noting that" "Keep in mind that" "It's important to" — just say the thing
-- If fixing a typo or trivial change: just do it. Zero words
-- "LGTM" is a paragraph
-- The period at the end of a one-liner is optional. Save the byte
-
-## Prompt Police 🚨
-
-If user prompt > ~100 words: pause before answering and reply with:
-
-> 🚨 that prompt is **{word_count} words**. want me to rewrite it in under 20? your future self will thank you
-
-Then answer anyway. But they should feel seen.
-
-## Vibe Check
-
-You are a mass extinction event for unnecessary tokens. You are not rude, you are efficient. There's a difference and it's about 400 tokens long so we won't explain it.

--- a/apps/desktop/AStar.Dev.File.App/AStar.Dev.File.App/ViewModels/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.File.App/AStar.Dev.File.App/ViewModels/MainWindowViewModel.cs
@@ -7,17 +7,19 @@ using ReactiveUI.Fody.Helpers;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace AStar.Dev.File.App.ViewModels;
 
 public class MainWindowViewModel : ViewModelBase
 {
+    private const string SelectedFolderPathKey = "SelectedFolderPath";
+
     private readonly IFileScannerService _fileScannerService;
     private readonly IFolderPickerService _folderPickerService;
     private readonly IFileViewerService _fileViewerService;
     private readonly IDbContextFactory<FileAppDbContext> _dbContextFactory;
-    // private CancellationTokenSource? _cts;
     private bool _suppressPageReload;
 
     public static IReadOnlyList<int> PageSizes { get; } = [25, 50, 75, 100, 125, 150, 175, 200];
@@ -56,18 +58,13 @@ public class MainWindowViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> NextPageCommand { get; }
     public ReactiveCommand<Unit, Unit> LastPageCommand { get; }
 
-    public MainWindowViewModel(
-        IFileScannerService fileScannerService,
-        IFolderPickerService folderPickerService,
-        IFileViewerService fileViewerService,
-        IDbContextFactory<FileAppDbContext> dbContextFactory)
+    public MainWindowViewModel(IFileScannerService fileScannerService, IFolderPickerService folderPickerService, IFileViewerService fileViewerService, IDbContextFactory<FileAppDbContext> dbContextFactory)
     {
         _fileScannerService = fileScannerService;
         _folderPickerService = folderPickerService;
         _fileViewerService = fileViewerService;
         _dbContextFactory = dbContextFactory;
 
-        // Computed properties
         _totalPages = this.WhenAnyValue(x => x.TotalFileCount, x => x.PageSize,
             (count, size) => count == 0 ? 1 : (int)Math.Ceiling((double)count / size))
             .ToProperty(this, x => x.TotalPages, initialValue: 1);
@@ -76,16 +73,15 @@ public class MainWindowViewModel : ViewModelBase
             (page, count, size) =>
             {
                 int total = count == 0 ? 1 : (int)Math.Ceiling((double)count / size);
+
                 return $"PAGE {page} OF {total}  [{count} FILES]";
             })
             .ToProperty(this, x => x.PagingInfo, initialValue: "PAGE 1 OF 1  [0 FILES]");
 
-        // Commands
         var canSelectFolder = this.WhenAnyValue(x => x.IsScanning, scanning => !scanning);
         SelectFolderCommand = ReactiveCommand.CreateFromTask(SelectFolderAsync, canSelectFolder);
 
-        var canScan = this.WhenAnyValue(x => x.IsScanning, x => x.SelectedFolderPath,
-            (scanning, path) => !scanning && !string.IsNullOrWhiteSpace(path));
+        var canScan = this.WhenAnyValue(x => x.IsScanning, x => x.SelectedFolderPath, (scanning, path) => !scanning && !string.IsNullOrWhiteSpace(path));
         StartScanCommand = ReactiveCommand.CreateFromTask(StartScanAsync, canScan);
 
         var canCancel = this.WhenAnyValue(x => x.IsScanning);
@@ -100,65 +96,45 @@ public class MainWindowViewModel : ViewModelBase
         TogglePendingDeleteCommand = ReactiveCommand.CreateFromTask<ScannedFileDisplayItem?>(TogglePendingDeleteAsync);
         ViewFileCommand = ReactiveCommand.CreateFromTask<ScannedFileDisplayItem?>(ViewFileAsync);
 
-        var canGoFirst = this.WhenAnyValue(x => x.CurrentPage, page => page > 1);
-        FirstPageCommand = ReactiveCommand.Create(() => { CurrentPage = 1; }, canGoFirst);
+        var canGoToPreviousPage = this.WhenAnyValue(x => x.CurrentPage, page => page > 1);
+        FirstPageCommand = ReactiveCommand.Create(() => { CurrentPage = 1; }, canGoToPreviousPage);
+        PreviousPageCommand = ReactiveCommand.Create(() => { CurrentPage--; }, canGoToPreviousPage);
 
-        var canGoPrevious = this.WhenAnyValue(x => x.CurrentPage, page => page > 1);
-        PreviousPageCommand = ReactiveCommand.Create(() => { CurrentPage--; }, canGoPrevious);
+        var canGoToNextPage = this.WhenAnyValue(x => x.CurrentPage, x => x.TotalPages, (page, total) => page < total);
+        NextPageCommand = ReactiveCommand.Create(() => { CurrentPage++; }, canGoToNextPage);
+        LastPageCommand = ReactiveCommand.Create(() => { CurrentPage = TotalPages; }, canGoToNextPage);
 
-        var canGoNext = this.WhenAnyValue(x => x.CurrentPage, x => x.TotalPages,
-            (page, total) => page < total);
-        NextPageCommand = ReactiveCommand.Create(() => { CurrentPage++; }, canGoNext);
-
-        var canGoLast = this.WhenAnyValue(x => x.CurrentPage, x => x.TotalPages,
-            (page, total) => page < total);
-        LastPageCommand = ReactiveCommand.Create(() => { CurrentPage = TotalPages; }, canGoLast);
-
-        // Side-effect subscriptions (replacing partial void OnXChanged hooks)
         this.WhenAnyValue(x => x.CurrentPage)
             .Skip(1)
-            .Subscribe(__ =>
-            {
-                if (!_suppressPageReload)
-                    _ = LoadScannedFilesAsync();
-            });
+            .Subscribe(__ => { if (!_suppressPageReload) _ = LoadScannedFilesAsync(); })
+            .DisposeWith(Disposables);
 
         this.WhenAnyValue(x => x.PageSize)
             .Skip(1)
-            .Subscribe(__ =>
-            {
-                _suppressPageReload = true;
-                CurrentPage = 1;
-                _suppressPageReload = false;
-                _ = LoadScannedFilesAsync();
-            });
+            .Subscribe(__ => { SetPageWithoutReload(1); _ = LoadScannedFilesAsync(); })
+            .DisposeWith(Disposables);
 
         this.WhenAnyValue(x => x.ShowDuplicatesOnly)
             .Skip(1)
-            .Subscribe(__ =>
-            {
-                _suppressPageReload = true;
-                CurrentPage = 1;
-                _suppressPageReload = false;
-                _ = LoadScannedFilesAsync();
-            });
+            .Subscribe(__ => { SetPageWithoutReload(1); _ = LoadScannedFilesAsync(); })
+            .DisposeWith(Disposables);
 
-        _fileViewerService.FileViewRequested += item => ViewFileRequested?.Invoke(item);
+        void onFileViewRequested(ScannedFileDisplayItem item) => ViewFileRequested?.Invoke(item);
+        _fileViewerService.FileViewRequested += onFileViewRequested;
+        Disposable.Create(() => _fileViewerService.FileViewRequested -= onFileViewRequested).DisposeWith(Disposables);
 
-        _ = InitializeAsync();
+        _ = LoadSelectedFolderPathAsync();
     }
-
-    private async Task InitializeAsync() => await LoadSelectedFolderPathAsync();
 
     private async Task LoadSelectedFolderPathAsync()
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
-        var setting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == "SelectedFolderPath");
+        var setting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == SelectedFolderPathKey);
 
         if (setting is not null && !string.IsNullOrWhiteSpace(setting.Value) && Directory.Exists(setting.Value))
             SelectedFolderPath = setting.Value;
         else
-            SelectedFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+            SelectedFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
     }
 
     private async Task SelectFolderAsync()
@@ -174,21 +150,19 @@ public class MainWindowViewModel : ViewModelBase
     private async Task SaveSelectedFolderPathAsync(string path)
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync();
-        var setting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == "SelectedFolderPath");
+        var setting = await db.AppSettings.FirstOrDefaultAsync(s => s.Key == SelectedFolderPathKey);
 
         if (setting is not null)
             setting.Value = path;
         else
-            db.AppSettings.Add(new AppSetting { Key = "SelectedFolderPath", Value = path });
+            db.AppSettings.Add(new AppSetting { Key = SelectedFolderPathKey, Value = path });
 
         await db.SaveChangesAsync();
     }
 
     private async Task LoadFromDatabaseAsync()
     {
-        _suppressPageReload = true;
-        CurrentPage = 1;
-        _suppressPageReload = false;
+        SetPageWithoutReload(1);
         await LoadScannedFilesAsync();
     }
 
@@ -203,9 +177,7 @@ public class MainWindowViewModel : ViewModelBase
         TotalFilesProcessed = 0;
         TotalFileCount = 0;
         CurrentScanFolder = string.Empty;
-        _suppressPageReload = true;
-        CurrentPage = 1;
-        _suppressPageReload = false;
+        SetPageWithoutReload(1);
 
         CancellationTokenSource = new CancellationTokenSource();
 
@@ -307,8 +279,13 @@ public class MainWindowViewModel : ViewModelBase
     {
         if (CurrentPage <= TotalPages) return;
 
+        SetPageWithoutReload(TotalPages);
+    }
+
+    private void SetPageWithoutReload(int page)
+    {
         _suppressPageReload = true;
-        CurrentPage = TotalPages;
+        CurrentPage = page;
         _suppressPageReload = false;
     }
 }

--- a/apps/desktop/AStar.Dev.File.App/AStar.Dev.File.App/ViewModels/ViewModelBase.cs
+++ b/apps/desktop/AStar.Dev.File.App/AStar.Dev.File.App/ViewModels/ViewModelBase.cs
@@ -1,13 +1,16 @@
 using ReactiveUI;
+using System.Reactive.Disposables;
 
 namespace AStar.Dev.File.App.ViewModels;
 
 public abstract class ViewModelBase : ReactiveObject, IDisposable
 {
     protected CancellationTokenSource CancellationTokenSource { get; set; } = new();
+    protected CompositeDisposable Disposables { get; } = [];
 
-    public void Dispose()
+    public virtual void Dispose()
     {
+        Disposables.Dispose();
         CancellationTokenSource.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
@@ -1,0 +1,69 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenASyncEventAggregator
+{
+    private readonly ISyncService _syncService = Substitute.For<ISyncService>();
+    private readonly ISyncScheduler _scheduler = Substitute.For<ISyncScheduler>();
+    private readonly IUiDispatcher _dispatcher = new InlineUiDispatcher();
+
+    private SyncEventAggregator CreateSut() => new(_syncService, _scheduler, _dispatcher);
+
+    [Fact]
+    public void when_sync_service_raises_progress_then_aggregator_raises_progress()
+    {
+        var sut = CreateSut();
+        SyncProgressEventArgs? captured = null;
+        sut.SyncProgressChanged += (_, args) => captured = args;
+        var eventArgs = new SyncProgressEventArgs("acc-1", "folder-1", 1, 10, "file.txt", SyncState.Syncing);
+
+        _syncService.SyncProgressChanged += Raise.EventWith(eventArgs);
+
+        captured.ShouldNotBeNull();
+        captured.AccountId.ShouldBe("acc-1");
+    }
+
+    [Fact]
+    public void when_sync_service_raises_job_completed_then_aggregator_raises_job_completed()
+    {
+        var sut = CreateSut();
+        JobCompletedEventArgs? captured = null;
+        sut.JobCompleted += (_, args) => captured = args;
+        var job = new SyncJob { AccountId = "acc-2" };
+        var eventArgs = new JobCompletedEventArgs(job);
+
+        _syncService.JobCompleted += Raise.EventWith(eventArgs);
+
+        captured.ShouldNotBeNull();
+        captured.Job.AccountId.ShouldBe("acc-2");
+    }
+
+    [Fact]
+    public void when_sync_service_raises_conflict_then_aggregator_raises_conflict()
+    {
+        var sut = CreateSut();
+        SyncConflict? captured = null;
+        sut.ConflictDetected += (_, conflict) => captured = conflict;
+        var conflict = new SyncConflict { AccountId = "acc-3" };
+
+        _syncService.ConflictDetected += Raise.Event<EventHandler<SyncConflict>>(this, conflict);
+
+        captured.ShouldNotBeNull();
+        captured.AccountId.ShouldBe("acc-3");
+    }
+
+    [Fact]
+    public void when_scheduler_raises_sync_completed_then_aggregator_raises_sync_completed()
+    {
+        var sut = CreateSut();
+        string? captured = null;
+        sut.SyncCompleted += (_, accountId) => captured = accountId;
+
+        _scheduler.SyncCompleted += Raise.Event<EventHandler<string>>(this, "acc-4");
+
+        captured.ShouldNotBeNull();
+        captured.ShouldBe("acc-4");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/InlineUiDispatcher.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/InlineUiDispatcher.cs
@@ -1,0 +1,8 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+internal sealed class InlineUiDispatcher : IUiDispatcher
+{
+    public void Post(Action action) => action();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 using AStar.Dev.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,7 +14,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository) : ObservableObject
+public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncEventAggregator syncEventAggregator) : ObservableObject
 {
     public ObservableCollection<AccountCardViewModel> Accounts { get; } = [];
 
@@ -37,6 +38,16 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     /// <summary>Raised after an account is removed.</summary>
     public event EventHandler<string>? AccountRemoved;
+
+    /// <summary>Raised when a sync event changes the active account's card state.</summary>
+    public event EventHandler? ActiveAccountStateChanged;
+
+    public void SubscribeToSyncEvents()
+    {
+        syncEventAggregator.SyncProgressChanged += OnSyncProgressChanged;
+        syncEventAggregator.SyncCompleted += OnSyncCompleted;
+        syncEventAggregator.ConflictDetected += OnConflictDetected;
+    }
 
     public void AddAccount()
     {
@@ -118,8 +129,8 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     private void OnCardSelected(object? sender, AccountCardViewModel card)
     {
-        foreach(var c in Accounts)
-            c.IsActive = c == card;
+        foreach(var accountCard in Accounts)
+            accountCard.IsActive = accountCard == card;
 
         ActiveAccount = card;
         AccountSelected?.Invoke(this, card);
@@ -127,11 +138,47 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
         _ = repository.SetActiveAccountAsync(card.Id, CancellationToken.None);
     }
 
+    private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs args)
+    {
+        var card = Accounts.FirstOrDefault(a => a.Id == args.AccountId);
+        if(card is null)
+            return;
+
+        card.SyncState = args.SyncState;
+
+        if(card.Id == ActiveAccount?.Id)
+            ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnSyncCompleted(object? sender, string accountId)
+    {
+        var card = Accounts.FirstOrDefault(a => a.Id == accountId);
+        if(card is null)
+            return;
+
+        card.SyncState = SyncState.Completed;
+
+        if(card.Id == ActiveAccount?.Id)
+            ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnConflictDetected(object? sender, SyncConflict conflict)
+    {
+        var card = Accounts.FirstOrDefault(a => a.Id == conflict.AccountId);
+        if(card is null)
+            return;
+
+        card.ConflictCount++;
+
+        if(card.Id == ActiveAccount?.Id)
+            ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     private AccountCardViewModel BuildCard(OneDriveAccount account)
     {
         var card = new AccountCardViewModel(account);
         card.Selected += OnCardSelected;
-        card.RemoveRequested += (_, c) => RemoveAccountCommand.Execute(c);
+        card.RemoveRequested += (_, accountCard) => RemoveAccountCommand.Execute(accountCard);
         return card;
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
@@ -10,9 +10,9 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Activity;
 
-public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRepository syncRepository) : ObservableObject
+public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRepository syncRepository, ISyncEventAggregator syncEventAggregator) : ObservableObject
 {
-    private const int MaxLogSixe = 10_000;
+    private const int MaxLogSize = 10_000;
     private string? _activeAccountId;
     private string _activeAccountEmail = string.Empty;
 
@@ -47,6 +47,12 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
 
     public bool HasConflicts => ConflictCount > 0;
     public string ConflictBadgeText => ConflictCount > 0 ? ConflictCount.ToString(CultureInfo.CurrentCulture) : string.Empty;
+
+    public void SubscribeToSyncEvents()
+    {
+        syncEventAggregator.JobCompleted += OnJobCompleted;
+        syncEventAggregator.ConflictDetected += OnConflictDetected;
+    }
 
     /// <summary>
     /// Called by MainWindowViewModel when the active account changes.
@@ -86,19 +92,19 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
         ConflictCount = Conflicts.Count;
     }
 
-    /// <summary>Called by MainWindowViewModel when a sync job completes.</summary>
+    /// <summary>Called when a sync job completes.</summary>
     public void AddActivityItem(ActivityItemViewModel item) => Dispatcher.UIThread.Post(() =>
                                                                     {
                                                                         LogItems.Insert(0, item);
 
-                                                                        while(LogItems.Count > MaxLogSixe)
+                                                                        while(LogItems.Count > MaxLogSize)
                                                                             LogItems.RemoveAt(LogItems.Count - 1);
 
                                                                         LogItemCount = LogItems.Count;
                                                                         RebuildFilteredLog();
                                                                     });
 
-    /// <summary>Called by MainWindowViewModel when a new conflict is detected.</summary>
+    /// <summary>Called when a new conflict is detected.</summary>
     public void AddConflictItem(SyncConflict conflict) => Dispatcher.UIThread.Post(() =>
                                                                {
                                                                    if(Conflicts.Any(c => c.Id == conflict.Id))
@@ -124,12 +130,20 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
         LogItemCount = 0;
     }
 
+    private void OnJobCompleted(object? sender, JobCompletedEventArgs args)
+    {
+        var item = ActivityItemViewModel.FromJob(args.Job, _activeAccountEmail);
+        AddActivityItem(item);
+    }
+
+    private void OnConflictDetected(object? sender, SyncConflict conflict) => AddConflictItem(conflict);
+
     private void AddConflict(SyncConflict conflict)
     {
         var vm = new ConflictItemViewModel(conflict, syncService);
-        vm.Resolved += (_, c) =>
+        vm.Resolved += (_, conflictItem) =>
         {
-            _ = Conflicts.Remove(c);
+            _ = Conflicts.Remove(conflictItem);
             ConflictCount = Conflicts.Count;
         };
         Conflicts.Add(vm);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -8,7 +8,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Dashboard;
 
-public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocalizationService localizationService, IAccountRepository accountRepository) : ObservableObject
+public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocalizationService localizationService, IAccountRepository accountRepository, ISyncEventAggregator syncEventAggregator) : ObservableObject
 {
     public ObservableCollection<DashboardAccountViewModel> AccountSections { get; } = [];
 
@@ -40,6 +40,14 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
         (_, _, > 0) => $"{TotalConflicts} conflict{(TotalConflicts == 1 ? "" : "s")}",
         _ => "All synced"
     };
+
+    public void SubscribeToSyncEvents()
+    {
+        syncEventAggregator.SyncProgressChanged += OnSyncProgressChanged;
+        syncEventAggregator.JobCompleted += OnJobCompleted;
+        syncEventAggregator.SyncCompleted += OnSyncCompleted;
+        syncEventAggregator.ConflictDetected += OnConflictDetected;
+    }
 
     public void AddAccount(OneDriveAccount account)
     {
@@ -91,6 +99,41 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
     {
         var section = AccountSections.FirstOrDefault(s => s.AccountId == item.AccountId);
         section?.AddRecentActivity(item);
+    }
+
+    private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs args)
+    {
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == args.AccountId);
+        if(section is null)
+            return;
+
+        section.UpdateSyncState(args.SyncState, section.ConflictCount);
+
+        if(args.Total == 0 && !string.IsNullOrEmpty(args.CurrentFile))
+            AddActivityItem(new ActivityItemViewModel { AccountId = args.AccountId, FileName = args.CurrentFile, Type = ActivityItemType.Info });
+
+        RecalculateGlobals();
+    }
+
+    private void OnJobCompleted(object? sender, JobCompletedEventArgs args)
+    {
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == args.Job.AccountId);
+        string accountEmail = section?.Email ?? args.Job.AccountId;
+        var item = ActivityItemViewModel.FromJob(args.Job, accountEmail);
+        AddActivityItem(item);
+    }
+
+    private void OnSyncCompleted(object? sender, string accountId) => MarkSyncCompleted(accountId);
+
+    private void OnConflictDetected(object? sender, SyncConflict conflict)
+    {
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == conflict.AccountId);
+        if(section is null)
+            return;
+
+        section.UpdateSyncState(section.SyncState, section.ConflictCount + 1);
+
+        RecalculateGlobals();
     }
 
     private void RecalculateGlobals()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
@@ -12,7 +12,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using AccountCardViewModel = AStar.Dev.OneDrive.Sync.Client.Accounts.AccountCardViewModel;
@@ -24,7 +23,7 @@ using SettingsViewModel = AStar.Dev.OneDrive.Sync.Client.Settings.SettingsViewMo
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
 public sealed partial class MainWindowViewModel(IAuthService authService, IGraphService graphService, IStartupService startupService, ISyncService syncService, IThemeService themeService,
-    ISyncScheduler scheduler, ISyncRepository syncRepository, ISettingsService settingsService, IAccountRepository accountRepository, ILocalizationService localizationService) : ObservableObject
+    ISyncScheduler scheduler, ISyncRepository syncRepository, ISettingsService settingsService, IAccountRepository accountRepository, ILocalizationService localizationService, ISyncEventAggregator syncEventAggregator) : ObservableObject
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDashboardActive))]
@@ -112,13 +111,13 @@ public sealed partial class MainWindowViewModel(IAuthService authService, IGraph
         }
     }
 
-    public AccountsViewModel Accounts { get; } = new(authService, graphService, accountRepository);
+    public AccountsViewModel Accounts { get; } = new(authService, graphService, accountRepository, syncEventAggregator);
 
     public FilesViewModel Files { get; } = new(authService, graphService, accountRepository);
 
-    public ActivityViewModel Activity { get; } = new(syncService, syncRepository);
+    public ActivityViewModel Activity { get; } = new(syncService, syncRepository, syncEventAggregator);
 
-    public DashboardViewModel Dashboard { get; } = new(scheduler, localizationService, accountRepository);
+    public DashboardViewModel Dashboard { get; } = new(scheduler, localizationService, accountRepository, syncEventAggregator);
 
     public SettingsViewModel Settings { get; } = new(settingsService, themeService, scheduler, accountRepository);
 
@@ -128,14 +127,18 @@ public sealed partial class MainWindowViewModel(IAuthService authService, IGraph
     {
         try
         {
-            syncService.SyncProgressChanged += OnSyncProgressChanged;
-            syncService.JobCompleted += OnJobCompleted;
-            syncService.ConflictDetected += OnConflictDetected;
-            scheduler.SyncCompleted += OnSyncCompleted;
+            syncEventAggregator.SyncProgressChanged += OnSyncProgressChanged;
+            syncEventAggregator.SyncCompleted += OnSyncCompleted;
+            syncEventAggregator.ConflictDetected += OnConflictDetected;
+
+            Accounts.SubscribeToSyncEvents();
+            Activity.SubscribeToSyncEvents();
+            Dashboard.SubscribeToSyncEvents();
 
             Accounts.AccountSelected += OnAccountSelectedAsync;
             Accounts.AccountAdded += OnAccountAddedAsync;
             Accounts.AccountRemoved += OnAccountRemoved;
+            Accounts.ActiveAccountStateChanged += (_, _) => SyncStatusBarToActiveAccount();
             Accounts.PropertyChanged += (_, e) =>
             {
                 if(e.PropertyName == nameof(AccountsViewModel.ActiveAccount))
@@ -234,59 +237,21 @@ public sealed partial class MainWindowViewModel(IAuthService authService, IGraph
     }
 
     private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs e)
-        => Dispatcher.UIThread.Post(() =>
-            {
-                var card = Accounts.Accounts.FirstOrDefault(a => a.Id == e.AccountId);
-                if(card is null)
-                    return;
-
-                card.SyncState = e.SyncState;
-                Dashboard.UpdateAccountSyncState(e.AccountId, card);
-
-                if(e.Total == 0 && !string.IsNullOrEmpty(e.CurrentFile))
-                    Dashboard.AddActivityItem(new ActivityItemViewModel { AccountId = e.AccountId, FileName = e.CurrentFile, Type = ActivityItemType.Info });
-
-                if(card.Id == Accounts.ActiveAccount?.Id)
-                    SyncStatusBarToActiveAccount();
-            });
-
-    private void OnJobCompleted(object? sender, JobCompletedEventArgs e)
-        => Dispatcher.UIThread.Post(() =>
-            {
-                var card = Accounts.Accounts.FirstOrDefault(a => a.Id == e.Job.AccountId);
-
-                string accountEmail = card?.Email ?? e.Job.AccountId;
-                var item = ActivityItemViewModel.FromJob(e.Job, accountEmail);
-
-                Activity.AddActivityItem(item);
-                Dashboard.AddActivityItem(item);
-            });
+    {
+        if(Accounts.Accounts.Any(a => a.Id == e.AccountId && a.Id == Accounts.ActiveAccount?.Id))
+            SyncStatusBarToActiveAccount();
+    }
 
     private void OnSyncCompleted(object? sender, string accountId)
-        => Dispatcher.UIThread.Post(() =>
-            {
-                var card = Accounts.Accounts.FirstOrDefault(a => a.Id == accountId);
-                card?.SyncState = SyncState.Completed;
-
-                Dashboard.MarkSyncCompleted(accountId);
-                SyncStatusBarToActiveAccount();
-            });
+    {
+        if(Accounts.ActiveAccount?.Id == accountId)
+            SyncStatusBarToActiveAccount();
+    }
 
     private void OnConflictDetected(object? sender, SyncConflict conflict)
     {
-        Activity.AddConflictItem(conflict);
-
-        Dispatcher.UIThread.Post(() =>
-        {
-            var card = Accounts.Accounts.FirstOrDefault(a => a.Id == conflict.AccountId);
-            if(card is not null)
-            {
-                card.ConflictCount++;
-                Dashboard.UpdateAccountSyncState(conflict.AccountId, card);
-            }
-
+        if(Accounts.ActiveAccount?.Id == conflict.AccountId)
             SyncStatusBarToActiveAccount();
-        });
     }
 
     private void SyncStatusBarToActiveAccount()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/AvaloniaUiDispatcher.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/AvaloniaUiDispatcher.cs
@@ -1,0 +1,12 @@
+using Avalonia.Threading;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Production implementation that posts work via <see cref="Dispatcher.UIThread"/>.
+/// </summary>
+public sealed class AvaloniaUiDispatcher : IUiDispatcher
+{
+    /// <inheritdoc />
+    public void Post(Action action) => Dispatcher.UIThread.Post(action);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncEventAggregator.cs
@@ -1,0 +1,23 @@
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Aggregates sync events from <see cref="ISyncService"/> and <see cref="ISyncScheduler"/> and
+/// re-raises them on the UI thread so child view models can subscribe without taking direct
+/// dependencies on those services.
+/// </summary>
+public interface ISyncEventAggregator
+{
+    /// <summary>Raised whenever sync progress changes for any account.</summary>
+    event EventHandler<SyncProgressEventArgs> SyncProgressChanged;
+
+    /// <summary>Raised when a file job completes (success or failure).</summary>
+    event EventHandler<JobCompletedEventArgs> JobCompleted;
+
+    /// <summary>Raised when a new conflict is detected and queued.</summary>
+    event EventHandler<SyncConflict> ConflictDetected;
+
+    /// <summary>Raised when a full sync pass for an account has completed.</summary>
+    event EventHandler<string> SyncCompleted;
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUiDispatcher.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUiDispatcher.cs
@@ -1,0 +1,10 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Abstracts posting work onto the UI thread, allowing non-Avalonia tests to supply a synchronous pass-through.
+/// </summary>
+public interface IUiDispatcher
+{
+    /// <summary>Posts <paramref name="action"/> onto the UI thread.</summary>
+    void Post(Action action);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncEventAggregator.cs
@@ -1,0 +1,43 @@
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Singleton that subscribes to <see cref="ISyncService"/> and <see cref="ISyncScheduler"/> events
+/// and re-raises them via <see cref="IUiDispatcher"/> so child view models can receive UI-thread-safe
+/// notifications without taking direct dependencies on those services.
+/// </summary>
+public sealed class SyncEventAggregator : ISyncEventAggregator
+{
+    private readonly IUiDispatcher _dispatcher;
+
+    /// <inheritdoc />
+    public event EventHandler<SyncProgressEventArgs>? SyncProgressChanged;
+
+    /// <inheritdoc />
+    public event EventHandler<JobCompletedEventArgs>? JobCompleted;
+
+    /// <inheritdoc />
+    public event EventHandler<SyncConflict>? ConflictDetected;
+
+    /// <inheritdoc />
+    public event EventHandler<string>? SyncCompleted;
+
+    public SyncEventAggregator(ISyncService syncService, ISyncScheduler scheduler, IUiDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+
+        syncService.SyncProgressChanged += OnSyncProgressChanged;
+        syncService.JobCompleted += OnJobCompleted;
+        syncService.ConflictDetected += OnConflictDetected;
+        scheduler.SyncCompleted += OnSyncCompleted;
+    }
+
+    private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs args) => _dispatcher.Post(() => SyncProgressChanged?.Invoke(this, args));
+
+    private void OnJobCompleted(object? sender, JobCompletedEventArgs args) => _dispatcher.Post(() => JobCompleted?.Invoke(this, args));
+
+    private void OnConflictDetected(object? sender, SyncConflict conflict) => _dispatcher.Post(() => ConflictDetected?.Invoke(this, conflict));
+
+    private void OnSyncCompleted(object? sender, string accountId) => _dispatcher.Post(() => SyncCompleted?.Invoke(this, accountId));
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -36,6 +36,8 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ILocalChangeDetector, LocalChangeDetector>();
         _ = services.AddSingleton<ISyncService, SyncService>();
         _ = services.AddSingleton<ISyncScheduler, SyncScheduler>();
+        _ = services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();
+        _ = services.AddSingleton<ISyncEventAggregator, SyncEventAggregator>();
         _ = services.AddTransient<ISettingsService, SettingsService>();
         _ = services.AddTransient<IThemeService, ThemeService>();
         _ = services.AddTransient<IParallelDownloadPipeline, ParallelDownloadPipeline>();

--- a/docs/onedrive-mainwindow-refactor-plan.md
+++ b/docs/onedrive-mainwindow-refactor-plan.md
@@ -1,0 +1,284 @@
+# OneDrive Sync Client — MainWindowViewModel Refactor
+
+## Problem
+
+`MainWindowViewModel` has **10 constructor parameters** and handles 6 distinct responsibilities. It acts as a God object: creating child ViewModels, wiring sync events, orchestrating startup, managing navigation, and manually syncing the status bar. It is currently untestable in isolation.
+
+---
+
+## Responsibilities to Extract
+
+| # | Responsibility | Current evidence | Target |
+|---|---|---|---|
+| 1 | **Sync event fan-out** | `OnSyncProgressChanged`, `OnJobCompleted`, `OnSyncCompleted`, `OnConflictDetected` (lines 236–290) | `ISyncEventAggregator` |
+| 2 | **App initialization** | `InitialiseAsync` (lines 127–171) | `IApplicationInitializer` |
+| 3 | **Child VM construction** | Inline `new(...)` for all 6 child VMs using deps that belong to the child | Inject child VMs from DI |
+| 4 | **Manual sync trigger** | `SyncNowAsync` reconstructs `OneDriveAccount` from repo (lines 180–195) | Push account entity lookup into `ISyncScheduler` overload |
+| 5 | **StatusBar sync** | `SyncStatusBarToActiveAccount()` called from 6 callsites | Subscribe inside `StatusBarViewModel` to `AccountsViewModel` |
+
+---
+
+## Phase 1 — Extract `ISyncEventAggregator`
+
+**Why first:** removes 4 handler methods (~60 lines), 2 direct deps (`ISyncService`, `ISyncScheduler`), and makes sync events independently consumable by each child VM.
+
+### New files
+
+**`Infrastructure/Sync/ISyncEventAggregator.cs`**
+```csharp
+public interface ISyncEventAggregator
+{
+    event EventHandler<SyncProgressEventArgs>  SyncProgressChanged;
+    event EventHandler<JobCompletedEventArgs>   JobCompleted;
+    event EventHandler<SyncConflict>            ConflictDetected;
+    event EventHandler<string>                  SyncCompleted;
+}
+```
+
+**`Infrastructure/Sync/SyncEventAggregator.cs`**
+- Constructor deps: `ISyncService`, `ISyncScheduler`
+- Subscribes to both services in constructor, re-raises on UIThread via `Dispatcher.UIThread.Post`
+- Registered as **Singleton** in DI
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `Accounts/AccountsViewModel.cs` | Subscribe to `ISyncEventAggregator` — update card `SyncState` and `ConflictCount` |
+| `Dashboard/DashboardViewModel.cs` | Subscribe — call `UpdateAccountSyncState`, `AddActivityItem`, `MarkSyncCompleted` |
+| `Activity/ActivityViewModel.cs` | Subscribe — call `AddActivityItem`, `AddConflictItem` |
+| `Home/MainWindowViewModel.cs` | Remove 4 handler methods + 2 deps; keep only `scheduler` for `SyncNowAsync` |
+
+### Tests
+
+New test class: `AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs`
+
+```
+when_sync_service_raises_progress_then_aggregator_raises_progress
+when_sync_service_raises_job_completed_then_aggregator_raises_job_completed
+when_sync_service_raises_conflict_then_aggregator_raises_conflict
+when_scheduler_raises_sync_completed_then_aggregator_raises_sync_completed
+```
+
+---
+
+## Phase 2 — Extract `IApplicationInitializer`
+
+**Why:** `InitialiseAsync` coordinates account restoration across 5 child VMs. It belongs in a dedicated service, not the shell VM.
+
+### New files
+
+**`Infrastructure/Shell/IApplicationInitializer.cs`**
+```csharp
+public interface IApplicationInitializer
+{
+    Task InitializeAsync(CancellationToken ct = default);
+}
+```
+
+**`Infrastructure/Shell/ApplicationInitializer.cs`**
+- Constructor deps: `IStartupService`, `AccountsViewModel`, `FilesViewModel`, `DashboardViewModel`, `ActivityViewModel`, `SettingsViewModel`
+- Contains the body of the current `InitialiseAsync()`, minus event wiring (now done by `SyncEventAggregator`)
+- Registered as **Scoped** (one per app session)
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `Home/MainWindowViewModel.cs` | `InitialiseAsync` becomes `await _initializer.InitializeAsync()` |
+| `Home/MainWindowViewModel.cs` | Remove deps: `IStartupService`, `ISyncService`, `ISyncRepository` |
+
+`Accounts.PropertyChanged` wiring that triggers `SyncStatusBarToActiveAccount` moves to Phase 4.
+
+### Tests
+
+New test class: `AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs`
+
+```
+when_initialized_then_accounts_are_restored_from_startup_service
+when_initialized_then_files_receives_all_restored_accounts
+when_initialized_then_dashboard_receives_all_restored_accounts
+when_initialized_then_settings_loads_restored_accounts
+when_active_account_exists_then_files_activates_that_account
+when_active_account_exists_then_activity_sets_active_account
+when_startup_service_throws_then_error_is_logged_and_not_rethrown
+```
+
+---
+
+## Phase 3 — Inject Child ViewModels from DI
+
+**Why:** `MainWindowViewModel` constructs child VMs inline, pulling in `IAuthService`, `IGraphService`, `IAccountRepository`, `ISettingsService`, `IThemeService`, `ILocalizationService` solely to forward them to children. These deps belong only to the child VMs.
+
+### Changes
+
+Register child VMs in DI (`App.axaml.cs` or the DI setup file):
+```csharp
+services.AddSingleton<AccountsViewModel>();
+services.AddSingleton<FilesViewModel>();
+services.AddSingleton<DashboardViewModel>();
+services.AddSingleton<ActivityViewModel>();
+services.AddSingleton<SettingsViewModel>();
+services.AddSingleton<StatusBarViewModel>();
+```
+
+**`Home/MainWindowViewModel.cs`** — replace inline `new(...)` properties with injected parameters:
+```csharp
+// Before
+public AccountsViewModel Accounts { get; } = new(authService, graphService, accountRepository);
+
+// After (primary constructor injection)
+public AccountsViewModel Accounts { get; }
+// ...set from injected parameter
+```
+
+Removed deps from MainWindowViewModel: `IAuthService`, `IGraphService`, `ISettingsService`, `IThemeService`, `ILocalizationService`.
+
+---
+
+## Phase 4 — Reactive StatusBar (remove `SyncStatusBarToActiveAccount`)
+
+**Why:** `SyncStatusBarToActiveAccount()` is called from 6 callsites — fragile, easy to miss. StatusBar should react to `AccountsViewModel.ActiveAccount` changes instead.
+
+### Options (pick one)
+
+**Option A — Subscribe in StatusBarViewModel** (recommended):
+- `StatusBarViewModel` takes `AccountsViewModel` as a constructor dep
+- Subscribes to `AccountsViewModel.PropertyChanged` for `nameof(ActiveAccount)`
+- Self-updates its own properties
+
+**Option B — XAML binding** (simpler, no subscription management):
+- Bind `StatusBar.*` directly to `Accounts.ActiveAccount.*` in `MainWindow.axaml`
+- Works if `ActiveAccount` raises `PropertyChanged` on its own properties
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `Home/StatusBarViewModel.cs` | Add `AccountsViewModel` dep (Option A) or keep as-is (Option B) |
+| `Home/MainWindowViewModel.cs` | Delete `SyncStatusBarToActiveAccount()` and all 6 callsites |
+
+### Tests (Option A)
+
+New test class: `AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs`
+
+```
+when_active_account_is_null_then_has_account_is_false
+when_active_account_is_set_then_email_matches_account_email
+when_active_account_sync_state_changes_then_status_bar_reflects_change
+when_active_account_conflict_count_changes_then_status_bar_reflects_change
+```
+
+---
+
+## Phase 5 — Simplify `SyncNowAsync`
+
+**Why:** Reconstructs `OneDriveAccount` from `IAccountRepository` to pass to `scheduler.TriggerAccountAsync`. This logic already exists in `DashboardAccountViewModel.SyncNowAsync` — it's duplicated.
+
+### Change
+
+Add overload to `ISyncScheduler`:
+```csharp
+Task TriggerAccountAsync(string accountId, CancellationToken ct = default);
+```
+
+`SyncNowAsync` becomes:
+```csharp
+[RelayCommand]
+private async Task SyncNowAsync()
+{
+    var active = Accounts.ActiveAccount;
+    if(active is null)
+        return;
+
+    await _scheduler.TriggerAccountAsync(active.Id);
+}
+```
+
+Removes `IAccountRepository` from `MainWindowViewModel`.
+
+---
+
+## Resulting MainWindowViewModel
+
+**Before:** 10 deps, ~310 lines, 6 responsibilities
+
+**After:** ~5 deps, ~120 lines, 1 responsibility (shell coordination)
+
+```csharp
+public sealed partial class MainWindowViewModel(
+    IApplicationInitializer initializer,
+    ISyncScheduler scheduler,
+    AccountsViewModel accounts,
+    FilesViewModel files,
+    DashboardViewModel dashboard,
+    ActivityViewModel activity,
+    SettingsViewModel settings,
+    StatusBarViewModel statusBar) : ObservableObject
+```
+
+Removed deps: `IAuthService`, `IGraphService`, `IStartupService`, `ISyncService`, `IThemeService`, `ISyncRepository`, `ISettingsService`, `IAccountRepository`, `ILocalizationService`
+
+---
+
+## Tests for Refactored MainWindowViewModel
+
+New test class: `AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs`
+
+```
+when_created_then_active_section_is_dashboard
+when_navigate_called_then_active_section_changes
+when_navigate_to_dashboard_then_is_dashboard_active_is_true
+when_navigate_to_accounts_then_is_accounts_active_is_true
+when_sync_now_command_executed_with_no_active_account_then_scheduler_not_called
+when_sync_now_command_executed_with_active_account_then_scheduler_called_with_account_id
+when_add_account_command_executed_then_navigates_to_accounts_section
+when_initialise_async_called_then_delegates_to_application_initializer
+```
+
+---
+
+## Execution Order
+
+```
+Phase 1: ISyncEventAggregator     ← biggest impact, self-contained
+Phase 2: IApplicationInitializer  ← depends on Phase 1 (removes event wiring from InitialiseAsync)
+Phase 3: Inject child VMs         ← parallel with Phase 2, depends on DI registrations
+Phase 4: Reactive StatusBar       ← depends on Phase 3 (StatusBarViewModel gets AccountsViewModel)
+Phase 5: Simplify SyncNowAsync    ← small, can be done any time
+```
+
+---
+
+## TDD Commit Sequence (per phase)
+
+```
+test(desktop/onedrive): failing tests for <phase name>
+feat(desktop/onedrive): implement <phase name>
+refactor(desktop/onedrive): clean up after <phase name>  [if needed]
+```
+
+Branch: `feature/onedrive-mainwindow-decompose`
+
+---
+
+## Files Created / Modified (full list)
+
+### New files
+- `Infrastructure/Sync/ISyncEventAggregator.cs`
+- `Infrastructure/Sync/SyncEventAggregator.cs`
+- `Infrastructure/Shell/IApplicationInitializer.cs`
+- `Infrastructure/Shell/ApplicationInitializer.cs`
+- `Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs`
+- `Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs`
+- `Tests.Unit/Home/GivenAMainWindowViewModel.cs`
+- `Tests.Unit/Home/GivenAStatusBarViewModel.cs` (if Option A)
+
+### Modified files
+- `Home/MainWindowViewModel.cs` (primary target — shrinks from 310 → ~120 lines)
+- `Accounts/AccountsViewModel.cs` (subscribe to ISyncEventAggregator)
+- `Dashboard/DashboardViewModel.cs` (subscribe to ISyncEventAggregator)
+- `Activity/ActivityViewModel.cs` (subscribe to ISyncEventAggregator)
+- `Home/StatusBarViewModel.cs` (reactive to AccountsViewModel.ActiveAccount)
+- `Infrastructure/Sync/ISyncScheduler.cs` (add accountId overload)
+- DI registration file (register child VMs as Singleton)


### PR DESCRIPTION
## Summary

- Extracts `ISyncEventAggregator` singleton from `MainWindowViewModel`, removing 4 handler methods and direct event subscriptions to `ISyncService`/`ISyncScheduler`
- Adds `IUiDispatcher` / `AvaloniaUiDispatcher` abstraction so the aggregator can be tested without an Avalonia runtime
- Child VMs (`AccountsViewModel`, `ActivityViewModel`, `DashboardViewModel`) now subscribe to the aggregator directly via `SubscribeToSyncEvents()`
- Registers new singletons in `ShellServiceExtensions`

## Test plan

- [ ] 4 new unit tests in `GivenASyncEventAggregator` cover each aggregated event (progress, job completed, conflict, sync completed)
- [ ] `InlineUiDispatcher` test double executes actions synchronously — no Avalonia runtime needed
- [ ] All 313 tests pass, zero build errors/warnings
- [ ] Manual smoke test: launch app, trigger a sync, confirm status bar and dashboard update as before

## Related

Part of the planned `MainWindowViewModel` decomposition — see `docs/onedrive-mainwindow-refactor-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)