### PR TITLE
refactor(desktop/onedrive): convert AuthResult to record, harden Grap…

### DIFF
--- a/.claude/agents/c-sharp-reviewer.md
+++ b/.claude/agents/c-sharp-reviewer.md
@@ -1,7 +1,7 @@
 ---
-name: c-sharp-code-reviewer
+name: c-sharp-reviewer
 description: Reviews C# code for correctness, style, and adherence to AStar.Dev mono-repo conventions. Use when reviewing .cs or .csproj files, NuGet package code, Blazor components, or any .NET code in this repository.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 color: purple
 ---
@@ -25,11 +25,15 @@ You are a senior C# / .NET engineer reviewing code in the AStar.Dev mono-repo.
 ## Code quality checks
 
 - Correctness: logic errors, off-by-one errors, incorrect async/await usage, missing `ConfigureAwait`, fire-and-forget tasks.
+- Class operates on one level of abstraction — flag classes that mix low-level details (e.g., database access) with high-level logic (e.g., business rules).
+- Class operates on one domain concept — flag classes that mix unrelated concepts (e.g., user management and payment processing).
+- Methods should be short and focused — flag methods that are too long or do too many things.
+- Methods should operate on one level of abstraction — flag methods that mix low-level details with high-level logic.
 - Security: SQL injection, XSS (in Blazor), command injection, secrets in source, insecure deserialization, OWASP Top 10.
 - Performance: unnecessary allocations, `string` concatenation in loops, blocking async code (`.Result`, `.Wait()`), missing `CancellationToken` propagation, N+1 database calls.
 - Design: SOLID violations, inappropriate use of `static`, overly large classes/methods, missing abstractions where code will clearly be reused. Flag any file placed in a technical-type folder (`ViewModels/`, `Commands/`, `Validators/`, etc.) — code must be organised by business feature (see `c-sharp-senior-developer`).
-- Formatting: every `return` statement must be preceded by a blank line — flag any `return` that has code on the immediately preceding line (this applies in production code, tests, and test helpers without exception).
-- Test coverage: public API surface should have tests; flag any public method in a `packages/` project that has no corresponding test.
+- Formatting: every `return` statement must be preceded by a blank line (except when the return follows `if`/`else` directly) — flag any `return` that has code on the immediately preceding line (this applies in production code, tests, and test helpers without exception).
+- Test coverage: public API surface should have tests; flag any public method that has no corresponding tests.
 
 ## Output format
 
@@ -39,5 +43,9 @@ For each issue found, provide:
 2. **Severity** — `error` / `warning` / `suggestion`
 3. **Issue** — one-sentence description
 4. **Fix** — concrete corrected code snippet where applicable
+
+## Output file
+
+1. **Documentation** — create the report as a markdown file with links to relevant documentation (e.g., Microsoft C# coding conventions, OWASP Top 10, AStar.Dev repo guidelines). Filename format: `code-review-report-<project>-<timestamp>.md` and place in the `docs/` directory.
 
 End with a short summary: total counts by severity and an overall verdict (approve / approve with suggestions / request changes).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,12 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [{ "type": "command", "command": "if echo \"$CLAUDE_FILE_PATHS\" | grep -q '\\.cs$'; then dotnet build --nologo -v q 2>&1 | tail -20; fi" }]
+      }
     ]
   },
   "statusLine": {

--- a/.claude/skills/add-tests/SKILL.md
+++ b/.claude/skills/add-tests/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: add-tests
+description: Add behaviour tests to a C# file via the c-sharp-qa subagent. Reads the target file and its dependencies, captures a baseline test count, delegates test writing to the QA agent, then reports the delta and any pre-existing failures.
+---
+
+Add behaviour tests to the C# file specified in $ARGUMENTS.
+
+**Input**: Path to the target `.cs` source file (not the test file). Example: `/add-tests apps/desktop/Foo/Services/BarService.cs`
+
+**Steps**
+
+1. **Resolve the target file**
+
+   If $ARGUMENTS is a relative path, resolve it against the repo root. If no argument is given, ask the user which file to test.
+
+2. **Capture baseline test results**
+
+   Run the full test suite and capture the output before any changes:
+
+   ```bash
+   dotnet test --nologo 2>&1
+   ```
+
+   Parse and record:
+   - Total tests passed (baseline count)
+   - Any already-failing tests (name + error) — label these **pre-existing failures**
+
+   If the build itself fails, report that immediately and stop.
+
+3. **Read the target file and its direct dependencies**
+
+   - Read the target source file in full.
+   - Identify every type it directly depends on (constructor parameters, method parameters, return types, field types).
+   - Read each dependency file. Use `Glob` / `Grep` to locate them if the path is not obvious.
+   - Locate the existing test project for this file (pattern: `[Assembly].Tests.Unit`) and read any existing test class for this type so the agent does not duplicate coverage.
+   - Read `.claude/rules/c-sharp-code-style.md` and `.claude/agents/c-sharp-qa.md` for conventions.
+
+4. **Spawn the c-sharp-qa subagent**
+
+   Delegate with this briefing (fill in the placeholders):
+
+   > You are writing behaviour tests for `{TARGET_FILE}` in the AStar.Dev mono-repo.
+   >
+   > **Target file content:**
+   > {TARGET_FILE_CONTENT}
+   >
+   > **Direct dependencies (read these before writing tests):**
+   > {LIST_OF_DEPENDENCY_PATHS}
+   >
+   > **Existing test class (if any) — do not duplicate these cases:**
+   > {EXISTING_TEST_CLASS_CONTENT_OR_"None"}
+   >
+   > **Conventions:**
+   > - Test class: `Given[Context]`, sealed, in `[Assembly].Tests.Unit`
+   > - Test methods: `when_[action]_then_[outcome]` snake_case
+   > - Assertions: Shouldly only — never `Assert.*`
+   > - Mocking: NSubstitute only
+   > - Global usings already cover xUnit, Shouldly, NSubstitute — do not re-add them
+   > - No comments, no XML docs inside test classes
+   > - AAA sections separated by a single blank line; no `// Arrange` labels
+   > - Single-line method signatures regardless of parameter count
+   > - Blank line before every `return` statement except when the return follows `if`/`else` directly
+   >
+   > Write tests covering all branches and observable behaviours not already covered.
+   > After writing, run `dotnet build` on the test project and confirm zero errors and zero warnings.
+   > Do NOT run `dotnet test` — the caller will do that.
+
+5. **Run the test suite after the agent completes**
+
+   ```bash
+   dotnet test --nologo 2>&1
+   ```
+
+   Parse:
+   - New total passed count
+   - Any newly failing tests (tests that were passing before but now fail)
+
+6. **Report results**
+
+   Output a summary in this format:
+
+   ```
+   ## Add Tests: {TARGET_FILE_NAME}
+
+   ### Test Count
+   Before: {BASELINE_COUNT} passing
+   After:  {NEW_COUNT} passing
+   Delta:  +{DELTA} new tests
+
+   ### Pre-existing Failures (not caused by this change)
+   {LIST_OR_"None"}
+
+   ### New Failures Introduced
+   {LIST_OR_"None — all tests pass"}
+   ```
+
+   If new failures were introduced, do NOT commit. Investigate and fix before reporting done.
+
+**Guardrails**
+- Never write tests directly yourself — always delegate to the c-sharp-qa subagent.
+- Never commit or create a PR — the human decides when to commit.
+- If the test project does not exist, stop and ask the human before proceeding.
+- If baseline has build errors, stop immediately and report them.
+- Pre-existing failures are informational only; do not attempt to fix them unless asked.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,5 +108,5 @@
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "cSpell.language": "en-GB",
-  "cSpell.words": ["Astar", "Avalonia", "axaml", "Blazor", "dorny", "Isnt", "NOLOGO", "OPTOUT", "Parameterised", "SENDGRID", "Serilog", "Shouldly", "slnx", "testsettings", "XMLDOC"]
+  "cSpell.words": ["Astar", "Avalonia", "axaml", "Blazor", "dorny", "Isnt", "Msal", "NOLOGO", "OPTOUT", "Parameterised", "SENDGRID", "Serilog", "Shouldly", "slnx", "testsettings", "XMLDOC"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance to Claude Code (claude.ai/code) for this repo.
 
 ## Repository Overview
 
-Mono-repo containing all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, and ~25 published **NuGet packages**. Solution file: `AStar.Dev.slnx`.
+Mono-repo, all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, ~25 published **NuGet packages**. Solution: `AStar.Dev.slnx`.
 
 ## Build Commands
 
@@ -32,7 +32,7 @@ dotnet test tests/[ProjectName].Tests
 dotnet test --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
 ```
 
-Coverage reports are written to `TestResults/`.
+Coverage → `TestResults/`.
 
 ## Running Applications
 
@@ -46,21 +46,21 @@ cd apps/web/[appname] && npm run dev
 
 ## Logging
 
-Logging is NEVER an after-thought. Whether .Net or JavaScript, logging MUST be implemented from day one. Refer to the @.claude/agents/c-sharp-senior-developer.md for all .Net Projects or @.claude/agents/javascript-senior-developer.md.md for JavaScript projects for additional logging information. ALL Logging MUST be sent to Azure Application Insights unless otherwise instructed. Where applicable, use the AStar.Dev.Logging.Extensions (specifically the `LogMessage` class) to use compile-time logging templates. If a suitable template does not exist, ADD IT. Avoid `logger.Log...` wherever possible. There is currently no JavaScript equivalent but logging must still be performed.
+Logging NEVER afterthought. .Net or JavaScript — MUST implement day one. See @.claude/agents/c-sharp-senior-developer.md (.Net) or @.claude/agents/javascript-senior-developer.md.md (JS). ALL logging MUST go to Azure Application Insights unless instructed otherwise. Use `AStar.Dev.Logging.Extensions` (`LogMessage` class) for compile-time templates. No suitable template? ADD IT. Avoid `logger.Log...`. No JS equivalent exists; log anyway.
 
 ## Dependency Injection
 
-Dependency Injection is NEVER an after-thought. If the language supports it, DI MUST be implemented from the beginning.
+DI NEVER afterthought. Language supports it? MUST implement from start.
 
 ## NuGet projects
 
-The mono repo contains many NuGet projects that are deployed to both GitHub and NuGet. These include:
+Mono-repo has many NuGet projects deployed to GitHub and NuGet.org:
 
-- AStar.Dev.Functional.Extensions: Result<T>, Option<T>, Map<Async>, Bind<Async> etc to support the functional approach. ALWAYS use when practicable.
-- AStar.Dev.Logging.Extensions: Compile-time LogMessage format and many other related logging extensions. ALWAYS use when practicable.
-- AStar.Dev.Utilities: a plethora of string extensions, nullability checks and many other `utility` methods. ALWAYS use when practicable.
+- AStar.Dev.Functional.Extensions: Result<T>, Option<T>, Map<Async>, Bind<Async> etc. ALWAYS use when practicable.
+- AStar.Dev.Logging.Extensions: Compile-time `LogMessage` format + logging extensions. ALWAYS use when practicable.
+- AStar.Dev.Utilities: string extensions, nullability checks, utility methods. ALWAYS use when practicable.
 
-- If the above (or the other projects) have a suitable method: USE IT. If new code is reusable: ADD IT to the relevant project and raise a GitHub issue documenting why it was created, where it was created and how to deploy the updated package to GitHub / NuGet.
+Suitable method exists in above? USE IT. New reusable code? ADD IT to relevant project + raise GitHub issue documenting why, where, how to deploy.
 
 ## Architecture
 
@@ -82,35 +82,42 @@ tests/        # Repo-wide integration/E2E tests
 
 ### Centralized Build Configuration
 
-All `.csproj` files automatically inherit from three root files — never duplicate settings already defined there:
+All `.csproj` inherit from three root files — never duplicate settings already defined there:
 
 - **`Directory.Build.props`** — Target framework (`net10.0`), nullable reference types, `TreatWarningsAsErrors=true`, output paths to `artifacts/`, shared NuGet metadata
 - **`Directory.Build.targets`** — Source Link, package metadata validation (requires `Description`, `PackageTags`, `PackageLicenseExpression`), project naming enforcement (`AStar.Dev.*` prefix), VSTest blame mode
-- **`Directory.Packages.props`** — Central Package Management (CPM): all NuGet package versions are declared here; individual `.csproj` files reference packages without versions
+- **`Directory.Packages.props`** — Central Package Management (CPM): all NuGet versions declared here; `.csproj` files reference without versions
 
 ### Build Output
 
-All `bin/` and `obj/` folders redirect to `artifacts/` at the repo root. Do not look for binaries inside individual project directories.
+All `bin/` and `obj/` redirect to `artifacts/` at repo root. Don't look for binaries inside individual project dirs.
 
 ### Versioning
 
-- Version is injected by CI at publish time via `-p:Version=$(GitTag)`; local builds use the fallback `0.0.1-local`
-- Single repo-wide version tag: all packages in a release share the same version
+- CI injects version at publish via `-p:Version=$(GitTag)`; local builds fallback to `0.0.1-local`
+- Single repo-wide version tag: all packages in release share same version
 - Tag format: `v1.2.3` (triggers `nuget-publish.yml`)
 - Pre-release: `v2.0.0-beta.1`
 
 ### NuGet Packages
 
-- Naming convention: `AStar.Dev.[Area].[Name]`
-- Published to both GitHub Packages and NuGet.org via CI
-- Symbol packages (`.snupkg`) are published alongside `.nupkg`
-- **Do not run `dotnet pack` / `dotnet nuget push` manually for releases** — use the tag workflow
-- During local development, use `<ProjectReference>` instead of `<PackageReference>` to avoid publish cycles
+- Naming: `AStar.Dev.[Area].[Name]`
+- Published to GitHub Packages and NuGet.org via CI
+- Symbol packages (`.snupkg`) published alongside `.nupkg`
+- **No manual `dotnet pack` / `dotnet nuget push` for releases** — use tag workflow
+- Local dev: use `<ProjectReference>` not `<PackageReference>` to avoid publish cycles
 
 ### Avalonia / Blazor / C# / .NET Patterns
 
-For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions), see @.claude/agents/c-sharp-senior-developer.md and @.claude/rules/c-sharp-code-style.md
-For all C#-specific updates, use the @.claude/agentsc-sharp-senior-developer.md subagent
+C#-specific patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions): see @.claude/agents/c-sharp-senior-developer.md and @.claude/rules/c-sharp-code-style.md.
+C# updates: use @.claude/agentsc-sharp-senior-developer.md subagent.
+
+### C#/.NET Conventions
+
+- Eliminate "what" comments by extracting well-named methods — NOT by moving them into XML docs.
+- Blank line before every `return` (except `return` directly after `if`/`else`).
+- ReactiveUI issues: prefer `RxAppBuilder`/`RxSchedulers` over NuGet downgrades.
+- Testing internals with NSubstitute: account for proxy limitations on `internal` classes.
 
 ### CI/CD Workflows
 
@@ -122,39 +129,52 @@ For all C#-specific updates, use the @.claude/agentsc-sharp-senior-developer.md 
 
 ### Conventions
 
-- **Commit messages**: Conventional Commits format — `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
-- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` is ALWAYS deployable
-- **Test projects**: Named `*.Tests.Unit` or `*.Tests.Integration` — automatically set `IsPackable=false`
-- **Method signatures**: Always single-line regardless of parameter count — `public void Foo(string a, int b, CancellationToken ct = default)`. Never split parameters across lines. This applies to every file type.
-- **Comments**: Never add comments that restate what the code already says — in any file type (`.cs`, `.csproj`, `.axaml`, config files, etc.). Refactor to extract the code that needs a comment when appropriate. Only write a comment when the *reason* behind a decision is not derivable from the code itself.
-- **Child `Directory.Build.props`**: Sub-folder overrides must import the parent via `$([MSBuild]::GetPathOfFileAbove(...))`
-- **Naming Conventions**: follow the @.claude/rules/c-sharp-code-style.md for .Net projects or @.claude/rules/javascript-code-style.md for JavaScript projects. Fallback to the official language-specific naming when no local specification exists locally.
-- **XML Comments**: include for all public methods / properties
-    - Classes that implement an interface should rely on interface documentation, not class-level docs. Use `<inheritdoc />` where supported.
+- **Commit messages**: Conventional Commits — `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
+- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` ALWAYS deployable
+- **Test projects**: Named `*.Tests.Unit` or `*.Tests.Integration` — auto-set `IsPackable=false`
+- **Method signatures**: Always single-line regardless of param count — `public void Foo(string a, int b, CancellationToken ct = default)`. Never split params across lines. Every file type.
+- **Comments**: Never restate what code says — any file type (`.cs`, `.csproj`, `.axaml`, config, etc.). Refactor to extract when needed. Only comment when _reason_ behind decision isn't derivable from code.
+- **Child `Directory.Build.props`**: Sub-folder overrides must import parent via `$([MSBuild]::GetPathOfFileAbove(...))`
+- **Naming**: follow @.claude/rules/c-sharp-code-style.md (.Net) or @.claude/rules/javascript-code-style.md (JS). Fallback to official language naming when no local spec exists.
+- **XML Comments**: all public methods/properties
+    - Classes implementing interface: use `<inheritdoc />`, not class-level docs.
 
 ## Before Starting Any Task
 
-These two steps are **MANDATORY** before writing a single line of code. No exceptions, including spikes.
+Two steps **MANDATORY** before single line of code. No exceptions, including spikes.
 
-1. **Branch first** — run `git branch` to confirm you are not on `main`. If you are, create a feature branch immediately:
+1. **Branch first** — run `git branch`, confirm not on `main`. If on main, create branch:
 
     ```bash
     git checkout -b feature/short-description
     ```
 
-    Branch naming: `feature/...`, `bug/...`, `doc/...`. Never commit directly to `main`. See @docs/git-instructions.md.
+    Naming: `feature/...`, `bug/...`, `doc/...`. Never commit to `main`. See @docs/git-instructions.md.
 
-2. **Tests are MANDATORY** — every coding task requires a test project. New code MUST have tests covering all branches wherever possible.
+2. **Tests MANDATORY** — every coding task needs test project. New code MUST have tests covering all branches wherever possible.
+
+## Branching & Commits
+
+- NEVER commit to `main`. Always branch first.
+- NEVER commit code with failing tests or build errors.
+- Human signals completion (`perfect`, `thanks`, `lgtm`) → STOP editing unless asked.
+
+## Workflow Discipline
+
+- Non-trivial change? State plan, confirm with human first.
+- Don't spend entire session exploring. Timebox, then implement.
+- Verify shell working directory before creating migrations or path-sensitive artifacts.
+- EF Core migrations: always include Designer file.
 
 ## Definition of Done
 
-Before considering any coding task complete — including commits and PRs — always:
+Before any coding task complete — commits and PRs included:
 
-1. `dotnet build` the affected project(s) and confirm zero errors and zero warnings
-2. `dotnet test` the affected test project(s) and confirm all tests pass
-3. Request the human reviews the code BEFORE committing it.
-4. If the human requests changes, implement them and then request re-review.
-5. ONLY when the human confirms the code is approved can you commit the code to the branch and raise the GitHub PR.
+1. `dotnet build` affected projects — zero errors, zero warnings
+2. `dotnet test` affected test projects — all pass
+3. Request human review BEFORE committing.
+4. Human requests changes? Implement, re-request review.
+5. ONLY after human approval: commit to branch, raise GitHub PR.
 
 ## Additional Instructions
 

--- a/CLAUDE.original.md
+++ b/CLAUDE.original.md
@@ -1,0 +1,181 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+Mono-repo containing all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, and ~25 published **NuGet packages**. Solution file: `AStar.Dev.slnx`.
+
+## Build Commands
+
+```bash
+dotnet restore
+
+dotnet build
+or
+dotnet build --configuration Release
+
+dotnet build packages/core/[PackageName]
+dotnet build apps/web/[AppName].Blazor
+
+# If Directory.Build.props changes aren't taking effect
+dotnet clean && dotnet build
+```
+
+## Test Commands
+
+```bash
+dotnet test
+
+dotnet test tests/[ProjectName].Tests
+
+dotnet test --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+```
+
+Coverage reports are written to `TestResults/`.
+
+## Running Applications
+
+```bash
+dotnet run --project apps/web/[AppName].Blazor
+
+dotnet run --project apps/desktop/[AppName].Desktop
+
+cd apps/web/[appname] && npm run dev
+```
+
+## Logging
+
+Logging is NEVER an after-thought. Whether .Net or JavaScript, logging MUST be implemented from day one. Refer to the @.claude/agents/c-sharp-senior-developer.md for all .Net Projects or @.claude/agents/javascript-senior-developer.md.md for JavaScript projects for additional logging information. ALL Logging MUST be sent to Azure Application Insights unless otherwise instructed. Where applicable, use the AStar.Dev.Logging.Extensions (specifically the `LogMessage` class) to use compile-time logging templates. If a suitable template does not exist, ADD IT. Avoid `logger.Log...` wherever possible. There is currently no JavaScript equivalent but logging must still be performed.
+
+## Dependency Injection
+
+Dependency Injection is NEVER an after-thought. If the language supports it, DI MUST be implemented from the beginning.
+
+## NuGet projects
+
+The mono repo contains many NuGet projects that are deployed to both GitHub and NuGet. These include:
+
+- AStar.Dev.Functional.Extensions: Result<T>, Option<T>, Map<Async>, Bind<Async> etc to support the functional approach. ALWAYS use when practicable.
+- AStar.Dev.Logging.Extensions: Compile-time LogMessage format and many other related logging extensions. ALWAYS use when practicable.
+- AStar.Dev.Utilities: a plethora of string extensions, nullability checks and many other `utility` methods. ALWAYS use when practicable.
+
+- If the above (or the other projects) have a suitable method: USE IT. If new code is reusable: ADD IT to the relevant project and raise a GitHub issue documenting why it was created, where it was created and how to deploy the updated package to GitHub / NuGet.
+
+## Architecture
+
+### Directory Layout
+
+```
+apps/
+  web/        # Blazor (C#) WebAssembly/Server and astro apps
+  desktop/    # Avalonia (C#) cross-platform desktop apps
+packages/
+  core/       # Domain models, business logic
+  infra/      # Data access, auth, logging, HTTP clients
+  ui/         # Shared UI components
+infra/terraform/
+  staging/    # Auto-applies on merge to main
+  prod/       # Requires GitHub Environments approval gate
+tests/        # Repo-wide integration/E2E tests
+```
+
+### Centralized Build Configuration
+
+All `.csproj` files automatically inherit from three root files — never duplicate settings already defined there:
+
+- **`Directory.Build.props`** — Target framework (`net10.0`), nullable reference types, `TreatWarningsAsErrors=true`, output paths to `artifacts/`, shared NuGet metadata
+- **`Directory.Build.targets`** — Source Link, package metadata validation (requires `Description`, `PackageTags`, `PackageLicenseExpression`), project naming enforcement (`AStar.Dev.*` prefix), VSTest blame mode
+- **`Directory.Packages.props`** — Central Package Management (CPM): all NuGet package versions are declared here; individual `.csproj` files reference packages without versions
+
+### Build Output
+
+All `bin/` and `obj/` folders redirect to `artifacts/` at the repo root. Do not look for binaries inside individual project directories.
+
+### Versioning
+
+- Version is injected by CI at publish time via `-p:Version=$(GitTag)`; local builds use the fallback `0.0.1-local`
+- Single repo-wide version tag: all packages in a release share the same version
+- Tag format: `v1.2.3` (triggers `nuget-publish.yml`)
+- Pre-release: `v2.0.0-beta.1`
+
+### NuGet Packages
+
+- Naming convention: `AStar.Dev.[Area].[Name]`
+- Published to both GitHub Packages and NuGet.org via CI
+- Symbol packages (`.snupkg`) are published alongside `.nupkg`
+- **Do not run `dotnet pack` / `dotnet nuget push` manually for releases** — use the tag workflow
+- During local development, use `<ProjectReference>` instead of `<PackageReference>` to avoid publish cycles
+
+### Avalonia / Blazor / C# / .NET Patterns
+
+For all C#-specific architecture patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions), see @.claude/agents/c-sharp-senior-developer.md and @.claude/rules/c-sharp-code-style.md
+For all C#-specific updates, use the @.claude/agentsc-sharp-senior-developer.md subagent
+
+### C#/.NET Conventions
+
+- Eliminate "what" comments by extracting well-named methods — do NOT simply move them into XML docs.
+- Add a blank line before every `return` statement (except `return` directly after an `if`/`else` directly).
+- For ReactiveUI issues, prefer `RxAppBuilder`/`RxSchedulers` replacements over downgrading NuGet packages.
+- When testing internals with NSubstitute, account for proxy limitations on `internal` classes.
+
+### CI/CD Workflows
+
+| Workflow            | Trigger                                                     |
+| ------------------- | ----------------------------------------------------------- |
+| `dotnet-ci.yml`     | Push/PR touching `.cs`, `.csproj`, `*.slnx`, MSBuild config |
+| `nuget-publish.yml` | Push of a `v*` tag                                          |
+| `infra-deploy.yml`  | Push/PR touching `infra/**`                                 |
+
+### Conventions
+
+- **Commit messages**: Conventional Commits format — `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
+- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` is ALWAYS deployable
+- **Test projects**: Named `*.Tests.Unit` or `*.Tests.Integration` — automatically set `IsPackable=false`
+- **Method signatures**: Always single-line regardless of parameter count — `public void Foo(string a, int b, CancellationToken ct = default)`. Never split parameters across lines. This applies to every file type.
+- **Comments**: Never add comments that restate what the code already says — in any file type (`.cs`, `.csproj`, `.axaml`, config files, etc.). Refactor to extract the code that needs a comment when appropriate. Only write a comment when the _reason_ behind a decision is not derivable from the code itself.
+- **Child `Directory.Build.props`**: Sub-folder overrides must import the parent via `$([MSBuild]::GetPathOfFileAbove(...))`
+- **Naming Conventions**: follow the @.claude/rules/c-sharp-code-style.md for .Net projects or @.claude/rules/javascript-code-style.md for JavaScript projects. Fallback to the official language-specific naming when no local specification exists locally.
+- **XML Comments**: include for all public methods / properties
+    - Classes that implement an interface should rely on interface documentation, not class-level docs. Use `<inheritdoc />` where supported.
+
+## Before Starting Any Task
+
+These two steps are **MANDATORY** before writing a single line of code. No exceptions, including spikes.
+
+1. **Branch first** — run `git branch` to confirm you are not on `main`. If you are, create a feature branch immediately:
+
+    ```bash
+    git checkout -b feature/short-description
+    ```
+
+    Branch naming: `feature/...`, `bug/...`, `doc/...`. Never commit directly to `main`. See @docs/git-instructions.md.
+
+2. **Tests are MANDATORY** — every coding task requires a test project. New code MUST have tests covering all branches wherever possible.
+
+## Branching & Commits
+
+- NEVER commit directly to `main`. Always create a feature branch first.
+- NEVER commit code with failing tests or build errors.
+- After the human signals completion (e.g., `perfect`, `thanks`, `lgtm`), STOP making further edits unless explicitly asked.
+
+## Workflow Discipline
+
+- Before implementing a non-trivial change, briefly state the plan and confirm with the human.
+- Do NOT spend an entire session exploring; timebox exploration and start implementing.
+- Verify the shell working directory before creating migration files or other path-sensitive artifacts.
+- For EF Core migrations, always include the Designer file.
+
+## Definition of Done
+
+Before considering any coding task complete — including commits and PRs — always:
+
+1. `dotnet build` the affected project(s) and confirm zero errors and zero warnings
+2. `dotnet test` the affected test project(s) and confirm all tests pass
+3. Request the human reviews the code BEFORE committing it.
+4. If the human requests changes, implement them and then request re-review.
+5. ONLY when the human confirms the code is approved can you commit the code to the branch and raise the GitHub PR.
+
+## Additional Instructions
+
+- Git workflow: @docs/git-instructions.md

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountCardViewModelTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountCardViewModelTests.cs
@@ -1,0 +1,484 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnAccountCardViewModel
+{
+    [Fact]
+    public void when_constructed_then_is_active_is_synchronized_from_model()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-1"), IsActive = true };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.IsActive.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_constructed_with_inactive_model_then_is_active_is_false()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-2"), IsActive = false };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_constructed_with_no_sync_history_then_last_sync_text_is_never_synced()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-3"), LastSyncedAt = null };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("Never synced");
+    }
+
+    [Fact]
+    public void when_constructed_with_recent_sync_within_two_minutes_then_last_sync_text_is_just_now()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-4"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("Just now");
+    }
+
+    [Fact]
+    public void when_last_synced_thirty_minutes_ago_then_last_sync_text_shows_minutes()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-5"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-30)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("30m ago");
+    }
+
+    [Fact]
+    public void when_last_synced_three_hours_ago_then_last_sync_text_shows_hours()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-6"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-3)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("3h ago");
+    }
+
+    [Fact]
+    public void when_last_synced_yesterday_then_last_sync_text_is_yesterday()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-7"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-24)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("Yesterday");
+    }
+
+    [Fact]
+    public void when_last_synced_five_days_ago_then_last_sync_text_shows_days()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-8"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-5)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("5d ago");
+    }
+
+    [Fact]
+    public void when_select_command_is_executed_then_selected_event_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-9") };
+        var sut = new AccountCardViewModel(model);
+        var eventRaised = false;
+        AccountCardViewModel? raisedViewModel = null;
+
+        sut.Selected += (sender, viewModel) =>
+        {
+            eventRaised = true;
+            raisedViewModel = viewModel;
+        };
+
+        sut.SelectCommand.Execute(null);
+
+        eventRaised.ShouldBeTrue();
+        raisedViewModel.ShouldBeSameAs(sut);
+    }
+
+    [Fact]
+    public void when_remove_command_is_executed_then_remove_requested_event_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-10") };
+        var sut = new AccountCardViewModel(model);
+        var eventRaised = false;
+        AccountCardViewModel? raisedViewModel = null;
+
+        sut.RemoveRequested += (sender, viewModel) =>
+        {
+            eventRaised = true;
+            raisedViewModel = viewModel;
+        };
+
+        sut.RemoveCommand.Execute(null);
+
+        eventRaised.ShouldBeTrue();
+        raisedViewModel.ShouldBeSameAs(sut);
+    }
+
+    [Fact]
+    public void when_refresh_from_model_called_with_updated_is_active_then_is_active_is_updated()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-11"), IsActive = true };
+        var sut = new AccountCardViewModel(model);
+
+        model.IsActive = false;
+        sut.RefreshFromModel();
+
+        sut.IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_refresh_from_model_called_then_display_name_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-12"), DisplayName = "Alice" };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.DisplayName))
+                propertyChangedRaised = true;
+        };
+
+        sut.RefreshFromModel();
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_refresh_from_model_called_then_email_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-13"), Email = "alice@outlook.com" };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.Email))
+                propertyChangedRaised = true;
+        };
+
+        sut.RefreshFromModel();
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_refresh_from_model_called_then_initials_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-14"), DisplayName = "Bob Smith" };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.Initials))
+                propertyChangedRaised = true;
+        };
+
+        sut.RefreshFromModel();
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_is_active_is_changed_then_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-15"), IsActive = false };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.IsActive))
+                propertyChangedRaised = true;
+        };
+
+        sut.IsActive = true;
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_sync_state_is_changed_then_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-16") };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.SyncState))
+                propertyChangedRaised = true;
+        };
+
+        sut.SyncState = SyncState.Syncing;
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_conflict_count_is_changed_then_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-17") };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.ConflictCount))
+                propertyChangedRaised = true;
+        };
+
+        sut.ConflictCount = 3;
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_last_sync_text_is_changed_then_property_changed_is_raised()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-18") };
+        var sut = new AccountCardViewModel(model);
+        var propertyChangedRaised = false;
+
+        sut.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(sut.LastSyncText))
+                propertyChangedRaised = true;
+        };
+
+        sut.LastSyncText = "2h ago";
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_display_name_has_two_parts_then_initials_are_first_letter_of_each()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-19"), DisplayName = "Alice Smith" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("AS");
+    }
+
+    [Fact]
+    public void when_display_name_is_single_word_then_initials_are_first_letter()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-20"), DisplayName = "Alice" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("A");
+    }
+
+    [Fact]
+    public void when_display_name_is_empty_and_email_provided_then_initials_are_first_letter_of_email()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-21"), DisplayName = "", Email = "bob@outlook.com" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("B");
+    }
+
+    [Fact]
+    public void when_display_name_and_email_are_empty_then_initials_are_question_mark()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-22"), DisplayName = "", Email = "" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("?");
+    }
+
+    [Fact]
+    public void when_display_name_has_multiple_words_then_initials_use_first_and_last()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-23"), DisplayName = "John Michael Smith" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("JS");
+    }
+
+    [Fact]
+    public void when_initials_are_derived_from_display_name_then_they_are_uppercase()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-24"), DisplayName = "alice smith" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("AS");
+    }
+
+    [Fact]
+    public void when_initials_are_derived_from_email_then_they_are_uppercase()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-25"), DisplayName = "", Email = "alice@outlook.com" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("A");
+    }
+
+    [Fact]
+    public void when_accent_index_is_zero_then_accent_hex_returns_first_palette_color()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-26"), AccentIndex = 0 };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.AccentHex.ShouldBe("#185FA5");
+    }
+
+    [Fact]
+    public void when_accent_index_is_beyond_palette_length_then_accent_hex_wraps_around()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-27"), AccentIndex = 6 };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.AccentHex.ShouldBe("#185FA5");
+    }
+
+    [Fact]
+    public void when_accent_index_is_five_then_accent_hex_returns_last_palette_color()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-28"), AccentIndex = 5 };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.AccentHex.ShouldBe("#854F0B");
+    }
+
+    [Fact]
+    public void when_accent_color_is_queried_then_it_returns_parsed_color_from_hex()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-29"), AccentIndex = 0 };
+
+        var sut = new AccountCardViewModel(model);
+
+        var expectedColor = Color.Parse("#185FA5");
+        sut.AccentColor.ShouldBe(expectedColor);
+    }
+
+    [Fact]
+    public void when_last_synced_exactly_two_minutes_ago_then_text_shows_minutes_not_just_now()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-31"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-2)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("2m ago");
+    }
+
+    [Fact]
+    public void when_last_synced_exactly_one_hour_ago_then_text_shows_hours_not_minutes()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-32"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("1h ago");
+    }
+
+    [Fact]
+    public void when_last_synced_exactly_one_day_ago_then_text_is_yesterday_not_hours()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-33"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("Yesterday");
+    }
+
+    [Fact]
+    public void when_last_synced_exactly_two_days_ago_then_text_shows_days_not_yesterday()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-34"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-2)
+        };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.LastSyncText.ShouldBe("2d ago");
+    }
+
+    [Fact]
+    public void when_refresh_from_model_is_called_then_last_sync_text_is_recalculated()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-35"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+
+        var sut = new AccountCardViewModel(model);
+        sut.LastSyncText.ShouldBe("Just now");
+
+        // Simulate time passing by updating the model's LastSyncedAt
+        model.LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        sut.RefreshFromModel();
+
+        sut.LastSyncText.ShouldBe("5m ago");
+    }
+
+    [Fact]
+    public void when_display_name_contains_extra_whitespace_then_initials_ignore_empty_parts()
+    {
+        var model = new OneDriveAccount { Id = new AccountId("account-36"), DisplayName = "Alice    Smith" };
+
+        var sut = new AccountCardViewModel(model);
+
+        sut.Initials.ShouldBe("AS");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
@@ -1,0 +1,268 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnAccountSyncSettingsViewModel
+{
+    private const string AccountIdValue = "test-account-id";
+    private const string DisplayNameValue = "Test User";
+    private const string EmailValue = "test@outlook.com";
+    private const string SyncPathValue = "/home/user/OneDrive";
+
+    private static OneDriveAccount BuildAccount(string? localSyncPath = null, ConflictPolicy conflictPolicy = ConflictPolicy.Ignore, int accentIndex = 0) => new()
+    {
+        Id = new AccountId(AccountIdValue),
+        DisplayName = DisplayNameValue,
+        Email = EmailValue,
+        AccentIndex = accentIndex,
+        LocalSyncPath = localSyncPath is null ? null : LocalSyncPath.Restore(localSyncPath),
+        ConflictPolicy = conflictPolicy
+    };
+
+    private static AccountEntity BuildEntity(string localSyncPath = "") => new()
+    {
+        Id = new AccountId(AccountIdValue),
+        DisplayName = DisplayNameValue,
+        Email = EmailValue
+    };
+
+    [Fact]
+    public void when_constructed_then_account_id_returns_inner_string_value()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        sut.AccountId.ShouldBe(AccountIdValue);
+    }
+
+    [Fact]
+    public void when_constructed_then_email_reflects_account_email()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        sut.Email.ShouldBe(EmailValue);
+    }
+
+    [Fact]
+    public void when_constructed_then_display_name_reflects_account_display_name()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        sut.DisplayName.ShouldBe(DisplayNameValue);
+    }
+
+    [Fact]
+    public void when_accent_index_is_zero_then_accent_hex_returns_first_palette_colour()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(accentIndex: 0), repository);
+
+        sut.AccentHex.ShouldBe("#185FA5");
+    }
+
+    [Fact]
+    public void when_accent_index_wraps_past_palette_length_then_accent_hex_returns_first_palette_colour()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(accentIndex: 6), repository);
+
+        sut.AccentHex.ShouldBe("#185FA5");
+    }
+
+    [Fact]
+    public void when_account_has_a_local_sync_path_then_local_sync_path_property_is_initialised_from_it()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(localSyncPath: SyncPathValue), repository);
+
+        sut.LocalSyncPath.ShouldBe(SyncPathValue);
+    }
+
+    [Fact]
+    public void when_account_has_no_local_sync_path_then_local_sync_path_property_is_empty_string()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(localSyncPath: null), repository);
+
+        sut.LocalSyncPath.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_constructed_then_conflict_policy_is_initialised_from_account()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(conflictPolicy: ConflictPolicy.LastWriteWins), repository);
+
+        sut.ConflictPolicy.ShouldBe(ConflictPolicy.LastWriteWins);
+    }
+
+    [Fact]
+    public void when_constructed_then_policy_options_contains_exactly_five_entries()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        sut.PolicyOptions.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public void when_constructed_then_policy_options_covers_all_conflict_policy_values()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        var policies = sut.PolicyOptions.Select(option => option.Policy).ToList();
+        policies.ShouldContain(ConflictPolicy.Ignore);
+        policies.ShouldContain(ConflictPolicy.KeepBoth);
+        policies.ShouldContain(ConflictPolicy.LastWriteWins);
+        policies.ShouldContain(ConflictPolicy.LocalWins);
+        policies.ShouldContain(ConflictPolicy.RemoteWins);
+    }
+
+    [Fact]
+    public async Task when_browse_command_is_executed_then_no_exception_is_thrown()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+
+        await sut.BrowseCommand.ExecuteAsync(null);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_and_entity_is_not_found_then_upsert_is_not_called()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns((AccountEntity?)null);
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(localSyncPath: SyncPathValue), repository);
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        await repository.DidNotReceive().UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_a_valid_path_and_entity_exists_then_upsert_is_called_once()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = SyncPathValue;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        await repository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_a_valid_path_then_entity_local_sync_path_value_is_updated()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        AccountEntity? captured = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = SyncPathValue;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        captured.ShouldNotBeNull();
+        captured!.LocalSyncPath.Value.ShouldBe(SyncPathValue);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_a_valid_path_then_entity_conflict_policy_is_updated()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        AccountEntity? captured = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = SyncPathValue;
+        sut.ConflictPolicy = ConflictPolicy.RemoteWins;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        captured.ShouldNotBeNull();
+        captured!.ConflictPolicy.ShouldBe(ConflictPolicy.RemoteWins);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_a_valid_path_then_account_model_local_sync_path_is_non_null_with_correct_value()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        var account = BuildAccount();
+        var sut = new AccountSyncSettingsViewModel(account, repository);
+        sut.LocalSyncPath = SyncPathValue;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        account.LocalSyncPath.ShouldNotBeNull();
+        account.LocalSyncPath!.Value.ShouldBe(SyncPathValue);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_an_empty_path_then_upsert_is_still_called()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = string.Empty;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        await repository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_an_empty_path_then_entity_local_sync_path_value_is_empty_string()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        AccountEntity? captured = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = string.Empty;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        captured.ShouldNotBeNull();
+        captured!.LocalSyncPath.Value.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_a_whitespace_path_then_entity_local_sync_path_value_is_empty_string()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        AccountEntity? captured = null;
+        await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
+        sut.LocalSyncPath = "   ";
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        captured.ShouldNotBeNull();
+        captured!.LocalSyncPath.Value.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public async Task when_save_is_executed_with_an_empty_path_then_account_model_local_sync_path_is_null()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(BuildEntity());
+        var account = BuildAccount();
+        var sut = new AccountSyncSettingsViewModel(account, repository);
+        sut.LocalSyncPath = string.Empty;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        account.LocalSyncPath.ShouldBeNull();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
@@ -1,0 +1,380 @@
+using AStar.Dev.OneDrive.Sync.Client.Activity;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Activity;
+
+public sealed class GivenAnActivityItemViewModel
+{
+    private const string AccountIdValue = "account-123";
+    private const string AccountEmailValue = "user@example.com";
+    private const string FolderNameValue = "Documents";
+    private const string RelativePathValue = "Documents/report.pdf";
+    private const string FileNameValue = "report.pdf";
+    private const string ErrorMessageValue = "Network timeout";
+    private const long FileSizeValue = 2048L;
+
+    private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null) => new()
+    {
+        AccountId = AccountIdValue,
+        Direction = direction,
+        RelativePath = relativePath,
+        FileSize = FileSizeValue,
+        CompletedAt = completedAt,
+        ErrorMessage = errorMessage
+    };
+
+    private static SyncConflict BuildSyncConflict(string relativePath = RelativePathValue, DateTimeOffset? detectedAt = null) => new()
+    {
+        AccountId = AccountIdValue,
+        RelativePath = relativePath,
+        DetectedAt = detectedAt ?? DateTimeOffset.UtcNow
+    };
+
+    [Fact]
+    public void when_type_is_downloaded_then_type_label_returns_downloaded() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Downloaded }.TypeLabel.ShouldBe("downloaded");
+
+    [Fact]
+    public void when_type_is_uploaded_then_type_label_returns_uploaded() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Uploaded }.TypeLabel.ShouldBe("uploaded");
+
+    [Fact]
+    public void when_type_is_deleted_then_type_label_returns_deleted() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Deleted }.TypeLabel.ShouldBe("deleted");
+
+    [Fact]
+    public void when_type_is_conflict_then_type_label_returns_conflict() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Conflict }.TypeLabel.ShouldBe("conflict");
+
+    [Fact]
+    public void when_type_is_error_then_type_label_returns_error() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Error }.TypeLabel.ShouldBe("error");
+
+    [Fact]
+    public void when_type_is_info_then_type_label_returns_info() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Info }.TypeLabel.ShouldBe("info");
+
+    [Fact]
+    public void when_type_is_downloaded_then_type_icon_returns_down_arrow() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Downloaded }.TypeIcon.ShouldBe("↓");
+
+    [Fact]
+    public void when_type_is_uploaded_then_type_icon_returns_up_arrow() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Uploaded }.TypeIcon.ShouldBe("↑");
+
+    [Fact]
+    public void when_type_is_deleted_then_type_icon_returns_multiplication_sign() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Deleted }.TypeIcon.ShouldBe("×");
+
+    [Fact]
+    public void when_type_is_conflict_then_type_icon_returns_warning_sign() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Conflict }.TypeIcon.ShouldBe("⚠");
+
+    [Fact]
+    public void when_type_is_error_then_type_icon_returns_warning_sign() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Error }.TypeIcon.ShouldBe("⚠");
+
+    [Fact]
+    public void when_type_is_info_then_type_icon_returns_bullet() =>
+        new ActivityItemViewModel { Type = ActivityItemType.Info }.TypeIcon.ShouldBe("•");
+
+    [Fact]
+    public void when_occurred_at_is_30_seconds_ago_then_time_ago_text_returns_just_now()
+    {
+        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
+
+        sut.TimeAgoText.ShouldBe("just now");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_5_minutes_ago_then_time_ago_text_returns_minutes_ago()
+    {
+        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddMinutes(-5) };
+
+        sut.TimeAgoText.ShouldBe("5m ago");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_3_hours_ago_then_time_ago_text_returns_hours_ago()
+    {
+        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddHours(-3) };
+
+        sut.TimeAgoText.ShouldBe("3h ago");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_25_hours_ago_then_time_ago_text_returns_yesterday()
+    {
+        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddHours(-25) };
+
+        sut.TimeAgoText.ShouldBe("yesterday");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_5_days_ago_then_time_ago_text_returns_days_ago()
+    {
+        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddDays(-5) };
+
+        sut.TimeAgoText.ShouldBe("5d ago");
+    }
+
+    [Fact]
+    public void when_file_size_is_non_zero_then_file_size_text_returns_non_empty_string()
+    {
+        var sut = new ActivityItemViewModel { FileSize = FileSizeValue };
+
+        sut.FileSizeText.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void when_file_size_is_zero_then_file_size_text_returns_non_null_string()
+    {
+        var sut = new ActivityItemViewModel { FileSize = 0L };
+
+        sut.FileSizeText.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void when_job_direction_is_download_then_from_job_returns_downloaded_type()
+    {
+        var job = BuildSyncJob(direction: SyncDirection.Download);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.Type.ShouldBe(ActivityItemType.Downloaded);
+    }
+
+    [Fact]
+    public void when_job_direction_is_upload_then_from_job_returns_uploaded_type()
+    {
+        var job = BuildSyncJob(direction: SyncDirection.Upload);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.Type.ShouldBe(ActivityItemType.Uploaded);
+    }
+
+    [Fact]
+    public void when_job_direction_is_delete_then_from_job_returns_deleted_type()
+    {
+        var job = BuildSyncJob(direction: SyncDirection.Delete);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.Type.ShouldBe(ActivityItemType.Deleted);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_account_id_is_mapped_from_job()
+    {
+        var job = BuildSyncJob();
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.AccountId.ShouldBe(AccountIdValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_account_email_is_mapped_from_parameter()
+    {
+        var job = BuildSyncJob();
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.AccountEmail.ShouldBe(AccountEmailValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_folder_name_is_mapped_from_parameter()
+    {
+        var job = BuildSyncJob();
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.FolderName.ShouldBe(FolderNameValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_file_name_is_derived_from_relative_path()
+    {
+        var job = BuildSyncJob(relativePath: RelativePathValue);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.FileName.ShouldBe(FileNameValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_relative_path_is_mapped_from_job()
+    {
+        var job = BuildSyncJob(relativePath: RelativePathValue);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.RelativePath.ShouldBe(RelativePathValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_file_size_is_mapped_from_job()
+    {
+        var job = BuildSyncJob();
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.FileSize.ShouldBe(FileSizeValue);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_then_error_message_is_mapped_from_job()
+    {
+        var job = BuildSyncJob(errorMessage: ErrorMessageValue);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.ErrorMessage.ShouldBe(ErrorMessageValue);
+    }
+
+    [Fact]
+    public void when_job_completed_at_is_set_then_occurred_at_equals_job_completed_at()
+    {
+        var completedAt = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var job = BuildSyncJob(completedAt: completedAt);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        result.OccurredAt.ShouldBe(completedAt);
+    }
+
+    [Fact]
+    public void when_job_completed_at_is_null_then_occurred_at_is_approximately_utc_now()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var job = BuildSyncJob(completedAt: null);
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+
+        var after = DateTimeOffset.UtcNow;
+        result.OccurredAt.ShouldBeInRange(before, after);
+    }
+
+    [Fact]
+    public void when_from_job_is_called_without_folder_name_then_folder_name_defaults_to_empty_string()
+    {
+        var job = BuildSyncJob();
+
+        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue);
+
+        result.FolderName.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_type_is_conflict()
+    {
+        var conflict = BuildSyncConflict();
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.Type.ShouldBe(ActivityItemType.Conflict);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_account_id_is_mapped_from_conflict()
+    {
+        var conflict = BuildSyncConflict();
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.AccountId.ShouldBe(AccountIdValue);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_account_email_is_mapped_from_parameter()
+    {
+        var conflict = BuildSyncConflict();
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.AccountEmail.ShouldBe(AccountEmailValue);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_folder_name_is_mapped_from_parameter()
+    {
+        var conflict = BuildSyncConflict();
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.FolderName.ShouldBe(FolderNameValue);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_file_name_is_derived_from_relative_path()
+    {
+        var conflict = BuildSyncConflict(relativePath: RelativePathValue);
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.FileName.ShouldBe(FileNameValue);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_relative_path_is_mapped_from_conflict()
+    {
+        var conflict = BuildSyncConflict(relativePath: RelativePathValue);
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.RelativePath.ShouldBe(RelativePathValue);
+    }
+
+    [Fact]
+    public void when_from_conflict_is_called_then_occurred_at_is_mapped_from_detected_at()
+    {
+        var detectedAt = new DateTimeOffset(2026, 3, 10, 8, 0, 0, TimeSpan.Zero);
+        var conflict = BuildSyncConflict(detectedAt: detectedAt);
+
+        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+
+        result.OccurredAt.ShouldBe(detectedAt);
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_type_is_error()
+    {
+        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+
+        result.Type.ShouldBe(ActivityItemType.Error);
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_account_id_is_set_correctly()
+    {
+        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+
+        result.AccountId.ShouldBe(AccountIdValue);
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_account_email_is_set_correctly()
+    {
+        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+
+        result.AccountEmail.ShouldBe(AccountEmailValue);
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_error_message_is_set_correctly()
+    {
+        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+
+        result.ErrorMessage.ShouldBe(ErrorMessageValue);
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_file_name_is_sync_error()
+    {
+        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+
+        result.FileName.ShouldBe("Sync error");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
@@ -16,7 +16,6 @@ public sealed class AuthResultTests
 
         result.IsSuccess.ShouldBeTrue();
         result.IsCancelled.ShouldBeFalse();
-        result.IsError.ShouldBeFalse();
         result.AccessToken.ShouldBe(accessToken);
         result.AccountId.ShouldBe(accountId);
         result.DisplayName.ShouldBe(displayName);
@@ -27,11 +26,10 @@ public sealed class AuthResultTests
     [Fact]
     public void Cancelled_ShouldCreateCancelledResult()
     {
-        var result = AuthResult.Cancelled();
+        var result = AuthResult.Cancelled;
 
         result.IsCancelled.ShouldBeTrue();
         result.IsSuccess.ShouldBeFalse();
-        result.IsError.ShouldBeFalse();
         result.AccessToken.ShouldBeNull();
         result.AccountId.ShouldBeNull();
         result.DisplayName.ShouldBeNull();
@@ -46,7 +44,6 @@ public sealed class AuthResultTests
 
         var result = AuthResult.Failure(errorMessage);
 
-        result.IsError.ShouldBeTrue();
         result.IsSuccess.ShouldBeFalse();
         result.IsCancelled.ShouldBeFalse();
         result.ErrorMessage.ShouldBe(errorMessage);
@@ -84,31 +81,7 @@ public sealed class AuthResultTests
         var result = AuthResult.Failure(errorMessage);
 
         result.ErrorMessage.ShouldBe(errorMessage);
-        result.IsError.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsError_ShouldBeTrueWhenNotSuccessAndNotCancelled()
-    {
-        var result = AuthResult.Failure("Some error");
-
-        result.IsError.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsError_ShouldBeFalseWhenSuccess()
-    {
-        var result = AuthResult.Success("token", "account", "name", "email@test.com");
-
-        result.IsError.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsError_ShouldBeFalseWhenCancelled()
-    {
-        var result = AuthResult.Cancelled();
-
-        result.IsError.ShouldBeFalse();
+        result.IsSuccess.ShouldBeFalse();
     }
 
     [Fact]
@@ -123,7 +96,7 @@ public sealed class AuthResultTests
     [Fact]
     public void CancelledResult_ShouldNotBeEqual_ToFailureResult()
     {
-        var cancelledResult = AuthResult.Cancelled();
+        var cancelledResult = AuthResult.Cancelled;
         var failureResult = AuthResult.Failure("error message");
 
         cancelledResult.IsCancelled.ShouldNotBe(failureResult.IsCancelled);
@@ -133,7 +106,7 @@ public sealed class AuthResultTests
     public void SuccessResult_ShouldNotBeEqual_ToCancelledResult()
     {
         var successResult = AuthResult.Success("token", "account", "name", "email@test.com");
-        var cancelledResult = AuthResult.Cancelled();
+        var cancelledResult = AuthResult.Cancelled;
 
         successResult.IsSuccess.ShouldNotBe(cancelledResult.IsSuccess);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
@@ -5,6 +5,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Graph;
 
 public sealed class GivenAGraphService
 {
+    private const string AnyAccessToken = "any-access-token";
+    private const string AnyDriveId = "drive-001";
+    private const string AnyFolderId = "folder-001";
+    private const string AnyItemId = "item-001";
+    private const string AnyRemotePath = "/Documents";
+    private const string AnyLocalPath = "/home/user/file.txt";
+
     [Fact]
     public void when_constructed_then_instance_is_not_null()
     {
@@ -19,5 +26,137 @@ public sealed class GivenAGraphService
         var service = new GraphService(Substitute.For<IUploadService>());
 
         _ = service.ShouldBeAssignableTo<IGraphService>();
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDriveIdAsync(AnyAccessToken, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_get_root_folders_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetRootFoldersAsync(AnyAccessToken, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_get_child_folders_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetChildFoldersAsync(AnyAccessToken, AnyDriveId, AnyFolderId, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_get_quota_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetQuotaAsync(AnyAccessToken, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_enumerate_folder_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, AnyRemotePath, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_get_folder_id_by_path_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetFolderIdByPathAsync(AnyAccessToken, AnyDriveId, AnyRemotePath, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_get_download_url_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDownloadUrlAsync(AnyAccessToken, AnyItemId, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_upload_file_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.UploadFileAsync(AnyAccessToken, AnyLocalPath, AnyRemotePath, AnyFolderId, cts.Token));
+    }
+
+    [Fact]
+    public async Task when_delete_item_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = new GraphService(Substitute.For<IUploadService>());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.DeleteItemAsync(AnyAccessToken, AnyItemId, cts.Token));
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_get_root_folders_returns_mixed_items_then_only_folders_are_returned_ordered_by_name()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_get_folder_id_by_path_receives_a_404_then_null_is_returned()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_get_quota_response_has_null_total_then_zero_is_returned_for_both_values()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_get_download_url_item_has_no_additional_data_then_null_is_returned()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_enumerate_folder_contains_subfolders_then_recursive_enumeration_visits_each_child()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_enumerate_folder_encounters_a_cycle_via_parentId_then_each_folder_is_visited_exactly_once()
+    {
+        await Task.CompletedTask;
+    }
+
+    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    public async Task when_drive_context_is_resolved_twice_with_the_same_token_then_the_me_drive_endpoint_is_called_only_once()
+    {
+        await Task.CompletedTask;
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -66,7 +66,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         {
             var authResult = await _authService.AcquireTokenSilentAsync(_account.Id.Id);
 
-            if (authResult.IsError)
+            if (!authResult.IsSuccess)
             {
                 LoadError = authResult.ErrorMessage ?? "Authentication failed.";
                 HasLoadError = true;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/EntraIdConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/EntraIdConfiguration.cs
@@ -4,6 +4,6 @@ public record EntraIdConfiguration
 {
     public required string RedirectUri { get; init; }
     public required string ClientId { get; init; }
-    public required string[] Scopes { get; init; }
+    public required IReadOnlyList<string> Scopes { get; init; }
     public required string AuthorityForMicrosoftAccountsOnly { get; init; }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
@@ -4,40 +4,4 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 /// Outcome of an authentication operation.
 /// Use the static factory methods rather than constructing directly.
 /// </summary>
-public sealed class AuthResult
-{
-    public bool IsSuccess { get; private init; }
-    public bool IsCancelled { get; private init; }
-    public bool IsError => !IsSuccess && !IsCancelled;
-    public string? AccessToken { get; private init; }
-    public string? AccountId { get; private init; }
-    public string? DisplayName { get; private init; }
-    public string? Email { get; private init; }
-    public string? ErrorMessage { get; private init; }
-
-    private AuthResult() { }
-
-    public static AuthResult Success(
-        string accessToken,
-        string accountId,
-        string displayName,
-        string email) => new()
-        {
-            IsSuccess = true,
-            AccessToken = accessToken,
-            AccountId = accountId,
-            DisplayName = displayName,
-            Email = email
-        };
-
-    public static AuthResult Cancelled() => new()
-    {
-        IsCancelled = true
-    };
-
-    public static AuthResult Failure(string errorMessage) => new()
-    {
-        IsSuccess = false,
-        ErrorMessage = errorMessage
-    };
-}
+public sealed record AuthResult(bool IsSuccess, bool IsCancelled, string? AccessToken, string? AccountId, string? DisplayName, string? Email, string? ErrorMessage);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
@@ -1,0 +1,38 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+
+public static class AuthResultFactory
+{
+    extension(AuthResult)
+    {
+        /// <summary>
+        /// Represents a cancelled authentication operation. Consumers can check for this result to handle cancellations gracefully, such as by showing a message to the user or simply returning to the previous state without an error.
+        /// </summary>
+        /// <returns>An AuthResult representing a cancelled authentication.</returns>
+        public static AuthResult Cancelled => new(false, true, null, null, null, null, null);
+
+        /// <summary>
+        /// Creates an AuthResult representing a failed authentication attempt, with an optional error message describing the failure. Consumers can use this information to display error messages or take corrective actions.
+        /// </summary>
+        /// <param name="errorMessage">The error message describing the failure.</param>
+        /// <returns>An AuthResult representing the failure.</returns>
+        public static AuthResult Failure(string errorMessage) => new(false, false, null, null, null, null, errorMessage);
+
+        /// <summary>
+        /// Creates an AuthResult representing a successful authentication attempt, with the necessary tokens and user information.
+        /// </summary>
+        /// <param name="accessToken">The access token for the authenticated user.</param>
+        /// <param name="accountId">The account ID of the authenticated user.</param>
+        /// <param name="displayName">The display name of the authenticated user.</param>
+        /// <param name="email">The email address of the authenticated user.</param>
+        /// <returns>An AuthResult representing the success.</returns>
+        public static AuthResult Success(string accessToken, string accountId, string displayName, string email)
+        {
+            ArgumentNullException.ThrowIfNull(accessToken);
+            ArgumentNullException.ThrowIfNull(accountId);
+            ArgumentNullException.ThrowIfNull(displayName);
+            ArgumentNullException.ThrowIfNull(email);
+            
+            return new(true, false, accessToken, accountId, displayName, email, null);
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
@@ -21,12 +22,12 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
             .Create(entraIdOptions.Value.ClientId)
             .WithAuthority(entraIdOptions.Value.AuthorityForMicrosoftAccountsOnly)
             .WithRedirectUri(entraIdOptions.Value.RedirectUri)
-            .WithClientName("AStar.Dev.OneDrive.Sync")
-            .WithClientVersion("1.0.0")
+            .WithClientName(ApplicationMetadata.ApplicationName)
+            .WithClientVersion(Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0")
             .Build();
 
     private readonly ITokenCacheService _cacheService = cacheService;
-    private          bool                     _cacheRegistered;
+    private bool _cacheRegistered;
 
     public async Task<AuthResult> SignInInteractiveAsync(CancellationToken ct = default)
     {
@@ -42,19 +43,19 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
 
             return BuildSuccess(result);
         }
-        catch(MsalClientException ex) when(ex.ErrorCode is MsalError.AuthenticationCanceledError or "authentication_canceled" or "user_canceled")
+        catch (MsalClientException ex) when (ex.ErrorCode is MsalError.AuthenticationCanceledError or "authentication_canceled" or "user_canceled")
         {
-            return AuthResult.Cancelled();
+            return AuthResult.Cancelled;
         }
-        catch(OperationCanceledException)
+        catch (OperationCanceledException)
         {
-            return AuthResult.Cancelled();
+            return AuthResult.Cancelled;
         }
-        catch(MsalException ex)
+        catch (MsalException ex)
         {
             return AuthResult.Failure($"Authentication failed: {ex.Message}");
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             return AuthResult.Failure($"Unexpected error during sign-in: {ex.Message}");
         }
@@ -67,9 +68,9 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         try
         {
             var accounts = await _app.GetAccountsAsync();
-            var account  = accounts.FirstOrDefault(a => a.HomeAccountId.Identifier == accountId);
+            var account = accounts.FirstOrDefault(a => a.HomeAccountId.Identifier == accountId);
 
-            if(account is null)
+            if (account is null)
                 return AuthResult.Failure("Account not found in token cache.");
 
             var result = await _app
@@ -78,15 +79,15 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
 
             return BuildSuccess(result);
         }
-        catch(MsalUiRequiredException)
+        catch (MsalUiRequiredException)
         {
             return AuthResult.Failure("Re-authentication required.");
         }
-        catch(OperationCanceledException)
+        catch (OperationCanceledException)
         {
-            return AuthResult.Cancelled();
+            return AuthResult.Cancelled;
         }
-        catch(MsalException ex)
+        catch (MsalException ex)
         {
             return AuthResult.Failure($"Token refresh failed: {ex.Message}");
         }
@@ -97,9 +98,9 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         await EnsureCacheRegisteredAsync();
 
         var accounts = await _app.GetAccountsAsync();
-        var account  = accounts.FirstOrDefault(a => a.HomeAccountId.Identifier == accountId);
+        var account = accounts.FirstOrDefault(a => a.HomeAccountId.Identifier == accountId);
 
-        if(account is not null)
+        if (account is not null)
             await _app.RemoveAsync(account);
     }
 
@@ -108,14 +109,15 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         await EnsureCacheRegisteredAsync();
 
         var accounts = await _app.GetAccountsAsync();
+
         return accounts
-            .Select(a => a.HomeAccountId.Identifier)
+            .Select(account => account.HomeAccountId.Identifier)
             .ToList().AsReadOnly();
     }
 
     private async Task EnsureCacheRegisteredAsync()
     {
-        if(_cacheRegistered)
+        if (_cacheRegistered)
             return;
 
         await _cacheService.RegisterAsync(_app);
@@ -125,24 +127,20 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
     private static AuthResult BuildSuccess(AuthenticationResult result)
     {
         string? displayName = result.Account.Username;
-        string? email       = result.Account.Username;
+        string? email = result.Account.Username;
 
-        if(result.ClaimsPrincipal is not null)
+        if (result.ClaimsPrincipal is not null)
         {
-            string? nameClaim  = result.ClaimsPrincipal.FindFirst("name")?.Value;
+            string? nameClaim = result.ClaimsPrincipal.FindFirst("name")?.Value;
             string? emailClaim = result.ClaimsPrincipal.FindFirst("preferred_username")?.Value
                                  ?? result.ClaimsPrincipal.FindFirst("email")?.Value;
 
-            if(!string.IsNullOrEmpty(nameClaim))
+            if (!string.IsNullOrEmpty(nameClaim))
                 displayName = nameClaim;
-            if(!string.IsNullOrEmpty(emailClaim))
+            if (!string.IsNullOrEmpty(emailClaim))
                 email = emailClaim;
         }
 
-        return AuthResult.Success(
-            accessToken: result.AccessToken,
-            accountId: result.Account.HomeAccountId.Identifier,
-            displayName: displayName,
-            email: email);
+        return AuthResult.Success(accessToken: result.AccessToken, accountId: result.Account.HomeAccountId.Identifier, displayName: displayName, email: email);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 using Microsoft.Graph;
@@ -18,7 +19,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
         "eTag", "cTag", DownloadUrlKey
     ];
 
-    private readonly Dictionary<string, DriveContext> _cache = [];
+    private readonly ConcurrentDictionary<string, DriveContext> _cache = [];
 
     /// <inheritdoc />
     public async Task<string> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
@@ -117,7 +118,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
 
         try
         {
-            var item = await client.Drives[driveId].Items[$"root:{remotePath}"]
+            var item = await client.Drives[driveId].Items[$"{RootPathMarker}:{remotePath}"]
                 .GetAsync(req => req.QueryParameters.Select = ["id"], ct);
 
             return item?.Id;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/OneDrive/OneDriveClientOptions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/OneDrive/OneDriveClientOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.OneDrive;
 
 /// <summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -13,7 +13,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 {
     private Timer? _timer;
     private TimeSpan _interval = TimeSpan.FromMinutes(60);
-    private int _runningFlag;
+    private long _runningFlag;
 
     public static readonly TimeSpan DefaultInterval = TimeSpan.FromMinutes(60);
 
@@ -48,7 +48,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     /// </summary>
     public async Task TriggerNowAsync(CancellationToken ct = default)
     {
-        if(_runningFlag == 1)
+        if (SyncIsAlreadyRunning())
             return;
 
         await RunSyncPassAsync(ct);
@@ -96,11 +96,13 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     // ReSharper disable once AsyncVoidMethod - Timer requires this signature
     private async void OnTimerTickAsync(object? state)
     {
-        if(_runningFlag == 1)
+        if (SyncIsAlreadyRunning())
             return;
 
         await RunSyncPassAsync(CancellationToken.None);
     }
+
+    private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1;
 
     private async Task RunSyncPassAsync(CancellationToken ct)
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -21,7 +21,7 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
 
         var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct);
 
-        if(authResult.IsError)
+        if(!authResult.IsSuccess)
         {
             RaiseProgress(account.Id.Id, 0, 0, authResult.ErrorMessage ?? "Auth failed", SyncState.Error);
             return;
@@ -37,6 +37,10 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
         {
             await SyncAccountInternalAsync(account, authResult.AccessToken!, ct);
         }
+        catch (OperationCanceledException)
+        {
+            RaiseProgress(account.Id.Id, 0, 0, "Sync cancelled", SyncState.Idle);
+        }
         catch(Exception ex)
         {
             Serilog.Log.Error(ex, "[SyncService] Unhandled error syncing {Email}: {Error}", account.Email, ex.Message);
@@ -48,7 +52,7 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
     {
         var authResult = await authService.AcquireTokenSilentAsync(conflict.AccountId, ct);
 
-        if(authResult.IsError)
+        if(!authResult.IsSuccess)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.LocalModified, conflict.RemoteModified);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
 using Microsoft.Graph.Models;
@@ -124,7 +125,8 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory) : IUploa
 
             try
             {
-                using var content = new ByteArrayContent(chunk.ToArray());
+                var array = MemoryMarshal.TryGetArray(chunk, out var segment) ? segment : new ArraySegment<byte>(chunk.ToArray());
+                using var content = new ByteArrayContent(array.Array!, array.Offset, array.Count);
                 content.Headers.Add("Content-Range", $"bytes {rangeStart}-{rangeEnd}/{totalBytes}");
                 content.Headers.Add("Content-Length", chunk.Length.ToString(CultureInfo.CurrentCulture));
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/AppTheme.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/AppTheme.cs
@@ -1,0 +1,3 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+
+public enum AppTheme { Light, Dark, System }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/IThemeService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/IThemeService.cs
@@ -1,10 +1,23 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 
-public enum AppTheme { Light, Dark, System }
-
 public interface IThemeService
 {
+    /// <summary>
+    /// Gets the current application theme.
+    /// </summary>
+    /// </summary>
     AppTheme CurrentTheme { get; }
+
+    /// <summary>
+    /// Applies the specified theme to the application and raises the ThemeChanged event.
+    /// Consumers should subscribe to ThemeChanged to update their UI when the theme changes.
+    /// </summary>
+    /// <param name="theme"></param>
     void Apply(AppTheme theme);
+
+    /// <summary>
+    /// Event raised whenever the application theme changes. Provides the new theme as an argument.
+    /// Consumers should handle this event to update their UI accordingly.
+    /// </summary>
     event EventHandler<AppTheme>? ThemeChanged;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/ThemeService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/ThemeService.cs
@@ -20,9 +20,13 @@ public sealed class ThemeService : IThemeService, IDisposable
     private static readonly Uri _darkUri = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Dark.axaml");
     private Disposable? _systemWatcher;
 
+    ///<inheritdoc />
     public AppTheme CurrentTheme { get; private set; } = AppTheme.System;
+
+    ///<inheritdoc />
     public event EventHandler<AppTheme>? ThemeChanged;
 
+    ///<inheritdoc />
     public void Apply(AppTheme theme)
     {
         CurrentTheme = theme;
@@ -30,7 +34,7 @@ public sealed class ThemeService : IThemeService, IDisposable
         _systemWatcher?.Dispose();
         _systemWatcher = null;
 
-        if(theme == AppTheme.System)
+        if (theme == AppTheme.System)
         {
             ApplyVariant(GetSystemIsDark() ? AppTheme.Dark : AppTheme.Light);
             WatchSystem();
@@ -52,7 +56,7 @@ public sealed class ThemeService : IThemeService, IDisposable
     private void WatchSystem()
     {
         var app = Application.Current;
-        if(app is null)
+        if (app is null)
             return;
 
         app.ActualThemeVariantChanged += OnActualThemeVariantChanged;
@@ -62,7 +66,7 @@ public sealed class ThemeService : IThemeService, IDisposable
 
     private void OnActualThemeVariantChanged(object? sender, EventArgs e)
     {
-        if(CurrentTheme != AppTheme.System)
+        if (CurrentTheme != AppTheme.System)
             return;
         Dispatcher.UIThread.Post(() =>
             ApplyVariant(GetSystemIsDark() ? AppTheme.Dark : AppTheme.Light));
@@ -71,7 +75,7 @@ public sealed class ThemeService : IThemeService, IDisposable
     private static void ApplyVariant(AppTheme resolved)
     {
         var app = Application.Current;
-        if(app is null)
+        if (app is null)
             return;
 
         var targetUri = resolved == AppTheme.Dark ? _darkUri : _lightUri;
@@ -81,7 +85,7 @@ public sealed class ThemeService : IThemeService, IDisposable
             .OfType<ResourceInclude>()
             .FirstOrDefault(r => r.Source == _lightUri || r.Source == _darkUri);
 
-        if(existing is not null)
+        if (existing is not null)
             _ = merged.Remove(existing);
 
         merged.Add(new ResourceInclude(targetUri) { Source = targetUri });

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -138,7 +138,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
                 SignInStatusText = "Sign-in cancelled.";
                 SignInHasError = false;
             }
-            else if(result.IsError)
+            else if(!result.IsSuccess)
             {
                 SignInStatusText = result.ErrorMessage ?? "Sign-in failed.";
                 SignInHasError = true;

--- a/docs/code-review-report-AStar.Dev.OneDrive.Sync.Client-20260426.md
+++ b/docs/code-review-report-AStar.Dev.OneDrive.Sync.Client-20260426.md
@@ -1,0 +1,376 @@
+# Code Review Report
+
+**Project:** `apps/desktop/AStar.Dev.OneDrive.Sync.Client`
+**Scope:** `Infrastructure/` (all files and subfolders)
+**Date:** 2026-04-26
+**Reviewer:** c-sharp-reviewer subagent
+
+---
+
+## Summary
+
+| Severity   | Count  |
+| ---------- | ------ |
+| Error      | 12     |
+| Warning    | 47     |
+| Suggestion | 9      |
+| **Total**  | **68** |
+
+**Verdict: Request Changes**
+
+---
+
+## Errors
+
+### `Infrastructure/OneDrive/OneDriveClientOptions.cs:1`
+
+`#nullable enable` directive present. Repo uses `Directory.Build.props` to enable nullable globally. Per-file directives must not appear.
+**Fix:** Remove `#nullable enable`. Done
+
+### `Infrastructure/Graph/GraphService.cs:12`
+
+`private const string RootPathMarker = "root:";` declared but never referenced. The magic string `"root:"` is used inline at line 120: `Items[$"root:{remotePath}"]`.
+**Fix:** Delete the dead constant or use it: `Items[$"{RootPathMarker}{remotePath}"]`. Done.
+
+### `Infrastructure/Graph/GraphService.cs:21`
+
+`private readonly Dictionary<string, DriveContext> _cache = [];` — plain `Dictionary`, not thread-safe. `GraphService` is a singleton; concurrent account syncs produce data races.
+**Fix:** Use `ConcurrentDictionary<string, DriveContext>`. Done
+
+### `Infrastructure/Sync/SyncScheduler.cs:51,99`
+
+`if(_runningFlag == 1)` reads a non-volatile `int` without `Interlocked.Read`. JIT/CPU may cache a stale value — data race.
+**Fix:** Declare `private volatile int _runningFlag;`. Added Interlocked.Read
+
+### `Infrastructure/Sync/SyncService.cs:40–44`
+
+`catch(Exception ex)` swallows `OperationCanceledException`. Cancellation raises `SyncState.Error` to the UI — incorrect semantics.
+**Fix:** Done.
+
+```csharp
+catch (OperationCanceledException)
+{
+    RaiseProgress(account.Id.Id, 0, 0, "Sync cancelled", SyncState.Idle);
+}
+catch (Exception ex)
+{
+    Serilog.Log.Error(ex, "...");
+    RaiseProgress(account.Id.Id, 0, 0, ex.Message, SyncState.Error);
+}
+```
+
+### `Infrastructure/Sync/UploadService.cs:127`
+
+`chunk.ToArray()` inside `UploadChunkWithRetryAsync` allocates a new `byte[]` on every retry. For a 10 MB chunk with 5 retries = 50 MB of unnecessary allocations.
+**Fix:** Done.
+
+```csharp
+var array = MemoryMarshal.TryGetArray(chunk, out var segment) ? segment : new ArraySegment<byte>(chunk.ToArray());
+using var content = new ByteArrayContent(array.Array!, array.Offset, array.Count);
+```
+
+### `Infrastructure/OneDrive/OneDriveClientServiceExtensions.cs`
+
+`AddOneDriveClient` registers `IPublicClientApplication` into DI. `AuthService` ignores it and builds its own private instance in its constructor. Result: two separate MSAL token caches — accounts authenticated in one are unknown to the other.
+**Fix:** Either remove the MSAL registration from `AddOneDriveClient` (since `AuthService` manages its own), or inject `IPublicClientApplication` from DI into `AuthService` and remove its internal build.
+
+### `Infrastructure/Theme/IThemeService.cs:3`
+
+Two types defined in one file: `public enum AppTheme` and `public interface IThemeService`. Violates one-type-per-file rule.
+**Fix:** Move `AppTheme` to its own `AppTheme.cs`. Done
+
+### Logging — all Infrastructure files
+
+37 log call sites use `Serilog.Log` static global with string-literal templates. `AStar.Dev.Logging.Extensions` (`LogMessage` compile-time templates) is never used. `ILogger<T>` is never injected into any service class. Per `CLAUDE.md`, compile-time log templates are mandatory wherever possible.
+**Fix:** Inject `ILogger<T>` into each service; create `LogMessage` entries in `AStar.Dev.Logging.Extensions` for each template; remove all direct `Serilog.Log.*` calls from service classes.
+
+### Functional Extensions — all Infrastructure files
+
+`AStar.Dev.Functional.Extensions` is listed as a dependency but `Result<T>`, `Option<T>`, `Bind`, `Map`, `Match` are used nowhere. Methods like `SyncAccountAsync`, `AcquireTokenSilentAsync`, and `GetDownloadUrlAsync` return bare `Task<T>` with null/error-string patterns — textbook `Result<T>`/`Option<T>` candidates. Per `CLAUDE.md`: "ALWAYS use when practicable."
+
+### `Infrastructure/Sync/SyncService.cs:11`
+
+Constructor has 10 parameters — violates the 5-parameter maximum. The class handles authentication, drive state, rule evaluation, folder enumeration, conflict detection, local file scanning, download orchestration, upload detection, remote deletion detection, and persistence — violates SRP.
+**Fix:** Extract focused collaborators: `RemoteDeletionDetector`, `ConflictHandler`, `SyncedItemUpdater`.
+
+### `Infrastructure/Sync/SyncService.cs:60`
+
+`SyncAccountInternalAsync` is 151 lines. Repo convention: ideally under 20 lines. Mixes folder enumeration, ETag comparison, conflict building, phantom-item handling, job list construction, and account update.
+**Fix:** Extract each concern into a private method.
+
+---
+
+## Warnings
+
+### `Infrastructure/ApplicationConfiguration/EntraIdConfiguration.cs:7`
+
+`Scopes` declared as `string[]` — mutable array in a record violates immutability preference.
+**Fix:** `IReadOnlyList<string> Scopes { get; init; }`. Done.
+
+### `Infrastructure/ApplicationConfiguration/EntraIdConfiguration.cs:3`
+
+No `EntraIdConfigurationFactory` static factory class with a `Create` method. Validation (null/empty `ClientId`) has no home.
+
+### `Infrastructure/Authentication/AuthResult.cs:7`
+
+`sealed class` with private-init properties — use case fits `record`. Loses structural equality, `ToString`, and deconstruct for free.
+**Fix:** Convert to `public sealed record AuthResult`; move factory methods to `AuthResultFactory`. Done
+
+### `Infrastructure/Authentication/AuthResult.cs:20–31`
+
+`Success`, `Cancelled`, and `Failure` factory methods take `string` parameters with no null guards at the public boundary.
+**Fix:** Add `ArgumentException.ThrowIfNullOrWhiteSpace` / `ArgumentNullException.ThrowIfNull` in each method. Done.
+
+### `Infrastructure/Authentication/AuthService.cs:24–26`
+
+Magic strings `"AStar.Dev.OneDrive.Sync"` and `"1.0.0"` hard-coded in `.WithClientName` / `.WithClientVersion`. `ApplicationMetadata.ApplicationName` and the assembly version are already available. Done.
+
+### `Infrastructure/Authentication/AuthService.cs:29`
+
+`_cacheRegistered` bool read/written in a singleton with no synchronisation. Two concurrent calls before cache registration completes will both see `false` and call `RegisterAsync` twice.
+**Fix:** Use `SemaphoreSlim(1,1)` with double-check pattern.
+
+### `Infrastructure/Authentication/AuthService.cs:45`
+
+Magic strings `"authentication_canceled"` and `"user_canceled"` used as bare literals in `when` clause. Extract as `private const`.
+
+### `Infrastructure/Authentication/AuthService.cs:55,59`
+
+Error messages use `$"Authentication failed: {ex.Message}"` — leaks internal detail to UI. Log the full exception separately; surface a fixed user-facing message.
+
+### `Infrastructure/Authentication/AuthService.cs:70,100`
+
+Single-letter lambda parameter `a`. Use `account`. Done
+
+### `Infrastructure/Authentication/AuthService.cs:110–113`
+
+Missing blank line before `return accounts`. Done
+**Fix:**
+
+```csharp
+var accounts = await _app.GetAccountsAsync();
+
+return accounts.Select(account => account.HomeAccountId.Identifier).ToList().AsReadOnly();
+```
+
+### `ConfigureAwait(false)` — all Infrastructure async methods
+
+Absent on virtually every `await` across `AuthService`, `GraphService`, `SyncService`, `DownloadWorker`, `HttpDownloader`, `UploadService`, `ParallelDownloadPipeline`. These are service-layer classes with no UI-thread requirement.
+
+### `Infrastructure/Authentication/TokenCacheService.cs:69,78`
+
+Two inline comments inside method body. Extract the two blocks into private methods `RegisterLinuxFallbackCacheAsync` and `RegisterNonLinuxCacheAsync`.
+
+### `Infrastructure/Authentication/TokenCacheService.cs:94–106`
+
+Nested ternary for platform detection. A chain of `if (OperatingSystem.Is*())` guard clauses is clearer.
+
+### `Infrastructure/Graph/GraphService.cs:28` and `IGraphService`
+
+Return types use `List<T>` and `Task<List<...>>` — mutable. Interface methods should return `IReadOnlyList<T>`.
+
+### `Infrastructure/Graph/GraphService.cs:42,75`
+
+Single-letter lambda parameter `i`. Use `item` or `driveItem`.
+
+### `Infrastructure/Graph/GraphService.cs:163`
+
+`EnumerateSubFolderAsync` is recursive. Deep OneDrive folder trees risk `StackOverflowException`. Document depth limitation or implement iterative BFS.
+
+### `Infrastructure/Graph/GraphService.cs:213`
+
+`BuildClient(accessToken)` called before checking cache — builds a new `GraphServiceClient` even on cache hit. Move after the cache check.
+
+### `Infrastructure/OneDrive/OneDriveClientOptionsFactory.cs:12`
+
+Missing blank line before `return new OneDriveClientOptions { ... }`.
+
+### `Infrastructure/Shell/AppSettings.cs:9`
+
+Inline `//` comment inside class body (`// Account-specific settings...`). Replace with `<remarks>` XML doc or delete.
+
+### `Infrastructure/Shell/FeatureAvailabilityService.cs:15–20`
+
+`throw` on same line as `if`. Place on its own line.
+
+### `Infrastructure/Shell/FeatureAvailabilityService.cs` and `IFeatureAvailabilityService`
+
+No XML documentation on any public member.
+
+### `Infrastructure/Shell/SettingsService.cs:2–3`
+
+Missing blank line between `using` directives and `namespace` declaration.
+
+### `Infrastructure/Shell/SettingsService.cs:19`
+
+Static async factory `LoadAsync()` on the concrete class. Bypasses DI container. Callers must manually call it and register the result. Document the intentional static factory pattern explicitly, or refactor to `IHostedService` / `Lazy<Task<T>>`.
+
+### `Infrastructure/Shell/SettingsService.cs:7,13`
+
+`_jsonOpts`, `_path` — underscore prefix violates camelCase-no-underscore rule.
+**Fix:** Rename to `jsonOpts`, `path`.
+
+### `Infrastructure/Shell/ApplicationInitializer.cs:43`
+
+`catch(Exception ex)` catches `OperationCanceledException` and logs it as `Fatal` before re-throwing. Normal cancellation should not produce a `Fatal` log entry.
+**Fix:** Add `catch (OperationCanceledException) { throw; }` before the general handler.
+
+### `Infrastructure/Sync/DownloadWorker.cs:15`
+
+`Action<SyncJob, bool, string?> onJobComplete` raw delegate — hard to evolve. Use `JobCompletedEventArgs` already present in the codebase.
+
+### `Infrastructure/Sync/DownloadWorker.cs:79`
+
+`File.Delete(job.LocalPath)` with no guard for null/empty `LocalPath`.
+
+### `Infrastructure/Sync/HttpDownloader.cs:62,64`
+
+Magic number `81920` appears twice. Define as `private const int BufferSize = 81920;`.
+
+### `Infrastructure/Sync/HttpDownloader.cs:99`
+
+`return` on same line as `if`. Rewrite:
+
+```csharp
+if (response.Headers.RetryAfter?.Date is not { } date)
+    return GetBackoffDelay(attempt);
+```
+
+### `Infrastructure/Sync/LocalChangeDetector.cs:43`
+
+Building cross-platform relative path with string interpolation. Prefer `AStar.Dev.Utilities` path helpers where applicable.
+
+### `Infrastructure/Sync/LocalChangeDetector.cs:75`
+
+`dirInfo.Name.StartsWith('.')` — no `StringComparison`. Use `StartsWith('.', StringComparison.Ordinal)`.
+
+### `Infrastructure/Sync/LocalChangeDetector.cs:17`
+
+Single-letter lambda parameter `r`. Use `rule`.
+
+### `Infrastructure/Sync/ParallelDownloadPipeline.cs:64`
+
+`new DownloadWorker(...)` inside `ParallelDownloadPipeline` — newing up a service. Violates DI convention.
+**Fix:** Introduce `IDownloadWorkerFactory` or `Func<int, IDownloadWorker>` via DI.
+
+### `Infrastructure/Sync/ParallelDownloadPipeline.cs:25`
+
+`RunAsync` has 8 parameters — exceeds 5-parameter maximum.
+**Fix:** Introduce `PipelineRunOptions` record.
+
+### `Infrastructure/Sync/ParallelDownloadPipeline.cs:88`
+
+`catch(Exception ex)` swallows `OperationCanceledException` from workers. Cancellation contract silently broken.
+
+### `Infrastructure/Sync/SyncScheduler.cs:62–77`
+
+Mapping from `AccountEntity` to `OneDriveAccount` duplicated verbatim in `TriggerAccountAsync` and `RunSyncPassAsync`.
+**Fix:** Extract `private static OneDriveAccount ToOneDriveAccount(AccountEntity entity)`.
+
+### `Infrastructure/Sync/SyncScheduler.cs:73,122`
+
+Single-letter lambda parameter `f`. Use `folder`.
+
+### `Infrastructure/Sync/SyncScheduler.cs:102`
+
+`RunSyncPassAsync` passes `CancellationToken.None` to `accountRepository.GetAllAsync`, ignoring the `ct` parameter. Manually-triggered syncs cannot be cancelled at the repository stage.
+
+### `Infrastructure/Sync/SyncService.cs:38,56`
+
+Null-forgiving operator `authResult.AccessToken!` used where `AccessToken` can be `null` on `AuthResult.Success` (property is `string?`). Potential null-dereference.
+**Fix:** Strengthen `AuthResult.Success` to guarantee non-null `AccessToken`, or guard explicitly.
+
+### `Infrastructure/Sync/SyncService.cs:85–88`
+
+Complex unnamed LINQ expression for root include rules embedded inline.
+**Fix:** Extract `private static IEnumerable<SyncRuleEntity> FindRootIncludeRules(IReadOnlyList<SyncRuleEntity> rules)`.
+
+### `Infrastructure/Sync/SyncService.cs:207`
+
+`account.LastSyncedAt = DateTimeOffset.UtcNow;` mutates the method parameter as a side-effect. Mutation is silently lost in callers that rebuild `OneDriveAccount` each pass. Remove this line; persistence is handled by `accountRepository.UpsertAsync`.
+
+### `Infrastructure/Sync/SyncService.cs:330–350`
+
+`foreach(var (remoteId, knownItem) in syncedItems)` iterates without `.ToList()`. If any callee modifies `syncedItems` during iteration, `InvalidOperationException` is thrown. Apply `.ToList()` consistently (as done in `DetectRemoteDeletionsAsync`).
+
+### `Infrastructure/Sync/UploadService.cs:50`
+
+Method named `CreateSessionWithRetryAsync` has no retry loop. Single call, no catch.
+**Fix:** Rename to `CreateSessionAsync` or implement retry consistent with `UploadChunkWithRetryAsync`.
+
+### `Infrastructure/Sync/UploadService.cs:129`
+
+`content.Headers.Add("Content-Length", chunk.Length.ToString(CultureInfo.CurrentCulture))` — `Content-Length` is a restricted header (throws `InvalidOperationException` on some runtimes); `CurrentCulture` is wrong for HTTP headers.
+**Fix:** Use `content.Headers.ContentLength = chunk.Length;`.
+
+### `Infrastructure/Sync/UploadService.cs:62–69`
+
+Magic strings `"@microsoft.graph.conflictBehavior"`, `"replace"`, `"name"`, `"fileSystemInfo"` in `AdditionalData`. Extract as constants.
+
+### Private field naming — multiple files
+
+Underscore prefix violates camelCase-no-underscore rule. Affected fields:
+
+- `AuthService`: `_cacheRegistered`, `_cacheService`
+- `SyncScheduler`: `_timer`, `_interval`, `_runningFlag`
+- `SyncEventAggregator`: `_dispatcher`
+- `ThemeService`: `_lightUri`, `_darkUri`, `_systemWatcher`
+- `SettingsService`: `_jsonOpts`, `_path`
+
+---
+
+## Suggestions
+
+### `Infrastructure/Sync/SyncEventAggregator.cs`
+
+Subscribes to events in constructor but never unsubscribes. If the service is replaced or disposed, event subscriptions keep it alive (event listener leak).
+**Fix:** Implement `IDisposable` and unsubscribe in `Dispose()`.
+
+### `Infrastructure/Authentication/TokenCacheService.cs`
+
+XML `<summary>` opening sentence restates what the code already expresses. The platform-path table has documentation value; the generic preamble does not. Trim the redundant prose.
+
+### `Infrastructure/Sync/SyncRuleEvaluator.cs`
+
+`IsIncluded` is O(n × m) — every item checked against every rule linearly. For large file counts with many rules this may become a bottleneck. Consider pre-sorting rules by path length descending or building a trie.
+
+### `Infrastructure/Graph/GraphService.cs:163`
+
+`EnumerateSubFolderAsync` is recursive — risks `StackOverflowException` on deep folder hierarchies. Document depth limitation or convert to iterative BFS.
+
+### `Infrastructure/Theme/ThemeService.cs:92–95`
+
+Private `Disposable` nested class is a general-purpose action-disposable. Re-implementation of utility that belongs in `AStar.Dev.Utilities`. If absent there, add it.
+
+### `Infrastructure/ViewModelBase.cs`
+
+Placed at `Infrastructure/` root — a technical-type folder. `ViewModelBase` is a cross-cutting base; move to `Infrastructure/Shell/` or a dedicated `Common/` folder.
+
+### `Infrastructure/ViewModelBase.cs`
+
+Class body is empty with no XML documentation. If it exists only to alias `ObservableObject`, document the intent.
+
+### `Infrastructure/Sync/SyncScheduler.cs:96`
+
+`async void` timer callback with ReSharper suppression comment. Consider restructuring to a fire-and-forget wrapper to avoid `async void`:
+
+```csharp
+private void OnTimerTickAsync(object? state)
+    => _ = RunSyncPassAsync(CancellationToken.None);
+```
+
+### `Infrastructure/Sync/ParallelDownloadPipeline.cs`
+
+Channel/worker concurrency pattern (backpressure, progress reporting) tested only indirectly via `SyncService` tests. Dedicated unit tests for the pipeline behaviour are absent.
+
+---
+
+## Missing Test Coverage (Note Only)
+
+| Class                        | Gap                                                                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `LocalChangeDetector`        | No dedicated test class; hidden files, temp extensions, access-denied, and 5-second modification window untested directly |
+| `ParallelDownloadPipeline`   | No dedicated test class; channel/worker concurrency pattern tested only indirectly                                        |
+| `UploadService`              | No dedicated test class; chunk retry, session creation, and 429 handling untested                                         |
+| `FeatureAvailabilityService` | No dedicated test class                                                                                                   |
+| `TokenCacheService`          | Linux keyring timeout and plaintext fallback paths not exercised by existing tests                                        |


### PR DESCRIPTION
…hService, add tests

AuthResult refactored from private-ctor class to record + AuthResultFactory extension methods; eliminates construction boilerplate and aligns with record design convention (factory, no public ctor).

GraphService._cache switched from Dictionary to ConcurrentDictionary to prevent data races when multiple sync tasks run concurrently.

AuthService reads client version from the executing assembly instead of hardcoded "1.0.0".

AppTheme enum extracted to its own file; IThemeService gains XML docs.

New test coverage: GraphService cancellation paths, AccountCardViewModel, AccountSyncSettingsViewModel, AccountFilesViewModel, ActivityItemViewModel.

# Summary

Please include a brief description of the change and the motivation.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

<!-- e.g., Closes #123, Relates to #456 -->

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

<!-- e.g., libs/MyLib, apps/MyApp, web/Api -->

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.
