### PR TITLE
feat(desktop/onedrive): simplify SyncNowAsync — Phase 5

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -44,7 +44,7 @@ public sealed class GivenAMainWindowViewModel
     {
         var accountsVm = CreateAccountsViewModel();
 
-        return new(_initializer, _scheduler, _accountRepository, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
+        return new(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
     }
 
     [Fact]
@@ -93,7 +93,20 @@ public sealed class GivenAMainWindowViewModel
 
         await sut.SyncNowCommand.ExecuteAsync(null);
 
-        await _scheduler.DidNotReceive().TriggerAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+        await _scheduler.DidNotReceive().TriggerAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_sync_now_command_executed_with_active_account_then_scheduler_called_with_account_id()
+    {
+        const string accountId = "active-account-123";
+        var accountsVm = CreateAccountsViewModel();
+        accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = accountId, DisplayName = "Test User", Email = "test@example.com" });
+        var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
+
+        await sut.SyncNowCommand.ExecuteAsync(null);
+
+        await _scheduler.Received(1).TriggerAccountAsync(accountId, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -1,13 +1,14 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
 
-public sealed class SyncSchedulerTests
+public sealed class GivenASyncScheduler
 {
     [Fact]
-    public void Constructor_ShouldInitializeWithDependencies()
+    public void when_constructed_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -18,22 +19,11 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public void DefaultInterval_ShouldBe60Minutes()
+    public void when_default_interval_accessed_then_returns_60_minutes()
         => SyncScheduler.DefaultInterval.ShouldBe(TimeSpan.FromMinutes(60));
 
     [Fact]
-    public void Start_ShouldInitializeTimer()
-    {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
-
-        scheduler.Start();
-        _ = scheduler.ShouldNotBeNull();
-    }
-
-    [Fact]
-    public void Start_WithDefaultInterval_ShouldUse60Minutes()
+    public void when_started_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -45,7 +35,19 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public void Start_WithCustomInterval_ShouldUseProvidedInterval()
+    public void when_started_with_default_interval_then_scheduler_is_not_null()
+    {
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
+
+        scheduler.Start();
+
+        _ = scheduler.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void when_started_with_custom_interval_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -58,7 +60,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public void Stop_ShouldStopTimer()
+    public void when_stopped_after_start_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -71,7 +73,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public void SetInterval_ShouldUpdateInterval()
+    public void when_interval_set_after_start_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -85,7 +87,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerNowAsync_ShouldExecuteSyncPass()
+    public async Task when_trigger_now_then_repository_get_all_called_once()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -99,7 +101,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerNowAsync_WhenAlreadyRunning_ShouldNotStartNewPass()
+    public async Task when_trigger_now_called_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -113,7 +115,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerAccountAsync_ShouldSyncSpecificAccount()
+    public async Task when_trigger_account_then_sync_service_called_for_account()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -126,7 +128,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerAccountAsync_ShouldRaiseSyncStartedEvent()
+    public async Task when_trigger_account_then_sync_started_event_raised()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -148,7 +150,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerAccountAsync_ShouldRaiseSyncCompletedEvent()
+    public async Task when_trigger_account_then_sync_completed_event_raised()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -170,7 +172,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerAccountAsync_WhenSyncServiceThrows_ShouldStillRaiseCompletedEvent()
+    public async Task when_trigger_account_and_sync_service_throws_then_completed_event_still_raised()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -190,7 +192,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public void SyncScheduler_ShouldBeAsyncDisposable()
+    public void when_scheduler_created_then_it_is_async_disposable()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -204,7 +206,7 @@ public sealed class SyncSchedulerTests
     [InlineData(30)]
     [InlineData(60)]
     [InlineData(120)]
-    public void Start_WithVariousIntervals_ShouldInitializeSuccessfully(int minutes)
+    public void when_started_with_various_intervals_then_scheduler_is_not_null(int minutes)
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -217,7 +219,7 @@ public sealed class SyncSchedulerTests
     }
 
     [Fact]
-    public async Task TriggerAccountAsync_ShouldPassCorrectAccountData()
+    public async Task when_trigger_account_then_correct_account_data_passed_to_sync_service()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
@@ -234,5 +236,75 @@ public sealed class SyncSchedulerTests
         await mockSyncService.Received(1).SyncAccountAsync(
             Arg.Is<OneDriveAccount>(a => a.Id == "account-123"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_account_exists_then_sync_service_called()
+    {
+        const string accountId = "account-456";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(accountId, Arg.Any<CancellationToken>()).Returns(new AccountEntity
+        {
+            Id = accountId,
+            DisplayName = "Test User",
+            Email = "test@outlook.com",
+            LocalSyncPath = "/some/path",
+            ConflictPolicy = ConflictPolicy.Ignore,
+            SyncFolders = []
+        });
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
+
+        await scheduler.TriggerAccountAsync(accountId, TestContext.Current.CancellationToken);
+
+        await mockSyncService.Received(1).SyncAccountAsync(
+            Arg.Is<OneDriveAccount>(a => a.Id == accountId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_account_not_found_then_sync_service_not_called()
+    {
+        const string accountId = "missing-account";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(accountId, Arg.Any<CancellationToken>()).Returns((AccountEntity?)null);
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
+
+        await scheduler.TriggerAccountAsync(accountId, TestContext.Current.CancellationToken);
+
+        await mockSyncService.DidNotReceive().SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_account_exists_then_sync_started_event_raised()
+    {
+        const string accountId = "account-789";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(accountId, Arg.Any<CancellationToken>()).Returns(new AccountEntity { Id = accountId, DisplayName = "Test", Email = "test@test.com", SyncFolders = [] });
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
+        string? raisedId = null;
+        scheduler.SyncStarted += (_, id) => raisedId = id;
+
+        await scheduler.TriggerAccountAsync(accountId, TestContext.Current.CancellationToken);
+
+        raisedId.ShouldBe(accountId);
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_account_exists_then_sync_completed_event_raised()
+    {
+        const string accountId = "account-789";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(accountId, Arg.Any<CancellationToken>()).Returns(new AccountEntity { Id = accountId, DisplayName = "Test", Email = "test@test.com", SyncFolders = [] });
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository);
+        string? raisedId = null;
+        scheduler.SyncCompleted += (_, id) => raisedId = id;
+
+        await scheduler.TriggerAccountAsync(accountId, TestContext.Current.CancellationToken);
+
+        raisedId.ShouldBe(accountId);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
@@ -3,7 +3,6 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Models;
@@ -18,7 +17,7 @@ using SettingsViewModel = AStar.Dev.OneDrive.Sync.Client.Settings.SettingsViewMo
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
-public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, IAccountRepository accountRepository, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, StatusBarViewModel statusBar) : ObservableObject
+public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, StatusBarViewModel statusBar) : ObservableObject
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDashboardActive))]
@@ -141,22 +140,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
         if(active is null)
             return;
 
-        var entity = await accountRepository.GetByIdAsync(active.Id, CancellationToken.None);
-        if(entity is null)
-            return;
-
-        var account = new OneDriveAccount
-        {
-            Id                = entity.Id,
-            DisplayName       = entity.DisplayName,
-            Email             = entity.Email,
-            LocalSyncPath     = entity.LocalSyncPath,
-            ConflictPolicy    = entity.ConflictPolicy,
-            SelectedFolderIds = [.. entity.SyncFolders.Select(f => f.FolderId)],
-            LastSyncedAt      = entity.LastSyncedAt
-        };
-
-        await scheduler.TriggerAccountAsync(account);
+        await scheduler.TriggerAccountAsync(active.Id);
     }
 
     [RelayCommand]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
@@ -18,6 +18,11 @@ public interface ISyncScheduler
     Task TriggerNowAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Triggers an immediate sync for a single account identified by its ID.
+    /// </summary>
+    Task TriggerAccountAsync(string accountId, CancellationToken ct = default);
+
+    /// <summary>
     /// Triggers an immediate sync for a single account.
     /// </summary>
     Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -54,6 +54,29 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     }
 
     /// <summary>
+    /// Triggers an immediate sync for a single account identified by its ID.
+    /// </summary>
+    public async Task TriggerAccountAsync(string accountId, CancellationToken ct = default)
+    {
+        var entity = await accountRepository.GetByIdAsync(accountId, ct).ConfigureAwait(false);
+        if(entity is null)
+            return;
+
+        var account = new OneDriveAccount
+        {
+            Id                = entity.Id,
+            DisplayName       = entity.DisplayName,
+            Email             = entity.Email,
+            LocalSyncPath     = entity.LocalSyncPath,
+            ConflictPolicy    = entity.ConflictPolicy,
+            SelectedFolderIds = [.. entity.SyncFolders.Select(f => f.FolderId)],
+            LastSyncedAt      = entity.LastSyncedAt
+        };
+
+        await TriggerAccountAsync(account, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Triggers an immediate sync for a single account.
     /// </summary>
     public async Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default)


### PR DESCRIPTION
## Summary

- Simplifies `SyncNowAsync` in `MainWindowViewModel` by delegating sync orchestration to `ISyncScheduler`, removing ad-hoc cancellation token management and inline logic from the view-model
- Extends `ISyncScheduler` with an `accountId`-targeted overload so the scheduler owns the full sync lifecycle
- Renames `SyncSchedulerTests.cs` → `GivenASyncScheduler.cs` to match the `Given*` test-class naming convention; expands coverage for the new overload and all branches

## Test plan

- [ ] `GivenASyncScheduler` — all branches of the new `accountId` overload green
- [ ] `GivenAMainWindowViewModel` — `SyncNowAsync` delegates to `ISyncScheduler`; cancellation and error paths covered
- [ ] `dotnet build` — zero errors, zero warnings
- [ ] `dotnet test` on `AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)