### PR TITLE
refactor graphclient and fix bug in download timestamps

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly"/>
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
     <PackageReference Include="WireMock.Net" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GraphServiceTests.cs
@@ -1,9 +1,13 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Graph;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Graph;
 
-public sealed class GivenAGraphService
+public sealed class GivenAGraphService : IDisposable
 {
     private const string AnyAccessToken = "any-access-token";
     private const string AnyDriveId = "drive-001";
@@ -12,10 +16,17 @@ public sealed class GivenAGraphService
     private const string AnyRemotePath = "/Documents";
     private const string AnyLocalPath = "/home/user/file.txt";
 
+    private readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    private GraphService CreateSut() =>
+        new(Substitute.For<IUploadService>(), new WireMockGraphClientFactory(_server));
+
     [Fact]
     public void when_constructed_then_instance_is_not_null()
     {
-        var service = new GraphService(Substitute.For<IUploadService>());
+        var service = CreateSut();
 
         _ = service.ShouldNotBeNull();
     }
@@ -23,7 +34,7 @@ public sealed class GivenAGraphService
     [Fact]
     public void when_constructed_then_it_implements_IGraphService()
     {
-        var service = new GraphService(Substitute.For<IUploadService>());
+        var service = CreateSut();
 
         _ = service.ShouldBeAssignableTo<IGraphService>();
     }
@@ -31,7 +42,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_drive_id_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -41,7 +52,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_root_folders_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -51,7 +62,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_child_folders_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -61,7 +72,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_quota_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -71,7 +82,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_enumerate_folder_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -81,7 +92,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_folder_id_by_path_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -91,7 +102,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_get_download_url_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -101,7 +112,7 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_upload_file_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
@@ -111,52 +122,175 @@ public sealed class GivenAGraphService
     [Fact]
     public async Task when_delete_item_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var sut = new GraphService(Substitute.For<IUploadService>());
+        var sut = CreateSut();
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         await Should.ThrowAsync<OperationCanceledException>(() => sut.DeleteItemAsync(AnyAccessToken, AnyItemId, cts.Token));
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_get_root_folders_returns_mixed_items_then_only_folders_are_returned_ordered_by_name()
     {
-        await Task.CompletedTask;
+        SetupDriveContext(AnyDriveId, "root-001");
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/root-001/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    value = new object[]
+                    {
+                        new { id = "f1", name = "ZFolder", folder = new { }, parentReference = new { id = "root-001", driveId = AnyDriveId } },
+                        new { id = "f2", name = "AFolder", folder = new { }, parentReference = new { id = "root-001", driveId = AnyDriveId } },
+                        new { id = "fi1", name = "readme.txt", file = new { }, parentReference = new { id = "root-001", driveId = AnyDriveId } }
+                    }
+                }));
+
+        var result = await CreateSut().GetRootFoldersAsync(AnyAccessToken, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result[0].Name.ShouldBe("AFolder");
+        result[1].Name.ShouldBe("ZFolder");
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_get_folder_id_by_path_receives_a_404_then_null_is_returned()
     {
-        await Task.CompletedTask;
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(404)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "itemNotFound", message = "The resource could not be found." } }));
+
+        var result = await CreateSut().GetFolderIdByPathAsync(AnyAccessToken, AnyDriveId, AnyRemotePath, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_get_quota_response_has_null_total_then_zero_is_returned_for_both_values()
     {
-        await Task.CompletedTask;
+        SetupDriveContext(AnyDriveId, "root-001");
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = AnyDriveId }));
+
+        var (total, used) = await CreateSut().GetQuotaAsync(AnyAccessToken, TestContext.Current.CancellationToken);
+
+        total.ShouldBe(0L);
+        used.ShouldBe(0L);
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_get_download_url_item_has_no_additional_data_then_null_is_returned()
     {
-        await Task.CompletedTask;
+        SetupDriveContext(AnyDriveId, "root-001");
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = AnyItemId }));
+
+        var result = await CreateSut().GetDownloadUrlAsync(AnyAccessToken, AnyItemId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_enumerate_folder_contains_subfolders_then_recursive_enumeration_visits_each_child()
     {
-        await Task.CompletedTask;
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    value = new object[]
+                    {
+                        new { id = "file-root", name = "root-file.txt", file = new { }, size = 100L, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } },
+                        new { id = "subfolder-001", name = "SubFolder", folder = new { }, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } }
+                    }
+                }));
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-001/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    value = new object[]
+                    {
+                        new { id = "file-sub", name = "sub-file.txt", file = new { }, size = 200L, parentReference = new { id = "subfolder-001", driveId = AnyDriveId } }
+                    }
+                }));
+
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, "root", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(3);
+        result.ShouldContain(i => i.Id == "file-root");
+        result.ShouldContain(i => i.Id == "subfolder-001" && i.IsFolder);
+        result.ShouldContain(i => i.Id == "file-sub");
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_enumerate_folder_encounters_a_cycle_via_parentId_then_each_folder_is_visited_exactly_once()
     {
-        await Task.CompletedTask;
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    value = new object[]
+                    {
+                        new { id = "subfolder-A", name = "SubFolderA", folder = new { }, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } }
+                    }
+                }));
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-A/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    value = new object[]
+                    {
+                        new { id = AnyFolderId, name = "CyclicRef", folder = new { }, parentReference = new { id = "subfolder-A", driveId = AnyDriveId } }
+                    }
+                }));
+
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, "root", TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain(i => i.Id == "subfolder-A");
+        result.ShouldContain(i => i.Id == AnyFolderId);
     }
 
-    [Fact(Skip = "GraphService.BuildClient is private static and hardcodes graph.microsoft.com — no HTTP seam exists to point the SDK at WireMock without refactoring. See: https://github.com/astar-dev/astar-dev-mono/issues/TODO")]
+    [Fact]
     public async Task when_drive_context_is_resolved_twice_with_the_same_token_then_the_me_drive_endpoint_is_called_only_once()
     {
-        await Task.CompletedTask;
+        SetupDriveContext(AnyDriveId, "root-001");
+        var ct = TestContext.Current.CancellationToken;
+
+        var sut = CreateSut();
+        _ = await sut.GetDriveIdAsync(AnyAccessToken, ct);
+        _ = await sut.GetDriveIdAsync(AnyAccessToken, ct);
+
+        (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
+    }
+
+    private void SetupDriveContext(string driveId, string rootId)
+    {
+        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = driveId }));
+        _server.Given(Request.Create().WithPath($"/drives/{driveId}/root").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = rootId }));
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
@@ -1,0 +1,27 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using Microsoft.Graph;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+using WireMock.Server;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Graph;
+
+internal sealed class WireMockGraphClientFactory(WireMockServer server) : IGraphClientFactory
+{
+    public GraphServiceClient CreateClient(string accessToken)
+    {
+        var authProvider = new BaseBearerTokenAuthenticationProvider(new TestTokenProvider(accessToken));
+        var adapter = new HttpClientRequestAdapter(authProvider);
+        adapter.BaseUrl = server.Url;
+
+        return new GraphServiceClient(adapter);
+    }
+
+    private sealed class TestTokenProvider(string token) : IAccessTokenProvider
+    {
+        public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
+            => Task.FromResult(token);
+
+        public AllowedHostsValidator AllowedHostsValidator { get; } = new();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
@@ -68,6 +68,26 @@ public sealed class GivenAnHttpDownloader
     }
 
     [Fact]
+    public async Task when_download_async_succeeds_then_file_last_write_time_matches_remote_modified()
+    {
+        string localPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            var sut = new HttpDownloader(CreateOkFactory());
+
+            await sut.DownloadAsync(DownloadUrl, localPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+            File.GetLastWriteTimeUtc(localPath).ShouldBe(RemoteModified.UtcDateTime);
+        }
+        finally
+        {
+            if(File.Exists(localPath))
+                File.Delete(localPath);
+        }
+    }
+
+    [Fact]
     public async Task when_download_async_succeeds_with_progress_then_progress_is_reported()
     {
         string localPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphClientFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.Graph;
+using Microsoft.Kiota.Abstractions.Authentication;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+public sealed class GraphClientFactory : IGraphClientFactory
+{
+    /// <inheritdoc />
+    public GraphServiceClient CreateClient(string accessToken)
+        => new(new BaseBearerTokenAuthenticationProvider(new StaticAccessTokenProvider(accessToken)));
+
+    private sealed class StaticAccessTokenProvider(string token) : IAccessTokenProvider
+    {
+        public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
+            => Task.FromResult(token);
+
+        public AllowedHostsValidator AllowedHostsValidator { get; } = new(["graph.microsoft.com"]);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -4,11 +4,10 @@ using AStar.Dev.OneDrive.Sync.Client.Models;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Kiota.Abstractions;
-using Microsoft.Kiota.Abstractions.Authentication;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
-public sealed class GraphService(IUploadService uploadService) : IGraphService
+public sealed class GraphService(IUploadService uploadService, IGraphClientFactory graphClientFactory) : IGraphService
 {
     private const string RootPathMarker = "root:";
     private const string DownloadUrlKey = "@microsoft.graph.downloadUrl";
@@ -57,7 +56,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
     /// <inheritdoc />
     public async Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, string driveId, string parentFolderId, CancellationToken ct = default)
     {
-        var client = BuildClient(accessToken);
+        var client = graphClientFactory.CreateClient(accessToken);
 
         var result = await client.Drives[driveId].Items[parentFolderId].Children
             .GetAsync(req =>
@@ -103,7 +102,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
     /// <inheritdoc />
     public async Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, string driveId, string folderId, string remotePath, CancellationToken ct = default)
     {
-        var client = BuildClient(accessToken);
+        var client = graphClientFactory.CreateClient(accessToken);
         List<DeltaItem> items = [];
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, ct);
@@ -114,7 +113,7 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
     /// <inheritdoc />
     public async Task<string?> GetFolderIdByPathAsync(string accessToken, string driveId, string remotePath, CancellationToken ct = default)
     {
-        var client = BuildClient(accessToken);
+        var client = graphClientFactory.CreateClient(accessToken);
 
         try
         {
@@ -211,35 +210,24 @@ public sealed class GraphService(IUploadService uploadService) : IGraphService
 
     private async Task<(GraphServiceClient Client, DriveContext Ctx)> ResolveClientWithDriveContextAsync(string accessToken, CancellationToken ct)
     {
-        var graphServiceClient = BuildClient(accessToken);
+        var client = graphClientFactory.CreateClient(accessToken);
 
         if(_cache.TryGetValue(accessToken, out var cached))
-            return (graphServiceClient, cached);
+            return (client, cached);
 
-        var drive = await graphServiceClient.Me.Drive.GetAsync(cancellationToken: ct);
+        var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
 
         string driveId = drive?.Id ?? throw new InvalidOperationException("Could not retrieve drive ID.");
 
-        var root = await graphServiceClient.Drives[driveId].Root.GetAsync(cancellationToken: ct);
+        var root = await client.Drives[driveId].Root.GetAsync(cancellationToken: ct);
 
         string rootId = root?.Id ?? throw new InvalidOperationException("Could not retrieve root item ID.");
 
         var driveContext = new DriveContext(driveId, rootId);
         _cache[accessToken] = driveContext;
 
-        return (graphServiceClient, driveContext);
+        return (client, driveContext);
     }
-
-    private static GraphServiceClient BuildClient(string accessToken)
-        => new(new BaseBearerTokenAuthenticationProvider(new StaticAccessTokenProvider(accessToken)));
 
     private sealed record DriveContext(string DriveId, string RootId);
-
-    private sealed class StaticAccessTokenProvider(string token) : IAccessTokenProvider
-    {
-        public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
-            => Task.FromResult(token);
-
-        public AllowedHostsValidator AllowedHostsValidator { get; } = new(["graph.microsoft.com"]);
-    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphClientFactory.cs
@@ -1,0 +1,9 @@
+using Microsoft.Graph;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+public interface IGraphClientFactory
+{
+    /// <summary>Creates a <see cref="GraphServiceClient"/> authenticated with the supplied bearer token.</summary>
+    GraphServiceClient CreateClient(string accessToken);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
@@ -8,16 +8,11 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// </summary>
 public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttpDownloader
 {
-    private const string UserAgent         = "AStar.Dev.OneDrive.Sync/1.0";
-    private const int    MaxRetries        = 5;
-    private const double BaseDelaySeconds  = 2.0;
-    private const double MaxDelaySeconds   = 120.0;
+    private const string UserAgent        = "AStar.Dev.OneDrive.Sync/1.0";
+    private const int    MaxRetries       = 5;
+    private const double BaseDelaySeconds = 2.0;
+    private const double MaxDelaySeconds  = 120.0;
 
-    /// <summary>
-    /// Downloads the file at <paramref name="url"/> to <paramref name="localPath"/>.
-    /// Automatically retries on 429 with exponential backoff.
-    /// Preserves the remote last-modified timestamp on the local file.
-    /// </summary>
     /// <inheritdoc />
     public async Task DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
     {
@@ -40,9 +35,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttp
                 if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
                     if(attempt > MaxRetries)
-                    {
                         throw new HttpRequestException($"Rate limited after {MaxRetries} retries.");
-                    }
 
                     var delay = GetRetryDelay(response, attempt);
                     Serilog.Log.Warning("[HttpDownloader] 429 received, waiting {Delay:F1}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt, MaxRetries);
@@ -54,23 +47,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttp
 
                 _ = response.EnsureSuccessStatusCode();
 
-                string? dir = Path.GetDirectoryName(localPath);
-                if(!string.IsNullOrEmpty(dir))
-                    _ = Directory.CreateDirectory(dir);
+                EnsureDirectoryExists(localPath);
 
                 await using var stream = await response.Content.ReadAsStreamAsync(ct);
-                await using var file = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
-
-                byte[] buffer    = new byte[81920];
-                long written  = 0;
-                int  read;
-
-                while((read = await stream.ReadAsync(buffer, ct)) > 0)
-                {
-                    await file.WriteAsync(buffer.AsMemory(0, read), ct);
-                    written += read;
-                    progress?.Report(written);
-                }
+                await WriteToFileAsync(stream, localPath, progress, ct);
 
                 PreserveRemoteTimestamp(localPath, remoteModified);
 
@@ -89,6 +69,29 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttp
         }
     }
 
+    private static async Task WriteToFileAsync(Stream source, string localPath, IProgress<long>? progress, CancellationToken ct)
+    {
+        await using var file = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
+
+        byte[] buffer = new byte[81920];
+        long written  = 0;
+        int  read;
+
+        while((read = await source.ReadAsync(buffer, ct)) > 0)
+        {
+            await file.WriteAsync(buffer.AsMemory(0, read), ct);
+            written += read;
+            progress?.Report(written);
+        }
+    }
+
+    private static void EnsureDirectoryExists(string localPath)
+    {
+        string? dir = Path.GetDirectoryName(localPath);
+        if(!string.IsNullOrEmpty(dir))
+            _ = Directory.CreateDirectory(dir);
+    }
+
     private static void PreserveRemoteTimestamp(string localPath, DateTimeOffset remoteModified) => File.SetLastWriteTimeUtc(localPath, remoteModified.UtcDateTime);
 
     private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
@@ -96,7 +99,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttp
         if(response.Headers.RetryAfter?.Delta is { } delta)
             return delta + AddAdditionalSecondBackoff();
 
-        if (response.Headers.RetryAfter?.Date is not { } date) return GetBackoffDelay(attempt);
+        if(response.Headers.RetryAfter?.Date is not { } date) return GetBackoffDelay(attempt);
 
         var wait = date - DateTimeOffset.UtcNow;
         if(wait > TimeSpan.Zero)
@@ -110,12 +113,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory) : IHttp
     private static TimeSpan GetBackoffDelay(int attempt)
     {
         double seconds = CalculateExponentialBackoff(attempt);
+        double jitter  = seconds * 0.2 * Random.Shared.NextDouble();
 
-        double jitter = seconds * 0.2 * Random.Shared.NextDouble();
         return TimeSpan.FromSeconds(seconds + jitter);
     }
 
-    private static double CalculateExponentialBackoff(int attempt)
-            => Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
-
+    private static double CalculateExponentialBackoff(int attempt) => Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -32,6 +32,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ISyncedItemRepository, SyncedItemRepository>();
         _ = services.AddSingleton<ITokenCacheService, TokenCacheService>();
         _ = services.AddSingleton<IAuthService, AuthService>();
+        _ = services.AddSingleton<IGraphClientFactory, GraphClientFactory>();
         _ = services.AddSingleton<IGraphService, GraphService>();
         _ = services.AddTransient<IStartupService, StartupService>();
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();


### PR DESCRIPTION
# Summary

refactor graphclient and fix bug in download timestamps

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

none

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

refactor graphclient and fix bug in download timestamps

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.
