### PR TITLE
fix(desktop/onedrive): persist child folder selections to repository

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
@@ -10,12 +10,14 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
 
 public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
 {
-    private const string AccountIdString = "account-1";
+    private const string AccountIdString  = "account-1";
     private const string LocalSyncPathString = "/configured/sync/path";
-    private const string AccessToken = "token-abc";
-    private const string DriveId = "drive-1";
-    private const string FolderId = "folder-1";
-    private const string FolderName = "Photos";
+    private const string AccessToken      = "token-abc";
+    private const string DriveId          = "drive-1";
+    private const string FolderId         = "folder-1";
+    private const string FolderName       = "Photos";
+    private const string ChildFolderId    = "folder-1-child";
+    private const string ChildFolderName  = "Holidays";
 
     [Fact]
     public async Task when_a_folder_is_toggled_then_the_local_sync_path_is_preserved_in_the_repository()
@@ -86,6 +88,80 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         savedEntity!.ConflictPolicy.ShouldBe(ConflictPolicy.RemoteWins);
     }
 
+    [Fact]
+    public async Task when_a_child_folder_is_toggled_included_then_the_child_folder_is_persisted_to_the_repository()
+    {
+        var (authService, graphService, repository) = BuildMocksWithChild();
+
+        repository.GetByIdAsync(new AccountId(AccountIdString), Arg.Any<CancellationToken>())
+            .Returns(BuildStoredEntity(LocalSyncPathString, ConflictPolicy.Ignore));
+
+        var sut = BuildSut(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+        await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
+
+        AccountEntity? savedEntity = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(e => savedEntity = e), Arg.Any<CancellationToken>());
+
+        sut.RootFolders[0].Children[0].ToggleIncludeCommand.Execute(null);
+
+        await repository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+        savedEntity.ShouldNotBeNull();
+        savedEntity!.SyncFolders.ShouldContain(f => f.FolderId == new OneDriveFolderId(ChildFolderId));
+    }
+
+    [Fact]
+    public async Task when_a_child_folder_is_toggled_included_and_root_is_also_included_then_both_are_persisted()
+    {
+        var (authService, graphService, repository) = BuildMocksWithChild();
+
+        repository.GetByIdAsync(new AccountId(AccountIdString), Arg.Any<CancellationToken>())
+            .Returns(BuildStoredEntity(LocalSyncPathString, ConflictPolicy.Ignore));
+
+        var sut = BuildSut(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.RootFolders[0].ToggleIncludeCommand.Execute(null);
+
+        await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
+
+        AccountEntity? savedEntity = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(e => savedEntity = e), Arg.Any<CancellationToken>());
+
+        sut.RootFolders[0].Children[0].ToggleIncludeCommand.Execute(null);
+
+        await repository.Received(2).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+        savedEntity.ShouldNotBeNull();
+        savedEntity!.SyncFolders.ShouldContain(f => f.FolderId == new OneDriveFolderId(FolderId));
+        savedEntity!.SyncFolders.ShouldContain(f => f.FolderId == new OneDriveFolderId(ChildFolderId));
+    }
+
+    [Fact]
+    public async Task when_a_child_folder_is_toggled_excluded_then_the_child_is_removed_from_persisted_sync_folders()
+    {
+        var (authService, graphService, repository) = BuildMocksWithChild();
+
+        repository.GetByIdAsync(new AccountId(AccountIdString), Arg.Any<CancellationToken>())
+            .Returns(BuildStoredEntity(LocalSyncPathString, ConflictPolicy.Ignore));
+
+        var sut = BuildSut(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+        await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
+
+        sut.RootFolders[0].Children[0].ToggleIncludeCommand.Execute(null);
+
+        AccountEntity? savedEntity = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(e => savedEntity = e), Arg.Any<CancellationToken>());
+
+        sut.RootFolders[0].Children[0].ToggleIncludeCommand.Execute(null);
+
+        savedEntity.ShouldNotBeNull();
+        savedEntity!.SyncFolders.ShouldNotContain(f => f.FolderId == new OneDriveFolderId(ChildFolderId));
+    }
+
     private static (IAuthService Auth, IGraphService Graph, IAccountRepository Repository) BuildMocks()
     {
         var authService  = Substitute.For<IAuthService>();
@@ -100,6 +176,16 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(FolderId, FolderName)]);
+
+        return (authService, graphService, repository);
+    }
+
+    private static (IAuthService Auth, IGraphService Graph, IAccountRepository Repository) BuildMocksWithChild()
+    {
+        var (authService, graphService, repository) = BuildMocks();
+
+        graphService.GetChildFoldersAsync(AccessToken, DriveId, FolderId, Arg.Any<CancellationToken>())
+            .Returns([new DriveFolder(ChildFolderId, ChildFolderName, FolderId)]);
 
         return (authService, graphService, repository);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
@@ -3,10 +3,10 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Graph;
 
-public sealed class GraphServiceTests
+public sealed class GivenAGraphService
 {
     [Fact]
-    public void Constructor_ShouldInitializeSuccessfully()
+    public void when_constructed_then_instance_is_not_null()
     {
         var service = new GraphService(Substitute.For<IUploadService>());
 
@@ -14,11 +14,10 @@ public sealed class GraphServiceTests
     }
 
     [Fact]
-    public void GraphService_ShouldImplementIGraphService()
+    public void when_constructed_then_it_implements_IGraphService()
     {
         var service = new GraphService(Substitute.For<IUploadService>());
 
         _ = service.ShouldBeAssignableTo<IGraphService>();
     }
 }
-

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -131,8 +131,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         if (entity is null)
             return;
 
-        entity.SyncFolders = [.. RootFolders
-            .Where(f => f.IsIncluded)
+        entity.SyncFolders = [.. CollectAllIncluded(RootFolders)
             .Select(f => new SyncFolderEntity
             {
                 FolderId   = new OneDriveFolderId(f.Id),
@@ -160,5 +159,17 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                    : "xdg-open";
 
         _ = System.Diagnostics.Process.Start(opener, path);
+    }
+
+    private static IEnumerable<FolderTreeNodeViewModel> CollectAllIncluded(IEnumerable<FolderTreeNodeViewModel> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            if (node.IsIncluded)
+                yield return node;
+
+            foreach (var descendant in CollectAllIncluded(node.Children))
+                yield return descendant;
+        }
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -10,6 +10,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 public sealed class GraphService(IUploadService uploadService) : IGraphService
 {
     private const string RootPathMarker = "root:";
+
+    private static readonly string[] ChildrenSelect =
+    [
+        "id", "name", "folder", "file", "size", "lastModifiedDateTime", "parentReference",
+        "@microsoft.graph.downloadUrl"
+    ];
+
     private readonly Dictionary<string, DriveContext> _cache = [];
 
     /// <inheritdoc />
@@ -22,7 +29,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
         (var client, var driveContext) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
         var driveItemCollectionResponse = await client.Drives[driveContext.DriveId].Items[driveContext.RootId].Children
-            .GetAsync(req => req.QueryParameters.Select =    ["id", "name", "folder", "file", "size",     "lastModifiedDateTime", "parentReference",     "@microsoft.graph.downloadUrl"], ct);
+            .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
 
         List<DriveFolder> folders = [];
 
@@ -157,27 +164,47 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
     {
         List<DeltaItem> items = [];
         await EnumerateSubFolderAsync(client, driveId, folderId, folderName, items, ct);
-        var deltaPage = await GetDeltaLinkForNextSync(client, driveId, folderId, ct);
-
-        string? deltaLink = deltaPage?.OdataDeltaLink;
+        string? deltaLink = await ConsumeDeltaToGetLinkAsync(client, driveId, folderId, ct);
 
         return new DeltaResult(items, deltaLink, false);
     }
 
-    private static async Task<DeltaGetResponse?> GetDeltaLinkForNextSync(GraphServiceClient client, string driveId, string folderId, CancellationToken ct)
-            => await client.Drives[driveId].Items[folderId].Delta.GetAsDeltaGetResponseAsync(cancellationToken: ct);
+    /// <summary>
+    /// Pages through the entire delta feed for <paramref name="folderId"/> to reach the final
+    /// page that carries <c>@odata.deltaLink</c>. Only the link itself is returned; the items
+    /// enumerated here are discarded because the current sync already collected them via
+    /// <see cref="EnumerateSubFolderAsync"/>.
+    /// </summary>
+    private static async Task<string?> ConsumeDeltaToGetLinkAsync(GraphServiceClient client, string driveId, string folderId, CancellationToken ct)
+    {
+        var page = await client.Drives[driveId].Items[folderId].Delta
+            .GetAsDeltaGetResponseAsync(cancellationToken: ct);
+
+        while(page is not null)
+        {
+            if(page.OdataNextLink is null)
+                return page.OdataDeltaLink;
+
+            page = await client.Drives[driveId].Items[folderId].Delta
+                .WithUrl(page.OdataNextLink)
+                .GetAsDeltaGetResponseAsync(cancellationToken: ct);
+        }
+
+        return null;
+    }
 
     private static async Task EnumerateSubFolderAsync(GraphServiceClient client, string driveId, string parentId, string relativePath, List<DeltaItem> items, CancellationToken ct)
     {
-        var page = await client.Drives[driveId].Items[parentId].Children.GetAsync(cancellationToken: ct);
+        var page = await client.Drives[driveId].Items[parentId].Children
+            .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
 
         while(page?.Value is not null)
         {
             foreach(var item in page.Value)
             {
                 string itemPath = string.IsNullOrEmpty(relativePath)
-                ? item.Name ?? string.Empty
-                : $"{relativePath}/{item.Name}";
+                    ? item.Name ?? string.Empty
+                    : $"{relativePath}/{item.Name}";
 
                 items.Add(new DeltaItem(
                     Id: item.Id!,
@@ -195,9 +222,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
                     RelativePath: itemPath));
 
                 if(item.Folder is not null && item.Id is not null)
-                {
                     await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, ct);
-                }
             }
 
             if(page.OdataNextLink is null)


### PR DESCRIPTION
OnIncludeToggled only walked RootFolders directly, so any child-folder
toggle was silently lost on next load. CollectAllIncluded now recurses
the full tree so every included descendant is written to the DB.

Also extracts ChildrenSelect constant (removes inline duplicate array),
pages the full delta feed in ConsumeDeltaToGetLinkAsync to capture the
correct @odata.deltaLink, and renames test class/methods to project
naming conventions.