### PR TITLE
fix(onedrive-sync-client): eliminate SQL injection and unsafe Path.Co…

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRuleRepositoryTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRuleRepositoryTests.cs
@@ -174,6 +174,32 @@ public sealed class GivenASyncRuleRepository : IDisposable
         remaining.Count.ShouldBe(1);
     }
 
+    [Fact]
+    public async Task when_upsert_is_called_with_null_remote_item_id_then_no_exception_is_thrown()
+    {
+        await SeedAccountAsync();
+        var repository = new SyncRuleRepository(_factory);
+
+        var act = async () => await repository.UpsertAsync(new AccountId(AccountIdString), "/Photos", RuleType.Include, null, TestContext.Current.CancellationToken);
+
+        await act.ShouldNotThrowAsync();
+    }
+
+    [Fact]
+    public async Task when_delete_child_rules_is_called_and_no_children_exist_then_parent_rule_is_unchanged()
+    {
+        await SeedAccountAsync();
+        _seedingContext.SyncRules.Add(new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = "/Photos", RuleType = RuleType.Include });
+        await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = new SyncRuleRepository(_factory);
+        await repository.DeleteChildRulesAsync(new AccountId(AccountIdString), "/Photos", TestContext.Current.CancellationToken);
+
+        var rules = await _seedingContext.SyncRules.AsNoTracking().Where(r => r.AccountId == new AccountId(AccountIdString)).ToListAsync(TestContext.Current.CancellationToken);
+        rules.Count.ShouldBe(1);
+        rules[0].RemotePath.ShouldBe("/Photos");
+    }
+
     private async Task SeedAccountAsync(string accountId = AccountIdString)
     {
         if(await _seedingContext.Accounts.AnyAsync(a => a.Id == new AccountId(accountId), TestContext.Current.CancellationToken))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
@@ -344,4 +344,32 @@ public sealed class GivenALocalChangeDetector
 
         jobs.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void when_include_rule_has_multi_level_remote_path_then_local_path_starts_with_base_path()
+    {
+        var mockFs = new MockFileSystem();
+        mockFs.AddFile($"{BasePath}/Documents/2024/report.txt", new MockFileData("data"));
+        var sut = CreateSut(mockFs);
+        var rules = new[] { Rule("/Documents/2024", RuleType.Include) };
+
+        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
+
+        jobs.Count.ShouldBe(1);
+        jobs[0].LocalPath.ShouldStartWith(BasePath);
+    }
+
+    [Fact]
+    public void when_include_rule_has_multi_level_remote_path_then_local_path_contains_full_relative_structure()
+    {
+        var mockFs = new MockFileSystem();
+        mockFs.AddFile($"{BasePath}/Documents/2024/report.txt", new MockFileData("data"));
+        var sut = CreateSut(mockFs);
+        var rules = new[] { Rule("/Documents/2024", RuleType.Include) };
+
+        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
+
+        jobs.Count.ShouldBe(1);
+        jobs[0].RelativePath.ShouldBe("Documents/2024/report.txt");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -267,4 +267,34 @@ public sealed class GivenARemoteFolderEnumerator
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");
     }
+
+    [Fact]
+    public async Task when_remote_file_item_has_nested_relative_path_then_download_job_local_path_starts_with_base_path()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
+        var sut = CreateSut(new MockFileSystem());
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.DownloadJobs.ShouldHaveSingleItem();
+        result.DownloadJobs[0].LocalPath.ShouldStartWith(BasePath);
+    }
+
+    [Fact]
+    public async Task when_remote_file_item_has_nested_relative_path_then_download_job_local_path_does_not_equal_base_path()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
+        var sut = CreateSut(new MockFileSystem());
+
+        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.DownloadJobs.ShouldHaveSingleItem();
+        result.DownloadJobs[0].LocalPath.ShouldNotBe(BasePath);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Models;
+using AStar.Dev.Utilities;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -149,9 +150,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private void OnOpenInFileManager(object? sender, FolderTreeNodeViewModel node)
     {
-        string path = fileSystem.Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            "OneDrive", node.Name);
+        string path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).CombinePath("OneDrive", node.Name);
 
         if (!fileSystem.Directory.Exists(path))
             return;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRuleRepository.cs
@@ -1,12 +1,19 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Models;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 
 public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory) : ISyncRuleRepository
 {
+    private const string UpsertSql =
+        "INSERT INTO SyncRules (AccountId, RemotePath, RuleType, RemoteItemId) " +
+        "VALUES (@accountId, @remotePath, @ruleType, @remoteItemId) " +
+        "ON CONFLICT(AccountId, RemotePath) DO UPDATE SET RuleType = excluded.RuleType, " +
+        "RemoteItemId = COALESCE(excluded.RemoteItemId, RemoteItemId)";
+
     public async Task<List<SyncRuleEntity>> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
@@ -20,9 +27,15 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-        _ = await db.Database.ExecuteSqlAsync(
-            $"INSERT INTO SyncRules (AccountId, RemotePath, RuleType, RemoteItemId) VALUES ({accountId.Id}, {remotePath}, {(int)ruleType}, {remoteItemId}) ON CONFLICT(AccountId, RemotePath) DO UPDATE SET RuleType = excluded.RuleType, RemoteItemId = COALESCE(excluded.RemoteItemId, RemoteItemId)",
-            cancellationToken);
+        List<object> parameters =
+        [
+            new SqliteParameter("@accountId",    accountId.Id),
+            new SqliteParameter("@remotePath",   remotePath),
+            new SqliteParameter("@ruleType",     (int)ruleType),
+            new SqliteParameter("@remoteItemId", (object?)remoteItemId ?? DBNull.Value),
+        ];
+
+        _ = await db.Database.ExecuteSqlRawAsync(UpsertSql, parameters, cancellationToken);
     }
 
     public async Task DeleteAsync(AccountId accountId, string remotePath, CancellationToken cancellationToken)
@@ -47,9 +60,9 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-        string pattern = parentPath + "/%";
-        _ = await db.Database.ExecuteSqlAsync(
-            $"DELETE FROM SyncRules WHERE AccountId = {accountId.Id} AND RemotePath LIKE {pattern}",
-            cancellationToken);
+        string prefix = parentPath + "/";
+        _ = await db.SyncRules
+                   .Where(r => r.AccountId == accountId && r.RemotePath.StartsWith(prefix))
+                   .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Models;
+using AStar.Dev.Utilities;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -94,8 +95,8 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDe
         }
     }
 
-    private string BuildLocalPath(string localBasePath, string remotePath)
-        => fileSystem.Path.Combine(localBasePath, remotePath.TrimStart('/').Replace('/', fileSystem.Path.DirectorySeparatorChar));
+    private static string BuildLocalPath(string localBasePath, string remotePath)
+        => localBasePath.CombinePath(remotePath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
 
     private static bool IsFileToSkip(IFileInfo info)
         => info.Attributes.HasFlag(FileAttributes.Hidden) || info.Name.StartsWith('.') || IsTemporaryFile(info.Extension);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Models;
+using AStar.Dev.Utilities;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -207,6 +208,6 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             RemoteSize     = item.Size
         };
 
-    private string BuildLocalPath(string localBasePath, string relativePath)
-        => fileSystem.Path.Combine(localBasePath, relativePath.Replace('/', fileSystem.Path.DirectorySeparatorChar));
+    private static string BuildLocalPath(string localBasePath, string relativePath)
+        => localBasePath.CombinePath(relativePath.Replace('/', Path.DirectorySeparatorChar));
 }


### PR DESCRIPTION
…mbine

UpsertAsync used ExecuteSqlAsync with FormattableString — replaced with ExecuteSqlRawAsync + explicit SqliteParameter objects to remove injection surface. DeleteChildRulesAsync drops raw LIKE SQL in favour of LINQ ExecuteDeleteAsync with StartsWith predicate.

Three BuildLocalPath / path-building call sites replaced CombinePath (AStar.Dev.Utilities) for Path.Combine to prevent silent base-path drop when a segment starts with a directory separator.

Closes #184
Closes #185
