### PR TITLE
refactor(desktop/onedrive-sync): decompose SyncService into SRP colla…

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
@@ -1,0 +1,102 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenALocalDeletionDetector : IDisposable
+{
+    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
+    private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
+    private readonly string                _tempBase             = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+    private readonly AccountId             _accountId            = new("user-1");
+
+    public GivenALocalDeletionDetector() => Directory.CreateDirectory(_tempBase);
+
+    public void Dispose()
+    {
+        if(Directory.Exists(_tempBase))
+            Directory.Delete(_tempBase, recursive: true);
+    }
+
+    private LocalDeletionDetector CreateSut() => new(_graphService, _syncedItemRepository);
+
+    [Fact]
+    public async Task when_local_file_still_exists_then_graph_delete_is_not_called()
+    {
+        string localFile = Path.Combine(_tempBase, "file.txt");
+        File.WriteAllText(localFile, "data");
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = localFile, IsFolder = false }
+        };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+
+        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_local_file_is_missing_then_graph_delete_is_called()
+    {
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = Path.Combine(_tempBase, "deleted.txt"), IsFolder = false }
+        };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+
+        await _graphService.Received(1).DeleteItemAsync(Arg.Is("token"), Arg.Is("item-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_local_file_is_missing_then_synced_item_repository_delete_is_called()
+    {
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = Path.Combine(_tempBase, "deleted.txt"), IsFolder = false }
+        };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).DeleteByRemoteIdAsync(Arg.Is(_accountId), Arg.Is<OneDriveItemId>(id => id.Id == "item-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_synced_item_is_a_folder_then_it_is_skipped()
+    {
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["folder-1"] = new() { RemoteItemId = new OneDriveItemId("folder-1"), RemotePath = "/SubDir", LocalPath = Path.Combine(_tempBase, "SubDir"), IsFolder = true }
+        };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+
+        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_graph_delete_throws_then_exception_is_caught_and_remaining_items_are_processed()
+    {
+        _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new HttpRequestException("network error")));
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-fail"] = new() { RemoteItemId = new OneDriveItemId("item-fail"), RemotePath = "/fail.txt", LocalPath = Path.Combine(_tempBase, "fail.txt"), IsFolder = false },
+            ["item-ok"]   = new() { RemoteItemId = new OneDriveItemId("item-ok"),   RemotePath = "/ok.txt",   LocalPath = Path.Combine(_tempBase, "ok.txt"),   IsFolder = false }
+        };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+
+        await _graphService.Received(1).DeleteItemAsync(Arg.Is("token"), Arg.Is("item-ok"), Arg.Any<CancellationToken>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
@@ -1,0 +1,131 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenARemoteDeletionDetector : IDisposable
+{
+    private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
+    private readonly string                _tempBase             = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+    private readonly AccountId             _accountId            = new("user-1");
+
+    public GivenARemoteDeletionDetector() => Directory.CreateDirectory(_tempBase);
+
+    public void Dispose()
+    {
+        if(Directory.Exists(_tempBase))
+            Directory.Delete(_tempBase, recursive: true);
+    }
+
+    private RemoteDeletionDetector CreateSut() => new(_syncedItemRepository);
+
+    private static List<SyncRuleEntity> IncludeRules(params string[] paths)
+        => paths.Select(p => new SyncRuleEntity { RemotePath = p, RuleType = RuleType.Include }).ToList();
+
+    [Fact]
+    public async Task when_remote_id_is_in_seen_set_then_local_file_is_not_deleted()
+    {
+        string localFile = Path.Combine(_tempBase, "file.txt");
+        File.WriteAllText(localFile, "data");
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = localFile, IsFolder = false }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "item-1" };
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
+
+        File.Exists(localFile).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_remote_id_absent_and_local_file_exists_then_file_is_deleted()
+    {
+        string localFile = Path.Combine(_tempBase, "file.txt");
+        File.WriteAllText(localFile, "data");
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = localFile, IsFolder = false }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
+
+        File.Exists(localFile).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_remote_id_absent_and_local_file_does_not_exist_then_no_exception_is_thrown()
+    {
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/gone.txt", LocalPath = Path.Combine(_tempBase, "gone.txt"), IsFolder = false }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sut = CreateSut();
+
+        var act = async () => await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/gone.txt"), TestContext.Current.CancellationToken);
+
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task when_remote_id_absent_and_item_is_folder_then_directory_is_deleted_recursively()
+    {
+        string localDir = Path.Combine(_tempBase, "subfolder");
+        Directory.CreateDirectory(localDir);
+        File.WriteAllText(Path.Combine(localDir, "child.txt"), "data");
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["folder-1"] = new() { RemoteItemId = new OneDriveItemId("folder-1"), RemotePath = "/subfolder", LocalPath = localDir, IsFolder = true }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/subfolder"), TestContext.Current.CancellationToken);
+
+        Directory.Exists(localDir).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_remote_id_absent_then_synced_item_repository_delete_is_called()
+    {
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = Path.Combine(_tempBase, "file.txt"), IsFolder = false }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).DeleteByRemoteIdAsync(Arg.Is(_accountId), Arg.Is<OneDriveItemId>(id => id.Id == "item-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_remote_path_does_not_match_include_rules_then_item_is_not_treated_as_deleted()
+    {
+        string localFile = Path.Combine(_tempBase, "other.txt");
+        File.WriteAllText(localFile, "data");
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/Other/other.txt", LocalPath = localFile, IsFolder = false }
+        };
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sut = CreateSut();
+
+        await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/Documents"), TestContext.Current.CancellationToken);
+
+        File.Exists(localFile).ShouldBeTrue();
+        await _syncedItemRepository.DidNotReceive().DeleteByRemoteIdAsync(Arg.Any<AccountId>(), Arg.Any<OneDriveItemId>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -1,0 +1,287 @@
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenARemoteFolderEnumerator : IDisposable
+{
+    private readonly IGraphService            _graphService            = Substitute.For<IGraphService>();
+    private readonly ISyncRuleRepository      _syncRuleRepository      = Substitute.For<ISyncRuleRepository>();
+    private readonly ISyncedItemRepository    _syncedItemRepository    = Substitute.For<ISyncedItemRepository>();
+    private readonly string                   _tempBase                = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+    public GivenARemoteFolderEnumerator()
+    {
+        Directory.CreateDirectory(_tempBase);
+        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, SyncedItemEntity>());
+        _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("drive-1");
+    }
+
+    public void Dispose()
+    {
+        if(Directory.Exists(_tempBase))
+            Directory.Delete(_tempBase, recursive: true);
+    }
+
+    private RemoteFolderEnumerator CreateSut() => new(_graphService, _syncRuleRepository, _syncedItemRepository);
+
+    private OneDriveAccount CreateAccount() => new()
+    {
+        Id             = new AccountId("user-1"),
+        Email          = "user@outlook.com",
+        LocalSyncPath  = LocalSyncPath.Restore(_tempBase),
+        SelectedFolderIds = []
+    };
+
+    private static SyncRuleEntity IncludeRule(string remotePath, string? remoteItemId = null)
+        => new() { RemotePath = remotePath, RuleType = RuleType.Include, RemoteItemId = remoteItemId };
+
+    private static DeltaItem FileItem(string id, string name, string? relativePath = null, string? etag = null)
+        => new(id, "drive-1", name, null, false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, relativePath ?? name, etag);
+
+    private static DeltaItem FolderItem(string id, string name, string? relativePath = null)
+        => new(id, "drive-1", name, null, true, false, 0L, null, null, relativePath ?? name);
+
+    [Fact]
+    public async Task when_no_rules_configured_then_result_has_no_rules_flag_set()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.HadNoRules.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_no_rules_configured_then_graph_drive_id_is_not_requested()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_no_rules_configured_then_download_jobs_is_empty()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.DownloadJobs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_folder_id_cannot_be_resolved_then_enumerate_folder_is_not_called()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents")]);
+        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_folder_id_resolved_from_graph_then_sync_rule_repository_upsert_is_called_to_back_fill()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: null)]);
+        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("folder-resolved");
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-resolved"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_rule_already_has_matching_remote_item_id_then_sync_rule_upsert_is_not_called()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_enumeration_returns_items_then_seen_remote_ids_contains_all_item_ids()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.SeenRemoteIds.ShouldContain("item-a");
+        result.SeenRemoteIds.ShouldContain("item-b");
+    }
+
+    [Fact]
+    public async Task when_item_has_no_known_synced_item_and_no_local_file_then_download_job_is_created()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt")]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.DownloadJobs.ShouldHaveSingleItem();
+        result.DownloadJobs[0].RemoteItemId.ShouldBe("item-a");
+        result.DownloadJobs[0].Direction.ShouldBe(SyncDirection.Download);
+    }
+
+    [Fact]
+    public async Task when_etag_matches_and_local_file_exists_then_no_download_job_is_created()
+    {
+        string localFile = Path.Combine(_tempBase, "Documents", "a.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(localFile)!);
+        File.WriteAllText(localFile, "data");
+
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId      = new AccountId("user-1"),
+            RemoteItemId   = new OneDriveItemId("item-a"),
+            RemotePath     = "/Documents/a.txt",
+            LocalPath      = localFile,
+            ETag           = "etag-123",
+            RemoteModifiedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.DownloadJobs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_local_file_is_newer_than_known_remote_by_more_than_5_seconds_then_on_conflict_callback_is_invoked()
+    {
+        string localFile = Path.Combine(_tempBase, "Documents", "a.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(localFile)!);
+        File.WriteAllText(localFile, "modified locally");
+        File.SetLastWriteTimeUtc(localFile, DateTime.UtcNow);
+
+        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            RemoteModifiedAt = remoteModified
+        };
+        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([new DeltaItem("item-a", "drive-1", "a.txt", null, false, false, 100L, remoteModified, null, "/Documents/a.txt")]);
+
+        var conflictsDetected = new List<SyncConflict>();
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", conflict =>
+        {
+            conflictsDetected.Add(conflict);
+            return Task.CompletedTask;
+        }, TestContext.Current.CancellationToken);
+
+        conflictsDetected.ShouldHaveSingleItem();
+        conflictsDetected[0].RemoteItemId.ShouldBe("item-a");
+    }
+
+    [Fact]
+    public async Task when_item_is_a_folder_then_synced_item_repository_upsert_is_called()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FolderItem("subfolder-1", "Sub", "/Documents/Sub")]);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.IsFolder && e.RemoteItemId.Id == "subfolder-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_file_exists_locally_without_synced_item_then_phantom_item_is_upserted()
+    {
+        string localFile = Path.Combine(_tempBase, "Documents", "phantom.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(localFile)!);
+        File.WriteAllText(localFile, "phantom");
+
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]);
+
+        var sut = CreateSut();
+
+        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-phantom"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_result_returned_then_rules_are_included_in_result()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.Rules.ShouldHaveSingleItem();
+        result.Rules[0].RemotePath.ShouldBe("/Documents");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -1,0 +1,147 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenASyncJobExecutor
+{
+    private readonly ISyncRepository         _syncRepository         = Substitute.For<ISyncRepository>();
+    private readonly ISyncedItemRepository   _syncedItemRepository   = Substitute.For<ISyncedItemRepository>();
+    private readonly IParallelDownloadPipeline _pipeline             = Substitute.For<IParallelDownloadPipeline>();
+
+    private readonly OneDriveAccount _account = new()
+    {
+        Id    = new AccountId("user-1"),
+        Email = "user@outlook.com"
+    };
+
+    private SyncJobExecutor CreateSut() => new(_syncRepository, _syncedItemRepository, _pipeline);
+
+    private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
+        => new()
+        {
+            AccountId      = "user-1",
+            RemoteItemId   = remoteId,
+            RelativePath   = "Documents/file.txt",
+            LocalPath      = localPath,
+            Direction      = direction,
+            FileSize       = 100L,
+            RemoteModified = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+    [Fact]
+    public async Task when_jobs_list_is_empty_then_pipeline_is_not_called()
+    {
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(_account, "token", [], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _pipeline.DidNotReceive().RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_jobs_are_provided_then_sync_repository_enqueue_is_called()
+    {
+        var jobs = new List<SyncJob> { MakeJob("item-1", SyncDirection.Download) };
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _syncRepository.Received(1).EnqueueJobsAsync(Arg.Is<IEnumerable<SyncJob>>(j => j.Count() == 1));
+    }
+
+    [Fact]
+    public async Task when_pipeline_completes_download_job_successfully_then_synced_item_is_upserted()
+    {
+        var job = MakeJob("item-1", SyncDirection.Download) with { State = SyncJobState.Queued };
+        var jobs = new List<SyncJob> { job };
+
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
+                onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Completed }));
+            });
+
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_pipeline_completes_upload_job_with_remote_id_then_synced_item_is_upserted_with_uploaded_id()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        File.WriteAllText(tempFile, "data");
+
+        try
+        {
+            var job = MakeJob("item-1", SyncDirection.Upload, tempFile);
+            var jobs = new List<SyncJob> { job };
+
+            _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+                .Do(call =>
+                {
+                    var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
+                    onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Completed, UploadedRemoteItemId = "uploaded-remote-id" }));
+                });
+
+            var sut = CreateSut();
+
+            await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+            await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "uploaded-remote-id"), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            if(File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task when_job_fails_then_synced_item_is_not_upserted()
+    {
+        var job = MakeJob("item-1", SyncDirection.Download);
+        var jobs = new List<SyncJob> { job };
+
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
+                onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Failed, ErrorMessage = "disk full" }));
+            });
+
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.DidNotReceive().UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_jobs_execute_then_on_progress_callback_is_forwarded_from_pipeline()
+    {
+        var job = MakeJob("item-1", SyncDirection.Download);
+        var jobs = new List<SyncJob> { job };
+
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                var onProgress = call.Arg<Action<SyncProgressEventArgs>>();
+                onProgress(new SyncProgressEventArgs("user-1", string.Empty, 1, 1, "file.txt", SyncState.Syncing));
+            });
+
+        var progressReceived = new List<SyncProgressEventArgs>();
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(_account, "token", jobs, [], args => progressReceived.Add(args), _ => { }, TestContext.Current.CancellationToken);
+
+        progressReceived.ShouldHaveSingleItem();
+        progressReceived[0].CurrentFile.ShouldBe("file.txt");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -11,27 +11,39 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
 public sealed class GivenASyncServiceSyncingAnAccount
 {
     private readonly IAuthService              _authService              = Substitute.For<IAuthService>();
-    private readonly IGraphService             _graphService             = Substitute.For<IGraphService>();
     private readonly IAccountRepository        _accountRepository        = Substitute.For<IAccountRepository>();
     private readonly ISyncRepository           _syncRepository           = Substitute.For<ISyncRepository>();
     private readonly IDriveStateRepository     _driveStateRepository     = Substitute.For<IDriveStateRepository>();
-    private readonly ISyncRuleRepository       _syncRuleRepository       = Substitute.For<ISyncRuleRepository>();
-    private readonly ISyncedItemRepository     _syncedItemRepository     = Substitute.For<ISyncedItemRepository>();
-    private readonly ILocalChangeDetector      _localChangeDetector      = Substitute.For<ILocalChangeDetector>();
     private readonly IHttpDownloader           _httpDownloader           = Substitute.For<IHttpDownloader>();
-    private readonly IParallelDownloadPipeline _parallelDownloadPipeline = Substitute.For<IParallelDownloadPipeline>();
+    private readonly IGraphService             _graphService             = Substitute.For<IGraphService>();
+    private readonly IRemoteFolderEnumerator   _remoteFolderEnumerator   = Substitute.For<IRemoteFolderEnumerator>();
+    private readonly IRemoteDeletionDetector   _remoteDeletionDetector   = Substitute.For<IRemoteDeletionDetector>();
+    private readonly ILocalDeletionDetector    _localDeletionDetector    = Substitute.For<ILocalDeletionDetector>();
+    private readonly ILocalChangeDetector      _localChangeDetector      = Substitute.For<ILocalChangeDetector>();
+    private readonly ISyncJobExecutor          _syncJobExecutor          = Substitute.For<ISyncJobExecutor>();
 
-    private SyncService CreateSut() => new(_authService, _graphService, _accountRepository, _syncRepository, _driveStateRepository, _syncRuleRepository, _syncedItemRepository, _localChangeDetector, _httpDownloader, _parallelDownloadPipeline);
+    private SyncService CreateSut()
+    {
+        var dependencies = new SyncServiceDependencies(
+            _remoteFolderEnumerator,
+            _remoteDeletionDetector,
+            _localDeletionDetector,
+            _localChangeDetector,
+            _syncJobExecutor);
+
+        return new SyncService(_authService, _accountRepository, _driveStateRepository, _syncRepository, _httpDownloader, _graphService, dependencies);
+    }
 
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {
-        Id = new AccountId("user-1"),
-        Email = "user@outlook.com",
+        Id            = new AccountId("user-1"),
+        Email         = "user@outlook.com",
         LocalSyncPath = LocalSyncPath.Restore(localSyncPath),
         SelectedFolderIds = []
     };
 
-    private static SyncRuleEntity MakeIncludeRule(string remotePath = "/Documents", string? remoteItemId = null) => new() { RemotePath = remotePath, RuleType = RuleType.Include, RemoteItemId = remoteItemId };
+    private static RemoteEnumerationResult EmptyEnumerationResult()
+        => new([], new HashSet<string>(), [], []);
 
     private void SetupAuthSuccess() =>
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -42,10 +54,8 @@ public sealed class GivenASyncServiceSyncingAnAccount
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns((DriveStateEntity?)null);
-        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity>());
-        _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns("drive-1");
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyEnumerationResult());
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
             .Returns([]);
         _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
@@ -141,13 +151,13 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_internal_sync_throws_operation_cancelled_then_progress_is_sync_cancelled_with_idle_state()
+    public async Task when_enumerator_throws_operation_cancelled_then_progress_is_sync_cancelled_with_idle_state()
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns((DriveStateEntity?)null);
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<SyncRuleEntity>>(new OperationCanceledException()));
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<RemoteEnumerationResult>(new OperationCanceledException()));
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -168,13 +178,13 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_internal_sync_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
+    public async Task when_enumerator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns((DriveStateEntity?)null);
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<List<SyncRuleEntity>>(new InvalidOperationException("unexpected")));
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<RemoteEnumerationResult>(new InvalidOperationException("unexpected")));
 
         SyncState? capturedState = null;
         string? capturedMessage = null;
@@ -195,13 +205,13 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_no_sync_rules_are_configured_then_progress_raises_no_folders_selected_with_idle_state()
+    public async Task when_enumerator_returns_had_no_rules_then_progress_raises_no_folders_selected_with_idle_state()
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns((DriveStateEntity?)null);
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -222,63 +232,9 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_rule_has_no_remote_item_id_and_folder_id_cannot_be_resolved_then_enumerate_folder_is_not_called()
-    {
-        SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: null)]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns((string?)null);
-
-        var sut = CreateSut();
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task when_rule_has_no_remote_item_id_and_folder_id_is_resolved_then_sync_rule_repository_upsert_is_called_to_back_fill_id()
-    {
-        SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: null)]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns("folder-1");
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
-
-        var sut = CreateSut();
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-1"), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task when_rule_already_has_remote_item_id_matching_resolved_folder_then_sync_rule_repository_upsert_is_not_called()
-    {
-        SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
-
-        var sut = CreateSut();
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
     public async Task when_no_download_or_upload_jobs_exist_then_progress_raises_no_changes_with_idle_state()
     {
         SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -302,10 +258,6 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_sync_completes_with_no_jobs_then_progress_raises_sync_complete_with_idle_state()
     {
         SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -329,10 +281,6 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_rules_exist_then_progress_sequence_includes_detecting_remote_deletions_and_detecting_local_changes()
     {
         SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
 
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -349,10 +297,6 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_account_entity_exists_then_account_repository_upsert_is_called_after_sync()
     {
         SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
         _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(new AccountEntity { Id = new AccountId("user-1") });
 
@@ -367,10 +311,6 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_account_entity_does_not_exist_then_account_repository_upsert_is_not_called()
     {
         SetupDeepSyncPrerequisites();
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([MakeIncludeRule(remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new List<DeltaItem>());
 
         var sut = CreateSut();
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
@@ -10,30 +10,53 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
 
 public sealed class SyncServiceTests
 {
-    private readonly IAuthService             authService             = Substitute.For<IAuthService>();
-    private readonly IGraphService            graphService            = Substitute.For<IGraphService>();
-    private readonly IAccountRepository       accountRepository       = Substitute.For<IAccountRepository>();
-    private readonly ISyncRepository          syncRepository          = Substitute.For<ISyncRepository>();
-    private readonly IDriveStateRepository    driveStateRepository    = Substitute.For<IDriveStateRepository>();
-    private readonly ISyncRuleRepository      syncRuleRepository      = Substitute.For<ISyncRuleRepository>();
-    private readonly ISyncedItemRepository    syncedItemRepository    = Substitute.For<ISyncedItemRepository>();
-    private readonly ILocalChangeDetector     localChangeDetector     = Substitute.For<ILocalChangeDetector>();
-    private readonly IHttpDownloader          httpDownloader          = Substitute.For<IHttpDownloader>();
-    private readonly IParallelDownloadPipeline parallelDownloadPipeline = Substitute.For<IParallelDownloadPipeline>();
+    private readonly IAuthService              _authService             = Substitute.For<IAuthService>();
+    private readonly IGraphService             _graphService            = Substitute.For<IGraphService>();
+    private readonly IAccountRepository        _accountRepository       = Substitute.For<IAccountRepository>();
+    private readonly ISyncRepository           _syncRepository          = Substitute.For<ISyncRepository>();
+    private readonly IDriveStateRepository     _driveStateRepository    = Substitute.For<IDriveStateRepository>();
+    private readonly IHttpDownloader           _httpDownloader          = Substitute.For<IHttpDownloader>();
+    private readonly IRemoteFolderEnumerator   _remoteFolderEnumerator  = Substitute.For<IRemoteFolderEnumerator>();
+    private readonly IRemoteDeletionDetector   _remoteDeletionDetector  = Substitute.For<IRemoteDeletionDetector>();
+    private readonly ILocalDeletionDetector    _localDeletionDetector   = Substitute.For<ILocalDeletionDetector>();
+    private readonly ILocalChangeDetector      _localChangeDetector     = Substitute.For<ILocalChangeDetector>();
+    private readonly ISyncJobExecutor          _syncJobExecutor         = Substitute.For<ISyncJobExecutor>();
 
-    private SyncService BuildSut() => new(authService, graphService, accountRepository, syncRepository, driveStateRepository, syncRuleRepository, syncedItemRepository, localChangeDetector, httpDownloader, parallelDownloadPipeline);
+    private SyncService BuildSut()
+    {
+        var dependencies = new SyncServiceDependencies(
+            _remoteFolderEnumerator,
+            _remoteDeletionDetector,
+            _localDeletionDetector,
+            _localChangeDetector,
+            _syncJobExecutor);
+
+        return new SyncService(_authService, _accountRepository, _driveStateRepository, _syncRepository, _httpDownloader, _graphService, dependencies);
+    }
+
+    private static RemoteEnumerationResult EmptyEnumerationResult()
+        => new([], new HashSet<string>(), [], []);
 
     [Fact]
-    public void Constructor_ShouldInitializeWithDependencies()
+    public void constructor_creates_instance_successfully()
     {
         var service = BuildSut();
 
-        _ = service.ShouldNotBeNull();
+        service.ShouldNotBeNull();
     }
 
     [Fact]
-    public async Task SyncAccountAsync_WithValidAccount_ShouldCompleteSuccessfully()
+    public async Task when_sync_called_with_valid_account_then_auth_service_is_called()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns((DriveStateEntity?)null);
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyEnumerationResult());
+        _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
+            .Returns([]);
+
         var service = BuildSut();
         var account = new OneDriveAccount
         {
@@ -42,33 +65,25 @@ public sealed class SyncServiceTests
             LocalSyncPath = LocalSyncPath.Restore("/home/user/OneDrive")
         };
 
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-        syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
-        syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity>());
-
         await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
 
-        _ = await authService.Received(1).AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _authService.Received(1).AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task SyncAccountAsync_WhenAuthFails_ShouldRaiseErrorEvent()
+    public async Task when_auth_fails_then_error_progress_is_raised()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Failure("Authentication failed"));
+
         var service = BuildSut();
         var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
         bool errorRaised = false;
-
-        service.SyncProgressChanged += (s, args) =>
+        service.SyncProgressChanged += (_, args) =>
         {
             if(args.SyncState == SyncState.Error)
                 errorRaised = true;
         };
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("Authentication failed"));
 
         await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
 
@@ -76,18 +91,15 @@ public sealed class SyncServiceTests
     }
 
     [Fact]
-    public async Task SyncAccountAsync_WithoutSyncPath_ShouldRaiseNoSyncPathEvent()
+    public async Task when_local_sync_path_is_null_then_no_local_sync_path_progress_is_raised()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+
         var service = BuildSut();
         var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com", LocalSyncPath = null };
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-        syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
-
         bool noSyncPathRaised = false;
-        service.SyncProgressChanged += (s, args) =>
+        service.SyncProgressChanged += (_, args) =>
         {
             if(args.CurrentFile == "No local sync path configured")
                 noSyncPathRaised = true;
@@ -99,25 +111,15 @@ public sealed class SyncServiceTests
     }
 
     [Fact]
-    public async Task SyncAccountAsync_RaisesSyncProgressChangedEvent()
+    public async Task when_sync_called_then_sync_progress_changed_event_is_raised()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Failure("fail"));
+
         var service = BuildSut();
-        var account = new OneDriveAccount
-        {
-            Id            = new AccountId("user-1"),
-            Email         = "user@outlook.com",
-            LocalSyncPath = LocalSyncPath.Restore("/path/to/sync")
-        };
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-        syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
-        syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity>());
-
+        var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
         bool eventRaised = false;
-        service.SyncProgressChanged += (s, args) => eventRaised = true;
+        service.SyncProgressChanged += (_, _) => eventRaised = true;
 
         await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
 
@@ -125,8 +127,11 @@ public sealed class SyncServiceTests
     }
 
     [Fact]
-    public async Task ResolveConflictAsync_WithValidPolicy_ShouldResolveConflict()
+    public async Task when_resolve_conflict_called_with_valid_policy_then_sync_repository_resolve_is_called()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+
         var service = BuildSut();
         var conflict = new SyncConflict
         {
@@ -137,25 +142,23 @@ public sealed class SyncServiceTests
             State          = ConflictState.Pending
         };
 
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-
         await service.ResolveConflictAsync(conflict, ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
     }
 
     [Fact]
-    public async Task ResolveConflictAsync_WhenAuthFails_ShouldNotResolve()
+    public async Task when_resolve_conflict_auth_fails_then_sync_repository_resolve_is_not_called()
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Failure("Auth failed"));
+
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };
 
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("Auth failed"));
-
         await service.ResolveConflictAsync(conflict, ConflictPolicy.Ignore, TestContext.Current.CancellationToken);
-        await syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
     }
 
     [Theory]
@@ -163,73 +166,16 @@ public sealed class SyncServiceTests
     [InlineData(ConflictPolicy.KeepBoth)]
     [InlineData(ConflictPolicy.LastWriteWins)]
     [InlineData(ConflictPolicy.LocalWins)]
-    public async Task ResolveConflictAsync_WithVariousPolicies_ShouldApply(ConflictPolicy policy)
+    public async Task when_resolve_conflict_called_with_various_policies_then_policy_is_recorded(ConflictPolicy policy)
     {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
 
         await service.ResolveConflictAsync(conflict, policy, TestContext.Current.CancellationToken);
 
-        await syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Is(policy));
-    }
-
-    [Fact]
-    public async Task SyncAccountAsync_WithMultipleFolders_ShouldSyncAll()
-    {
-        var service = BuildSut();
-        var account = new OneDriveAccount
-        {
-            Id            = new AccountId("user-1"),
-            Email         = "user@outlook.com",
-            LocalSyncPath = LocalSyncPath.Restore("/path/to/sync")
-        };
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-        syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
-        syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity>());
-
-        await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
-    public async Task SyncAccountAsync_ShouldAcceptCancellationToken()
-    {
-        var service = BuildSut();
-        var account = new OneDriveAccount
-        {
-            Id            = new AccountId("user-1"),
-            Email         = "user@outlook.com",
-            DisplayName   = "Test User",
-            LocalSyncPath = LocalSyncPath.Restore("/path/to/sync")
-        };
-        var cts = new CancellationTokenSource();
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-        syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([]);
-        syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity>());
-
-        await service.SyncAccountAsync(account, cts.Token);
-    }
-
-    [Fact]
-    public async Task ResolveConflictAsync_ShouldAcceptCancellationToken()
-    {
-        var service = BuildSut();
-        var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };
-        var cts = new CancellationTokenSource();
-
-        _ = authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
-
-        await service.ResolveConflictAsync(conflict, ConflictPolicy.Ignore, cts.Token);
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Is(policy));
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -1,0 +1,51 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+/// <summary>
+/// Creates <see cref="SyncedItemEntity"/> instances from remote delta items and completed sync jobs.
+/// </summary>
+public static class SyncedItemEntityFactory
+{
+    /// <summary>Creates a tracking entity from a remote delta item (folder, file, or phantom).</summary>
+    public static SyncedItemEntity Create(AccountId accountId, DeltaItem item, string remotePath, string localPath)
+        => new()
+        {
+            AccountId        = accountId,
+            RemoteItemId     = new OneDriveItemId(item.Id),
+            RemoteParentId   = item.ParentId ?? string.Empty,
+            RemotePath       = remotePath,
+            LocalPath        = localPath,
+            IsFolder         = item.IsFolder,
+            RemoteModifiedAt = item.LastModified ?? DateTimeOffset.MinValue,
+            ETag             = item.ETag,
+            CTag             = item.CTag
+        };
+
+    /// <summary>Creates a tracking entity for a successfully completed download job.</summary>
+    public static SyncedItemEntity CreateFromDownloadJob(AccountId accountId, SyncJob job, string remotePath)
+        => new()
+        {
+            AccountId        = accountId,
+            RemoteItemId     = new OneDriveItemId(job.RemoteItemId),
+            RemoteParentId   = string.Empty,
+            RemotePath       = remotePath,
+            LocalPath        = job.LocalPath,
+            IsFolder         = false,
+            RemoteModifiedAt = job.RemoteModified
+        };
+
+    /// <summary>Creates a tracking entity for a successfully completed upload job.</summary>
+    public static SyncedItemEntity CreateFromUploadJob(AccountId accountId, SyncJob job, string remotePath)
+        => new()
+        {
+            AccountId        = accountId,
+            RemoteItemId     = new OneDriveItemId(job.UploadedRemoteItemId!),
+            RemoteParentId   = string.Empty,
+            RemotePath       = remotePath,
+            LocalPath        = job.LocalPath,
+            IsFolder         = false,
+            RemoteModifiedAt = new DateTimeOffset(new FileInfo(job.LocalPath).LastWriteTimeUtc, TimeSpan.Zero)
+        };
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ILocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ILocalDeletionDetector.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Detects locally deleted files and propagates those deletions to the remote drive.
+/// </summary>
+public interface ILocalDeletionDetector
+{
+    /// <summary>
+    /// Walks <paramref name="syncedItems"/> and, for each file no longer present on disk,
+    /// deletes the corresponding remote item via Graph and removes the local tracking record.
+    /// </summary>
+    Task DetectAndApplyAsync(AccountId accountId, string accessToken, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteDeletionDetector.cs
@@ -1,0 +1,18 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Detects remote items that were deleted since the last sync and removes their local counterparts.
+/// </summary>
+public interface IRemoteDeletionDetector
+{
+    /// <summary>
+    /// Cross-references <paramref name="syncedItems"/> against <paramref name="seenRemoteIds"/> from
+    /// the current enumeration pass. For each absent remote ID, deletes the local file or directory
+    /// and removes the tracking record from the repository.
+    /// </summary>
+    Task DetectAndApplyAsync(AccountId accountId, Dictionary<string, SyncedItemEntity> syncedItems, IReadOnlySet<string> seenRemoteIds, IReadOnlyList<SyncRuleEntity> rules, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteFolderEnumerator.cs
@@ -1,0 +1,19 @@
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Loads sync rules and synced items for an account, iterates every root include rule,
+/// resolves folder IDs, enumerates remote items, and classifies each as skipped, folder,
+/// phantom, conflict, or download job.
+/// </summary>
+public interface IRemoteFolderEnumerator
+{
+    /// <summary>
+    /// Performs a full remote enumeration pass for <paramref name="account"/>.
+    /// Invokes <paramref name="onConflict"/> for each conflict detected so the caller
+    /// can persist and raise the event without coupling this service to <c>ISyncRepository</c>.
+    /// </summary>
+    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Func<SyncConflict, Task> onConflict, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncJobExecutor.cs
@@ -1,0 +1,17 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Enqueues sync jobs, runs them through the parallel pipeline, and records the resulting state.
+/// </summary>
+public interface ISyncJobExecutor
+{
+    /// <summary>
+    /// Enqueues <paramref name="jobs"/> to the repository, runs them through the parallel pipeline,
+    /// and persists a <see cref="SyncedItemEntity"/> for each successfully completed download or upload.
+    /// Progress and job-completion events are forwarded via the provided callbacks.
+    /// </summary>
+    Task ExecuteAsync(OneDriveAccount account, string accessToken, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
@@ -1,0 +1,33 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedItemRepository syncedItemRepository) : ILocalDeletionDetector
+{
+    /// <inheritdoc />
+    public async Task DetectAndApplyAsync(AccountId accountId, string accessToken, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    {
+        foreach(var (remoteId, knownItem) in syncedItems)
+        {
+            if(knownItem.IsFolder) continue;
+            if(ct.IsCancellationRequested) break;
+            if(File.Exists(knownItem.LocalPath)) continue;
+
+            Serilog.Log.Information("[LocalDeletionDetector] Local file deleted — removing remote: {Path}", knownItem.RemotePath);
+
+            try
+            {
+                await graphService.DeleteItemAsync(accessToken, remoteId, ct);
+                await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+            }
+            catch(Exception ex)
+            {
+                Serilog.Log.Error(ex, "[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, ex.Message);
+            }
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteDeletionDetector.cs
@@ -1,0 +1,54 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepository) : IRemoteDeletionDetector
+{
+    /// <inheritdoc />
+    public async Task DetectAndApplyAsync(AccountId accountId, Dictionary<string, SyncedItemEntity> syncedItems, IReadOnlySet<string> seenRemoteIds, IReadOnlyList<SyncRuleEntity> rules, CancellationToken ct)
+    {
+        foreach(var (remoteId, knownItem) in syncedItems.ToList())
+        {
+            if(ct.IsCancellationRequested)
+                break;
+
+            if(!SyncRuleEvaluator.IsIncluded(knownItem.RemotePath, rules))
+                continue;
+
+            if(seenRemoteIds.Contains(remoteId))
+                continue;
+
+            Serilog.Log.Information("[RemoteDeletionDetector] Remote item no longer present — treating as deleted: {Path}", knownItem.RemotePath);
+            await HandleRemoteDeleteAsync(accountId, knownItem, syncedItems, ct);
+        }
+    }
+
+    private async Task HandleRemoteDeleteAsync(AccountId accountId, SyncedItemEntity knownItem, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    {
+        string localPath = knownItem.LocalPath;
+
+        if(knownItem.IsFolder)
+        {
+            if(Directory.Exists(localPath))
+            {
+                Serilog.Log.Information("[RemoteDeletionDetector] Remote folder deleted — removing local: {Path}", localPath);
+                Directory.Delete(localPath, recursive: true);
+            }
+        }
+        else
+        {
+            if(File.Exists(localPath))
+            {
+                Serilog.Log.Information("[RemoteDeletionDetector] Remote file deleted — removing local: {Path}", localPath);
+                File.Delete(localPath);
+            }
+        }
+
+        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+        syncedItems.Remove(knownItem.RemoteItemId.Id);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteEnumerationResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteEnumerationResult.cs
@@ -1,0 +1,10 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Carries the output of a single remote-enumeration pass.
+/// Consumed by deletion detectors and the job executor.
+/// </summary>
+public sealed record RemoteEnumerationResult(IReadOnlyList<SyncJob> DownloadJobs, IReadOnlySet<string> SeenRemoteIds, Dictionary<string, SyncedItemEntity> SyncedItems, IReadOnlyList<SyncRuleEntity> Rules, bool HadNoRules = false);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -1,0 +1,211 @@
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository) : IRemoteFolderEnumerator
+{
+    /// <inheritdoc />
+    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    {
+        var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct);
+
+        if(rules.Count == 0)
+        {
+            Serilog.Log.Information("[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync", account.Email);
+
+            return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: true);
+        }
+
+        var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct);
+        var driveId     = await graphService.GetDriveIdAsync(accessToken, ct);
+
+        var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
+        var rootIncludeRules = includeRules
+            .Where(rule => !includeRules.Any(other => other.RemotePath != rule.RemotePath && rule.RemotePath.StartsWith(other.RemotePath + "/", StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        List<SyncJob> downloadJobs  = [];
+        var seenRemoteIds           = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach(var rule in rootIncludeRules)
+        {
+            if(ct.IsCancellationRequested)
+                break;
+
+            var folderId = rule.RemoteItemId
+                ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
+                ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct);
+
+            if(folderId is null)
+            {
+                Serilog.Log.Warning("[RemoteFolderEnumerator] Cannot resolve folder ID for rule path {Path} — skipping", rule.RemotePath);
+                continue;
+            }
+
+            if(folderId != rule.RemoteItemId)
+            {
+                Serilog.Log.Debug("[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
+                await syncRuleRepository.UpsertAsync(account.Id, rule.RemotePath, RuleType.Include, folderId, ct);
+            }
+
+            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Email);
+            var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct);
+            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
+
+            foreach(var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
+            {
+                seenRemoteIds.Add(item.Id);
+
+                if(!SyncRuleEvaluator.IsIncluded(item.RelativePath ?? item.Name, rules))
+                    continue;
+
+                if(item.IsFolder)
+                {
+                    await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, account.LocalSyncPath!.Value, syncedItems, ct);
+                    continue;
+                }
+
+                string localPath = BuildLocalPath(account.LocalSyncPath!.Value, (item.RelativePath ?? item.Name).TrimStart('/'));
+
+                syncedItems.TryGetValue(item.Id, out var knownItem);
+
+                if(knownItem?.ETag is not null && knownItem.ETag == item.ETag && File.Exists(localPath))
+                {
+                    Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.RelativePath);
+                    continue;
+                }
+
+                if(knownItem is not null && File.Exists(localPath))
+                {
+                    var localModified = new DateTimeOffset(new FileInfo(localPath).LastWriteTimeUtc, TimeSpan.Zero);
+                    bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
+
+                    if(isConflict)
+                    {
+                        var conflict = BuildConflict(account, item, localPath, localModified);
+                        await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict);
+                        continue;
+                    }
+                }
+                else if(knownItem is null && File.Exists(localPath))
+                {
+                    Serilog.Log.Debug("[RemoteFolderEnumerator] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
+                    var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.RelativePath ?? item.Name, localPath);
+                    await syncedItemRepository.UpsertAsync(phantomItem, ct);
+                    syncedItems[item.Id] = phantomItem;
+                    continue;
+                }
+
+                downloadJobs.Add(new SyncJob
+                {
+                    AccountId      = account.Id.Id,
+                    FolderId       = string.Empty,
+                    RemoteItemId   = item.Id,
+                    RelativePath   = item.RelativePath ?? item.Name,
+                    LocalPath      = localPath,
+                    Direction      = SyncDirection.Download,
+                    DownloadUrl    = item.DownloadUrl,
+                    FileSize       = item.Size,
+                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
+                });
+            }
+        }
+
+        return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
+    }
+
+    private async Task HandleFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localBasePath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    {
+        string localPath = BuildLocalPath(localBasePath, remotePath.TrimStart('/'));
+        _ = Directory.CreateDirectory(localPath);
+
+        var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
+        await syncedItemRepository.UpsertAsync(entity, ct);
+        syncedItems[item.Id] = entity;
+    }
+
+    private static async Task HandleConflictAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, SyncConflict conflict, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict)
+    {
+        await onConflict(conflict);
+
+        var outcome = ConflictResolver.Resolve(account.ConflictPolicy, localModified, item.LastModified ?? DateTimeOffset.MinValue);
+
+        switch(outcome)
+        {
+            case ConflictOutcome.Skip:
+                break;
+
+            case ConflictOutcome.UseRemote:
+                downloadJobs.Add(new SyncJob
+                {
+                    AccountId      = account.Id.Id,
+                    FolderId       = string.Empty,
+                    RemoteItemId   = item.Id,
+                    RelativePath   = item.RelativePath ?? item.Name,
+                    LocalPath      = localPath,
+                    Direction      = SyncDirection.Download,
+                    DownloadUrl    = item.DownloadUrl,
+                    FileSize       = item.Size,
+                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
+                });
+                break;
+
+            case ConflictOutcome.UseLocal:
+                downloadJobs.Add(new SyncJob
+                {
+                    AccountId      = account.Id.Id,
+                    FolderId       = string.Empty,
+                    RemoteItemId   = item.Id,
+                    RelativePath   = item.RelativePath ?? item.Name,
+                    LocalPath      = localPath,
+                    Direction      = SyncDirection.Upload,
+                    FileSize       = new FileInfo(localPath).Length,
+                    RemoteModified = localModified
+                });
+                break;
+
+            case ConflictOutcome.KeepBoth:
+                string newName = ConflictResolver.MakeKeepBothName(localPath, localModified);
+                File.Move(localPath, newName);
+                downloadJobs.Add(new SyncJob
+                {
+                    AccountId      = account.Id.Id,
+                    FolderId       = string.Empty,
+                    RemoteItemId   = item.Id,
+                    RelativePath   = item.RelativePath ?? item.Name,
+                    LocalPath      = localPath,
+                    Direction      = SyncDirection.Download,
+                    DownloadUrl    = item.DownloadUrl,
+                    FileSize       = item.Size,
+                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
+                });
+                break;
+        }
+    }
+
+    private static string? TryResolveFromSyncedItems(Dictionary<string, SyncedItemEntity> syncedItems, string remotePath)
+        => syncedItems.Values.FirstOrDefault(i => i.IsFolder && string.Equals(i.RemotePath, remotePath, StringComparison.OrdinalIgnoreCase))?.RemoteItemId.Id;
+
+    private static SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
+        => new()
+        {
+            AccountId      = account.Id.Id,
+            FolderId       = string.Empty,
+            RemoteItemId   = item.Id,
+            RelativePath   = item.RelativePath ?? item.Name,
+            LocalPath      = localPath,
+            LocalModified  = localModified,
+            RemoteModified = item.LastModified ?? DateTimeOffset.MinValue,
+            LocalSize      = new FileInfo(localPath).Length,
+            RemoteSize     = item.Size
+        };
+
+    private static string BuildLocalPath(string localBasePath, string relativePath)
+        => Path.Combine(localBasePath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncJobExecutor.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, IParallelDownloadPipeline parallelDownloadPipeline) : ISyncJobExecutor
+{
+    /// <inheritdoc />
+    public async Task ExecuteAsync(OneDriveAccount account, string accessToken, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
+    {
+        if(jobs.Count == 0)
+            return;
+
+        await syncRepository.EnqueueJobsAsync(jobs);
+
+        var successfulJobs = new ConcurrentBag<SyncJob>();
+
+        await parallelDownloadPipeline.RunAsync(
+            jobs,
+            accessToken,
+            onProgress,
+            args =>
+            {
+                if(args.Job.State == SyncJobState.Completed)
+                    successfulJobs.Add(args.Job);
+
+                onJobCompleted(args);
+            },
+            account.Id.Id,
+            string.Empty,
+            ct: ct);
+
+        foreach(var job in successfulJobs)
+        {
+            var remotePath = NormaliseRemotePath(job.RelativePath);
+
+            if(job.Direction == SyncDirection.Download)
+            {
+                var entity = SyncedItemEntityFactory.CreateFromDownloadJob(account.Id, job, remotePath);
+                await syncedItemRepository.UpsertAsync(entity, ct);
+                syncedItems[job.RemoteItemId] = entity;
+            }
+            else if(job.Direction == SyncDirection.Upload && job.UploadedRemoteItemId is not null)
+            {
+                var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, job, remotePath);
+                await syncedItemRepository.UpsertAsync(entity, ct);
+                syncedItems[job.UploadedRemoteItemId] = entity;
+            }
+        }
+    }
+
+    private static string NormaliseRemotePath(string? relativePath)
+        => string.IsNullOrEmpty(relativePath) ? "/" : $"/{relativePath.TrimStart('/')}";
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -1,14 +1,13 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-public sealed class SyncService(IAuthService authService, IGraphService graphService, IAccountRepository accountRepository, ISyncRepository syncRepository, IDriveStateRepository driveStateRepository, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, ILocalChangeDetector localChangeDetector, IHttpDownloader httpDownloader, IParallelDownloadPipeline parallelDownloadPipeline) : ISyncService
+public sealed class SyncService(IAuthService authService, IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, ISyncRepository syncRepository, IHttpDownloader httpDownloader, IGraphService graphService, SyncServiceDependencies dependencies) : ISyncService
 {
     public event EventHandler<SyncProgressEventArgs>? SyncProgressChanged;
     public event EventHandler<JobCompletedEventArgs>?  JobCompleted;
@@ -37,7 +36,7 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
         {
             await SyncAccountInternalAsync(account, authResult.AccessToken!, ct);
         }
-        catch (OperationCanceledException)
+        catch(OperationCanceledException)
         {
             RaiseProgress(account.Id.Id, 0, 0, "Sync cancelled", SyncState.Idle);
         }
@@ -63,138 +62,53 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
 
     private async Task SyncAccountInternalAsync(OneDriveAccount account, string token, CancellationToken ct)
     {
-        string localBasePath = account.LocalSyncPath!.Value;
-
         var driveState = await driveStateRepository.GetByAccountIdAsync(account.Id, ct)
                          ?? new DriveStateEntity { AccountId = account.Id };
 
         driveState.LastSyncStartedAt = DateTimeOffset.UtcNow;
-        driveState.DeltaLink = null;
+        driveState.DeltaLink         = null;
         await driveStateRepository.UpsertAsync(driveState, ct);
 
-        var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct);
+        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(
+            account,
+            token,
+            async conflict =>
+            {
+                await syncRepository.AddConflictAsync(conflict);
+                ConflictDetected?.Invoke(this, conflict);
+            },
+            ct);
 
-        if(rules.Count == 0)
+        if(enumerationResult.HadNoRules)
         {
-            Serilog.Log.Information("[SyncService] No sync rules configured for {Email} — nothing to sync", account.Email);
             RaiseProgress(account.Id.Id, 0, 0, "No folders selected", SyncState.Idle);
             return;
         }
 
-        var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct);
-        var driveId = await graphService.GetDriveIdAsync(token, ct);
-
-        RaiseProgress(account.Id.Id, 0, 0, "Enumerating selected folders...", SyncState.Syncing);
-
-        var includeRules = rules.Where(r => r.RuleType == RuleType.Include).ToList();
-        var rootIncludeRules = includeRules
-            .Where(rule => !includeRules.Any(other => other.RemotePath != rule.RemotePath && rule.RemotePath.StartsWith(other.RemotePath + "/", StringComparison.OrdinalIgnoreCase)))
-            .ToList();
-
-        List<SyncJob> downloadJobs = [];
-        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach(var rule in rootIncludeRules)
-        {
-            if(ct.IsCancellationRequested)
-                break;
-
-            var folderId = rule.RemoteItemId
-                ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
-                ?? await graphService.GetFolderIdByPathAsync(token, driveId, rule.RemotePath, ct);
-
-            if(folderId is null)
-            {
-                Serilog.Log.Warning("[SyncService] Cannot resolve folder ID for rule path {Path} — skipping", rule.RemotePath);
-                continue;
-            }
-
-            if(folderId != rule.RemoteItemId)
-            {
-                Serilog.Log.Debug("[SyncService] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
-                await syncRuleRepository.UpsertAsync(account.Id, rule.RemotePath, RuleType.Include, folderId, ct);
-            }
-
-            Serilog.Log.Information("[SyncService] Enumerating {Path} for {Email}", rule.RemotePath, account.Email);
-            var items = await graphService.EnumerateFolderAsync(token, driveId, folderId, rule.RemotePath, ct);
-            Serilog.Log.Information("[SyncService] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
-
-            foreach(var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
-            {
-                seenRemoteIds.Add(item.Id);
-
-                if(!SyncRuleEvaluator.IsIncluded(item.RelativePath ?? item.Name, rules))
-                    continue;
-
-                if(item.IsFolder)
-                {
-                    await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, localBasePath, syncedItems, ct);
-                    continue;
-                }
-
-                string localPath = BuildLocalPath(localBasePath, (item.RelativePath ?? item.Name).TrimStart('/'));
-
-                syncedItems.TryGetValue(item.Id, out var knownItem);
-
-                if(knownItem?.ETag is not null && knownItem.ETag == item.ETag && File.Exists(localPath))
-                {
-                    Serilog.Log.Debug("[SyncService] ETag match — skipping unchanged file {Path}", item.RelativePath);
-                    continue;
-                }
-
-                if(knownItem is not null && File.Exists(localPath))
-                {
-                    var localModified = new DateTimeOffset(new FileInfo(localPath).LastWriteTimeUtc, TimeSpan.Zero);
-                    bool isConflict = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
-
-                    if(isConflict)
-                    {
-                        var conflict = BuildConflict(account, item, localPath, localModified);
-                        await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, ct);
-                        continue;
-                    }
-                }
-                else if(knownItem is null && File.Exists(localPath))
-                {
-                    Serilog.Log.Debug("[SyncService] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
-                    var phantomItem = BuildSyncedItem(account.Id, item, item.RelativePath ?? item.Name, localPath);
-                    await syncedItemRepository.UpsertAsync(phantomItem, ct);
-                    syncedItems[item.Id] = phantomItem;
-                    continue;
-                }
-
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
-            }
-        }
-
         RaiseProgress(account.Id.Id, 0, 0, "Detecting remote deletions...", SyncState.Syncing);
-        await DetectRemoteDeletionsAsync(account, syncedItems, seenRemoteIds, rules, ct);
+        await dependencies.RemoteDeletionDetector.DetectAndApplyAsync(account.Id, enumerationResult.SyncedItems, enumerationResult.SeenRemoteIds, enumerationResult.Rules, ct);
 
         RaiseProgress(account.Id.Id, 0, 0, "Detecting local changes...", SyncState.Syncing);
-        await DetectAndEnqueueLocalDeletesAsync(account, token, syncedItems, ct);
+        await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, token, enumerationResult.SyncedItems, ct);
 
-        var localPathLookup = syncedItems.Values.ToDictionary(i => i.LocalPath, StringComparer.OrdinalIgnoreCase);
-        var uploadJobs = localChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, localBasePath, rules, localPathLookup);
+        var localPathLookup = enumerationResult.SyncedItems.Values.ToDictionary(i => i.LocalPath, StringComparer.OrdinalIgnoreCase);
+        var uploadJobs      = dependencies.LocalChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, account.LocalSyncPath!.Value, enumerationResult.Rules, localPathLookup);
 
-        var allJobs = new List<SyncJob>(downloadJobs.Count + uploadJobs.Count);
-        allJobs.AddRange(downloadJobs);
+        var allJobs = new List<SyncJob>(enumerationResult.DownloadJobs.Count + uploadJobs.Count);
+        allJobs.AddRange(enumerationResult.DownloadJobs);
         allJobs.AddRange(uploadJobs);
 
         if(allJobs.Count > 0)
         {
             RaiseProgress(account.Id.Id, 0, allJobs.Count, $"Syncing {allJobs.Count} file(s)...", SyncState.Syncing);
-            await ExecuteJobsAsync(account, token, allJobs, syncedItems, ct);
+            await dependencies.JobExecutor.ExecuteAsync(
+                account,
+                token,
+                allJobs,
+                enumerationResult.SyncedItems,
+                args => SyncProgressChanged?.Invoke(this, args),
+                args => JobCompleted?.Invoke(this, args),
+                ct);
         }
         else
         {
@@ -212,204 +126,6 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
 
         Serilog.Log.Information("[SyncService] Sync complete for {Email}", account.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Sync complete", SyncState.Idle);
-    }
-
-    private async Task DetectRemoteDeletionsAsync(OneDriveAccount account, Dictionary<string, SyncedItemEntity> syncedItems, HashSet<string> seenRemoteIds, List<SyncRuleEntity> rules, CancellationToken ct)
-    {
-        foreach(var (remoteId, knownItem) in syncedItems.ToList())
-        {
-            if(ct.IsCancellationRequested)
-                break;
-
-            if(!SyncRuleEvaluator.IsIncluded(knownItem.RemotePath, rules))
-                continue;
-
-            if(seenRemoteIds.Contains(remoteId))
-                continue;
-
-            Serilog.Log.Information("[SyncService] Remote item no longer present — treating as deleted: {Path}", knownItem.RemotePath);
-            var pseudoDeletedItem = new DeltaItem(remoteId, string.Empty, knownItem.RemotePath, knownItem.RemoteParentId, knownItem.IsFolder, IsDeleted: true, 0L, null, null);
-            await HandleRemoteDeleteAsync(account.Id, pseudoDeletedItem, syncedItems, ct);
-        }
-    }
-
-    private async Task HandleRemoteDeleteAsync(AccountId accountId, DeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
-    {
-        if(!syncedItems.TryGetValue(item.Id, out var knownItem))
-            return;
-
-        string localPath = knownItem.LocalPath;
-
-        if(knownItem.IsFolder)
-        {
-            if(Directory.Exists(localPath))
-            {
-                Serilog.Log.Information("[SyncService] Remote folder deleted — removing local: {Path}", localPath);
-                Directory.Delete(localPath, recursive: true);
-            }
-        }
-        else
-        {
-            if(File.Exists(localPath))
-            {
-                Serilog.Log.Information("[SyncService] Remote file deleted — removing local: {Path}", localPath);
-                File.Delete(localPath);
-            }
-        }
-
-        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
-        syncedItems.Remove(item.Id);
-    }
-
-    private async Task HandleFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localBasePath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
-    {
-        string localPath = BuildLocalPath(localBasePath, remotePath.TrimStart('/'));
-        _ = Directory.CreateDirectory(localPath);
-
-        var entity = BuildSyncedItem(accountId, item, remotePath, localPath);
-        await syncedItemRepository.UpsertAsync(entity, ct);
-        syncedItems[item.Id] = entity;
-    }
-
-    private async Task HandleConflictAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, SyncConflict conflict, List<SyncJob> downloadJobs, CancellationToken ct)
-    {
-        await syncRepository.AddConflictAsync(conflict);
-        ConflictDetected?.Invoke(this, conflict);
-
-        var outcome = ConflictResolver.Resolve(account.ConflictPolicy, localModified, item.LastModified ?? DateTimeOffset.MinValue);
-
-        switch(outcome)
-        {
-            case ConflictOutcome.Skip:
-                break;
-
-            case ConflictOutcome.UseRemote:
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
-                break;
-
-            case ConflictOutcome.UseLocal:
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Upload,
-                    FileSize       = new FileInfo(localPath).Length,
-                    RemoteModified = localModified
-                });
-                break;
-
-            case ConflictOutcome.KeepBoth:
-                string newName = ConflictResolver.MakeKeepBothName(localPath, localModified);
-                File.Move(localPath, newName);
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
-                break;
-        }
-    }
-
-    private async Task DetectAndEnqueueLocalDeletesAsync(OneDriveAccount account, string token, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
-    {
-        foreach(var (remoteId, knownItem) in syncedItems)
-        {
-            if(knownItem.IsFolder) continue;
-            if(ct.IsCancellationRequested) break;
-            if(File.Exists(knownItem.LocalPath)) continue;
-
-            Serilog.Log.Information("[SyncService] Local file deleted — removing remote: {Path}", knownItem.RemotePath);
-
-            try
-            {
-                await graphService.DeleteItemAsync(token, remoteId, ct);
-                await syncedItemRepository.DeleteByRemoteIdAsync(account.Id, knownItem.RemoteItemId, ct);
-            }
-            catch(Exception ex)
-            {
-                Serilog.Log.Error(ex, "[SyncService] Failed to delete remote item {RemoteId}: {Error}", remoteId, ex.Message);
-            }
-        }
-    }
-
-    private async Task ExecuteJobsAsync(OneDriveAccount account, string token, List<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
-    {
-        await syncRepository.EnqueueJobsAsync(jobs);
-
-        var successfulJobs = new System.Collections.Concurrent.ConcurrentBag<SyncJob>();
-
-        await parallelDownloadPipeline.RunAsync(
-            jobs,
-            token,
-            args => SyncProgressChanged?.Invoke(this, args),
-            args =>
-            {
-                if(args.Job.State == SyncJobState.Completed)
-                    successfulJobs.Add(args.Job);
-
-                JobCompleted?.Invoke(this, args);
-            },
-            account.Id.Id,
-            string.Empty,
-            ct: ct);
-
-        foreach(var job in successfulJobs)
-        {
-            if(job.Direction == SyncDirection.Download)
-            {
-                var remotePath = NormaliseRemotePath(job.RelativePath);
-                var entity = new SyncedItemEntity
-                {
-                    AccountId        = account.Id,
-                    RemoteItemId     = new OneDriveItemId(job.RemoteItemId),
-                    RemoteParentId   = string.Empty,
-                    RemotePath       = remotePath,
-                    LocalPath        = job.LocalPath,
-                    IsFolder         = false,
-                    RemoteModifiedAt = job.RemoteModified
-                };
-                await syncedItemRepository.UpsertAsync(entity, ct);
-                syncedItems[job.RemoteItemId] = entity;
-            }
-            else if(job.Direction == SyncDirection.Upload && job.UploadedRemoteItemId is not null)
-            {
-                var remotePath = NormaliseRemotePath(job.RelativePath);
-                var localModified = new DateTimeOffset(new FileInfo(job.LocalPath).LastWriteTimeUtc, TimeSpan.Zero);
-                var entity = new SyncedItemEntity
-                {
-                    AccountId        = account.Id,
-                    RemoteItemId     = new OneDriveItemId(job.UploadedRemoteItemId),
-                    RemoteParentId   = string.Empty,
-                    RemotePath       = remotePath,
-                    LocalPath        = job.LocalPath,
-                    IsFolder         = false,
-                    RemoteModifiedAt = localModified
-                };
-                await syncedItemRepository.UpsertAsync(entity, ct);
-                syncedItems[job.UploadedRemoteItemId] = entity;
-            }
-        }
     }
 
     private async Task ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accessToken, CancellationToken ct)
@@ -430,43 +146,6 @@ public sealed class SyncService(IAuthService authService, IGraphService graphSer
                 break;
         }
     }
-
-    private static string? TryResolveFromSyncedItems(Dictionary<string, SyncedItemEntity> syncedItems, string remotePath)
-        => syncedItems.Values.FirstOrDefault(i => i.IsFolder && string.Equals(i.RemotePath, remotePath, StringComparison.OrdinalIgnoreCase))?.RemoteItemId.Id;
-
-    private static SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
-        => new()
-        {
-            AccountId      = account.Id.Id,
-            FolderId       = string.Empty,
-            RemoteItemId   = item.Id,
-            RelativePath   = item.RelativePath ?? item.Name,
-            LocalPath      = localPath,
-            LocalModified  = localModified,
-            RemoteModified = item.LastModified ?? DateTimeOffset.MinValue,
-            LocalSize      = new FileInfo(localPath).Length,
-            RemoteSize     = item.Size
-        };
-
-    private static SyncedItemEntity BuildSyncedItem(AccountId accountId, DeltaItem item, string remotePath, string localPath)
-        => new()
-        {
-            AccountId        = accountId,
-            RemoteItemId     = new OneDriveItemId(item.Id),
-            RemoteParentId   = item.ParentId ?? string.Empty,
-            RemotePath       = remotePath,
-            LocalPath        = localPath,
-            IsFolder         = item.IsFolder,
-            RemoteModifiedAt = item.LastModified ?? DateTimeOffset.MinValue,
-            ETag             = item.ETag,
-            CTag             = item.CTag
-        };
-
-    private static string NormaliseRemotePath(string? relativePath)
-        => string.IsNullOrEmpty(relativePath) ? "/" : $"/{relativePath.TrimStart('/')}";
-
-    private static string BuildLocalPath(string localBasePath, string relativePath)
-        => Path.Combine(localBasePath, relativePath.Replace('/', Path.DirectorySeparatorChar));
 
     private void RaiseProgress(string accountId, int completed, int total, string currentFile, SyncState syncState)
         => SyncProgressChanged?.Invoke(this, new SyncProgressEventArgs(accountId, string.Empty, completed, total, currentFile, syncState));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
@@ -1,0 +1,7 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Groups the five sync-pass collaborators injected into <see cref="SyncService"/>
+/// to keep its constructor within the parameter-count guideline.
+/// </summary>
+public sealed record SyncServiceDependencies(IRemoteFolderEnumerator RemoteFolderEnumerator, IRemoteDeletionDetector RemoteDeletionDetector, ILocalDeletionDetector LocalDeletionDetector, ILocalChangeDetector LocalChangeDetector, ISyncJobExecutor JobExecutor);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -38,6 +38,11 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();
         _ = services.AddSingleton<IUploadService, UploadService>();
         _ = services.AddSingleton<ILocalChangeDetector, LocalChangeDetector>();
+        _ = services.AddSingleton<IRemoteFolderEnumerator, RemoteFolderEnumerator>();
+        _ = services.AddSingleton<IRemoteDeletionDetector, RemoteDeletionDetector>();
+        _ = services.AddSingleton<ILocalDeletionDetector, LocalDeletionDetector>();
+        _ = services.AddSingleton<ISyncJobExecutor, SyncJobExecutor>();
+        _ = services.AddSingleton<SyncServiceDependencies>();
         _ = services.AddSingleton<ISyncService, SyncService>();
         _ = services.AddSingleton<ISyncScheduler, SyncScheduler>();
         _ = services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();


### PR DESCRIPTION
…borators

SyncService was a 473-line God class with 10 constructor deps handling enumeration, deletion detection, conflict resolution, job execution, progress reporting, and state recording — none testable in isolation.

Extracted four focused services:
- RemoteFolderEnumerator — rule loading, folder ID resolution, ETag/ conflict/phantom-item logic, download job construction
- RemoteDeletionDetector — cross-references seenRemoteIds, deletes local
- LocalDeletionDetector — propagates local deletions to Graph API
- SyncJobExecutor — enqueues, runs pipeline, records completed state

SyncServiceDependencies groups the five sync-pass collaborators so SyncService's constructor stays at 7 params (down from 10). SyncedItemEntityFactory centralises entity construction.

SyncService reduced to ~140 lines of pure orchestration. Each extracted class covered by a dedicated Given* test class (35 new tests).

# Summary

ecompose SyncService into SRP collaborators

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

N/A

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

<!-- e.g., libs/MyLib, apps/MyApp, web/Api -->

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.
