### PR TITLE
fix(desktop/onedrive): fix UI hang caused by blocking async in MainWindow constructor

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -41,12 +41,12 @@ public class App : Application, IDisposable
             return;
 
         var splashWindow = new SplashWindow();
-        var mainWindow = _services.GetRequiredService<MainWindow>();
         desktop.MainWindow = splashWindow;
 
         splashWindow.Opened += async (_, _) =>
         {
-            await BootstrapAsync(mainWindow, new Progress<string>(splashWindow.SetStatus));
+            await BootstrapAsync(new Progress<string>(splashWindow.SetStatus));
+            var mainWindow = _services.GetRequiredService<MainWindow>();
             desktop.MainWindow = mainWindow;
             mainWindow.Show();
             splashWindow.Close();
@@ -105,7 +105,7 @@ public class App : Application, IDisposable
             .CreateLogger();
     }
 
-    private async Task BootstrapAsync(MainWindow window, IProgress<string> progress)
+    private async Task BootstrapAsync(IProgress<string> progress)
     {
         try
         {
@@ -129,6 +129,10 @@ public class App : Application, IDisposable
 
             progress.Report("Initialising startup…");
             var startupService = _services.GetRequiredService<IStartupService>();
+
+            progress.Report("Initialising application…");
+            var mainWindowViewModel = _services.GetRequiredService<MainWindowViewModel>();
+            await mainWindowViewModel.InitialiseAsync();
 
             progress.Report("Starting sync scheduler…");
             scheduler.StartSync(TimeSpan.FromMinutes(settingsService.Current.SyncIntervalMinutes));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml.cs
@@ -10,7 +10,5 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         DataContext = vm;
-
-        vm.InitialiseAsync().GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## Summary

- `MainWindow` constructor called `.GetAwaiter().GetResult()` on `InitialiseAsync` — deadlocked the UI thread before the splash window could render
- `GetRequiredService<MainWindow>()` was resolved eagerly in `OnFrameworkInitializationCompleted`, triggering the deadlock immediately
- `MainWindow` ctor now only sets `DataContext`; all async init moved into `BootstrapAsync` as a named progress step

## Test plan

- [x] `dotnet build` — zero errors, zero warnings (local version warnings only)
- [x] `dotnet test` — 383/383 pass
- [x] Manual: verify splash displays, progress steps advance, and `MainWindow` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)