### PR TITLE
fix(desktop/onedrive): fetch download URL on-demand when absent from delta response

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
@@ -1,0 +1,164 @@
+using System.Threading.Channels;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenADownloadWorker
+{
+    private const string AccessToken = "test-token";
+    private const string ItemId      = "item-abc";
+
+    private readonly IHttpDownloader  _downloader     = Substitute.For<IHttpDownloader>();
+    private readonly IGraphService    _graphService   = Substitute.For<IGraphService>();
+    private readonly ISyncRepository  _syncRepository = Substitute.For<ISyncRepository>();
+
+    private DownloadWorker CreateSut(int workerId = 1) => new(workerId, _downloader, _graphService, _syncRepository);
+
+    private static SyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file") => new()
+    {
+        RemoteItemId   = ItemId,
+        RelativePath   = "Desktop/file.txt",
+        LocalPath      = "/tmp/file.txt",
+        Direction      = SyncDirection.Download,
+        DownloadUrl    = downloadUrl,
+        RemoteModified = DateTimeOffset.UtcNow
+    };
+
+    private static async Task<(List<SyncJob> Completed, List<string?> Errors)> RunWorkerWithJobsAsync(DownloadWorker worker, IEnumerable<SyncJob> jobs, CancellationToken ct)
+    {
+        var channel   = Channel.CreateUnbounded<SyncJob>();
+        var completed = new List<SyncJob>();
+        var errors    = new List<string?>();
+
+        foreach(var job in jobs)
+            channel.Writer.TryWrite(job);
+
+        channel.Writer.Complete();
+
+        await worker.RunAsync(channel.Reader, AccessToken, (job, _, error) =>
+        {
+            completed.Add(job);
+            errors.Add(error);
+        }, ct);
+
+        return (completed, errors);
+    }
+
+    [Fact]
+    public async Task when_download_job_has_url_then_downloader_is_called_with_that_url()
+    {
+        const string url = "https://example.com/direct";
+        var job = MakeDownloadJob(url);
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _downloader.Received(1).DownloadAsync(url, job.LocalPath, job.RemoteModified, ct: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_download_job_has_no_url_then_graph_service_is_called_to_resolve_it()
+    {
+        const string fetchedUrl = "https://example.com/fetched";
+        var job = MakeDownloadJob(downloadUrl: null);
+
+        _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
+            .Returns(fetchedUrl);
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _graphService.Received(1).GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>());
+        await _downloader.Received(1).DownloadAsync(fetchedUrl, job.LocalPath, job.RemoteModified, ct: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_download_job_has_no_url_and_graph_returns_null_then_job_fails_with_error_containing_item_id()
+    {
+        var job = MakeDownloadJob(downloadUrl: null);
+
+        _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var (completed, errors) = await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        completed.Count.ShouldBe(1);
+        string errorMessage = errors[0].ShouldNotBeNull();
+        errorMessage.ShouldContain(ItemId);
+        await _downloader.DidNotReceive().DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), ct: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_download_job_has_no_url_and_graph_returns_null_then_job_state_is_set_to_failed()
+    {
+        var job = MakeDownloadJob(downloadUrl: null);
+
+        _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Id, SyncJobState.Failed, Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_job_state_is_set_to_completed()
+    {
+        var job = MakeDownloadJob();
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Id, SyncJobState.Completed);
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_on_job_complete_is_called_with_no_error()
+    {
+        var job = MakeDownloadJob();
+
+        var (_, errors) = await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        errors.Count.ShouldBe(1);
+        errors[0].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task when_upload_job_is_processed_then_graph_service_upload_is_called()
+    {
+        var job = new SyncJob
+        {
+            RemoteItemId   = ItemId,
+            FolderId       = "folder-1",
+            RelativePath   = "Desktop/file.txt",
+            LocalPath      = "/tmp/file.txt",
+            Direction      = SyncDirection.Upload,
+            RemoteModified = DateTimeOffset.UtcNow
+        };
+
+        _graphService.UploadFileAsync(AccessToken, job.LocalPath, Arg.Any<string>(), job.FolderId, Arg.Any<CancellationToken>())
+            .Returns("remote-item-id");
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _graphService.Received(1).UploadFileAsync(AccessToken, job.LocalPath, Arg.Any<string>(), job.FolderId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_delete_job_is_processed_then_no_downloader_or_graph_download_calls_are_made()
+    {
+        var job = new SyncJob
+        {
+            RemoteItemId   = ItemId,
+            RelativePath   = "Desktop/file.txt",
+            LocalPath      = "/tmp/nonexistent-file-that-does-not-exist.txt",
+            Direction      = SyncDirection.Delete,
+            RemoteModified = DateTimeOffset.UtcNow
+        };
+
+        await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await _downloader.DidNotReceive().DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), ct: Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -10,11 +10,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 public sealed class GraphService(IUploadService uploadService) : IGraphService
 {
     private const string RootPathMarker = "root:";
+    private const string DownloadUrlKey  = "@microsoft.graph.downloadUrl";
 
     private static readonly string[] ChildrenSelect =
     [
         "id", "name", "folder", "file", "size", "lastModifiedDateTime", "parentReference",
-        "@microsoft.graph.downloadUrl"
+        DownloadUrlKey
     ];
 
     private readonly Dictionary<string, DriveContext> _cache = [];
@@ -153,6 +154,23 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
     }
 
     /// <inheritdoc />
+    public async Task<string?> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default)
+    {
+        (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+
+        var item = await client.Drives[ctx.DriveId].Items[itemId]
+            .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
+            .ConfigureAwait(false);
+
+        if(item?.AdditionalData is null)
+            return null;
+
+        return item.AdditionalData.TryGetValue(DownloadUrlKey, out var url)
+            ? url?.ToString()
+            : null;
+    }
+
+    /// <inheritdoc />
     public async Task<string> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
@@ -215,10 +233,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
                     IsDeleted: false,
                     Size: item.Size ?? 0L,
                     LastModified: item.LastModifiedDateTime,
-                    DownloadUrl: item.AdditionalData
-                        .TryGetValue("@microsoft.graph.downloadUrl", out object? url)
-                            ? url?.ToString()
-                            : null,
+                    DownloadUrl: ExtractDownloadUrl(item),
                     RelativePath: itemPath));
 
                 if(item.Folder is not null && item.Id is not null)
@@ -254,12 +269,14 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
             IsDeleted: item.Deleted is not null,
             Size: item.Size ?? 0L,
             LastModified: item.LastModifiedDateTime,
-            DownloadUrl: item.AdditionalData
-                .TryGetValue("@microsoft.graph.downloadUrl", out object? url)
-                    ? url?.ToString()
-                    : null,
+            DownloadUrl: ExtractDownloadUrl(item),
             RelativePath: relativePath);
     }
+
+    private static string? ExtractDownloadUrl(DriveItem item)
+        => item.AdditionalData?.TryGetValue(DownloadUrlKey, out var url) is true
+            ? url?.ToString()
+            : null;
 
     private async Task<(GraphServiceClient Client, DriveContext Ctx)> ResolveClientWithDriveContextAsync(string accessToken, CancellationToken ct)
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -48,6 +48,16 @@ public interface IGraphService
     Task<DeltaResult> GetDeltaAsync(string accessToken, string folderId, string? deltaLink, CancellationToken ct = default);
 
     /// <summary>
+    /// Fetches the pre-authenticated download URL for a specific drive item.
+    /// Use this when <c>@microsoft.graph.downloadUrl</c> is absent from a delta or children response.
+    /// </summary>
+    /// <param name="accessToken">The access token for the authenticated user.</param>
+    /// <param name="itemId">The Graph item ID of the file.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The download URL, or <see langword="null"/> if not available.</returns>
+    Task<string?> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default);
+
+    /// <summary>
     /// Uploads a local file to OneDrive using a resumable upload session.
     /// Handles all file sizes. Returns the remote item ID on success.
     /// </summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -42,7 +42,7 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
             catch(Exception ex)
             {
                 error = ex.Message;
-                Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path} stack={Stack}", workerId, ex.GetType().Name, ex.Message, job.LocalPath, ex.StackTrace);
+                Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}", workerId, ex.GetType().Name, ex.Message, job.LocalPath);
                 await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Failed, ex.Message);
             }
             finally
@@ -57,13 +57,10 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
         switch(job.Direction)
         {
             case SyncDirection.Download:
-                if(job.DownloadUrl is null)
-                {
-                    throw new InvalidOperationException($"No download URL for {job.RelativePath}");
-                }
+                string downloadUrl = await ResolveDownloadUrlAsync(job, accessToken, ct);
 
                 await downloader.DownloadAsync(
-                    job.DownloadUrl,
+                    downloadUrl,
                     job.LocalPath,
                     job.RemoteModified,
                     ct: ct);
@@ -82,5 +79,17 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
                     File.Delete(job.LocalPath);
                 break;
         }
+    }
+
+    private async Task<string> ResolveDownloadUrlAsync(SyncJob job, string accessToken, CancellationToken ct)
+    {
+        if(job.DownloadUrl is not null)
+            return job.DownloadUrl;
+
+        Serilog.Log.Debug("[Worker {Id}] DownloadUrl absent for {Path} — fetching on-demand", workerId, job.RelativePath);
+
+        var url = await graphService.GetDownloadUrlAsync(accessToken, job.RemoteItemId, ct).ConfigureAwait(false);
+
+        return url ?? throw new InvalidOperationException($"No download URL could be resolved for '{job.RelativePath}' (itemId={job.RemoteItemId}).");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -56,7 +56,7 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
 
         var outcome = ConflictResolver.Resolve(policy, conflict.LocalModified, conflict.RemoteModified);
 
-        await ApplyConflictOutcomeAsync(conflict, outcome, ct);
+        await ApplyConflictOutcomeAsync(conflict, outcome, authResult.AccessToken!, ct);
 
         await syncRepository.ResolveConflictAsync(conflict.Id, policy);
     }
@@ -298,23 +298,15 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
         await parallelDownloadPipeline.RunAsync(jobs, accessToken, args => SyncProgressChanged?.Invoke(this, args), args => JobCompleted?.Invoke(this, args), account.Id.Id, jobs.FirstOrDefault()?.FolderId ?? string.Empty, ct: ct);
     }
 
-    private async Task ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, CancellationToken ct)
+    private async Task ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accessToken, CancellationToken ct)
     {
         switch(outcome)
         {
             case ConflictOutcome.UseRemote:
-                var job = new SyncJob
-                {
-                    AccountId      = conflict.AccountId,
-                    FolderId       = conflict.FolderId,
-                    RemoteItemId   = conflict.RemoteItemId,
-                    RelativePath   = conflict.RelativePath,
-                    LocalPath      = conflict.LocalPath,
-                    Direction      = SyncDirection.Download,
-                    RemoteModified = conflict.RemoteModified
-                };
+                string downloadUrl = await graphService.GetDownloadUrlAsync(accessToken, conflict.RemoteItemId, ct).ConfigureAwait(false)
+                    ?? throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.RelativePath}' (itemId={conflict.RemoteItemId}).");
 
-                await httpDownloader.DownloadAsync(job.DownloadUrl ?? string.Empty, job.LocalPath, job.RemoteModified, ct: ct);
+                await httpDownloader.DownloadAsync(downloadUrl, conflict.LocalPath, conflict.RemoteModified, ct: ct);
                 break;
 
             case ConflictOutcome.KeepBoth:


### PR DESCRIPTION
## Summary

- `@microsoft.graph.downloadUrl` is not guaranteed in incremental delta responses — `DownloadWorker` was throwing `InvalidOperationException` and silently dropping the download
- `DownloadWorker` now calls `IGraphService.GetDownloadUrlAsync` on-demand when `DownloadUrl` is null; throws with a clear message (including `itemId`) only if Graph also returns null
- `SyncService.ApplyConflictOutcomeAsync` had the same bug — built a `SyncJob` with no URL then passed `string.Empty` to the downloader; now fetches on-demand via Graph
- `GraphService.GetDownloadUrlAsync` resolves the drive ID from the existing per-token cache, so no extra round-trip for cached sessions
- Extracted `DownloadUrlKey` constant and `ExtractDownloadUrl(DriveItem)` helper in `GraphService` to eliminate duplicated `AdditionalData.TryGetValue` calls

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 383 passed (8 new in `GivenADownloadWorker`)
- [ ] Smoke-test incremental sync on a folder with files not synced recently (delta path, no cached URL)
- [ ] Verify conflict resolution with `UseRemote` policy downloads the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)