### PR TITLE
fix(onedrive-sync-client): replace AuthResult with Result<AuthResult, AuthError>

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
@@ -190,7 +190,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         var repository   = Substitute.For<IAccountRepository>();
 
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success(AccessToken, AccountIdString, "Test User", "test@test.com"));
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, "Test User", "test@test.com"));
 
         graphService.GetDriveIdAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns(DriveId);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -1,0 +1,125 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnAccountFilesViewModelWithAuthFailure
+{
+    private const string AccountIdString = "account-1";
+
+    private static OneDriveAccount BuildAccount() => new()
+    {
+        Id          = new AccountId(AccountIdString),
+        DisplayName = "Test User",
+        Email       = "test@test.com"
+    };
+
+    private static AccountFilesViewModel BuildSut(IAuthService authService)
+    {
+        var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
+
+        return new AccountFilesViewModel(BuildAccount(), authService, Substitute.For<IGraphService>(), Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>());
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_fails_with_auth_failed_error_then_load_error_contains_the_failure_message()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("Token has expired"));
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.LoadError.ShouldBe("Token has expired");
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_fails_with_auth_failed_error_then_has_load_error_is_true()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("Token has expired"));
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.HasLoadError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_fails_with_auth_failed_error_then_root_folders_remain_empty()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("Token has expired"));
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.RootFolders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_is_cancelled_then_load_error_is_authentication_failed_fallback()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.LoadError.ShouldBe("Authentication failed.");
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_is_cancelled_then_has_load_error_is_true()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.HasLoadError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_fails_then_is_loading_is_false_after_return()
+    {
+        var authService = Substitute.For<IAuthService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("Error"));
+        var sut = BuildSut(authService);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.IsLoading.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_token_acquisition_succeeds_then_has_load_error_is_false()
+    {
+        var authService  = Substitute.For<IAuthService>();
+        var graphService = Substitute.For<IGraphService>();
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", AccountIdString, "Test User", "test@test.com"));
+        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("drive-1");
+        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
+        syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);
+
+        var sut = new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>());
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.HasLoadError.ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -12,14 +12,14 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
 
 public sealed class GivenAnAccountsViewModelWithACompletingWizard
 {
-    private const string AccessToken = "token-123";
+    private const string AccessToken  = "token-123";
     private const string AccountIdStr = "account-1";
-    private const string DisplayName = "Test User";
-    private const string Email = "test@outlook.com";
-    private const string FolderId1 = "f1";
-    private const string FolderName1 = "Documents";
-    private const string FolderId2 = "f2";
-    private const string FolderName2 = "Desktop";
+    private const string DisplayName  = "Test User";
+    private const string Email        = "test@outlook.com";
+    private const string FolderId1    = "f1";
+    private const string FolderName1  = "Documents";
+    private const string FolderId2    = "f2";
+    private const string FolderName2  = "Desktop";
 
     [Fact]
     public async Task when_wizard_completes_with_selected_folders_then_sync_rules_are_written_to_sync_rule_repository()
@@ -94,13 +94,13 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
 
     private static (IAuthService AuthService, IGraphService GraphService, IAccountRepository Repository, ISyncRuleRepository SyncRuleRepo) BuildMocks()
     {
-        var authService = Substitute.For<IAuthService>();
+        var authService  = Substitute.For<IAuthService>();
         var graphService = Substitute.For<IGraphService>();
-        var repository = Substitute.For<IAccountRepository>();
+        var repository   = Substitute.For<IAccountRepository>();
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
 
         authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success(AccessToken, AccountIdStr, DisplayName, Email));
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, DisplayName, Email));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(FolderId1, FolderName1), new DriveFolder(FolderId2, FolderName2)]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
@@ -1,113 +1,147 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Auth;
 
-public sealed class AuthResultTests
+public sealed class GivenAnAuthResultFactory
 {
+    private const string AccessToken  = "access-token-abc123";
+    private const string AccountId    = "account-123";
+    private const string DisplayName  = "Jason Smith";
+    private const string Email        = "jason@outlook.com";
+    private const string ErrorMessage = "Authentication failed: Invalid credentials";
+
     [Fact]
-    public void Success_ShouldCreateResultWithCorrectProperties()
+    public void when_success_is_called_then_result_is_ok() =>
+        AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email)
+            .ShouldBeOfType<Result<AuthResult, AuthError>.Ok>();
+
+    [Fact]
+    public void when_success_is_called_then_ok_value_has_correct_access_token()
     {
-        string accessToken = "access-token-abc123";
-        string accountId = "account-123";
-        string displayName = "Jason Smith";
-        string email = "jason@outlook.com";
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
 
-        var result = AuthResult.Success(accessToken, accountId, displayName, email);
-
-        result.IsSuccess.ShouldBeTrue();
-        result.IsCancelled.ShouldBeFalse();
-        result.AccessToken.ShouldBe(accessToken);
-        result.AccountId.ShouldBe(accountId);
-        result.DisplayName.ShouldBe(displayName);
-        result.Email.ShouldBe(email);
-        result.ErrorMessage.ShouldBeNull();
+        result.Value.AccessToken.ShouldBe(AccessToken);
     }
 
     [Fact]
-    public void Cancelled_ShouldCreateCancelledResult()
+    public void when_success_is_called_then_ok_value_has_correct_account_id()
     {
-        var result = AuthResult.Cancelled;
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
 
-        result.IsCancelled.ShouldBeTrue();
-        result.IsSuccess.ShouldBeFalse();
-        result.AccessToken.ShouldBeNull();
-        result.AccountId.ShouldBeNull();
-        result.DisplayName.ShouldBeNull();
-        result.Email.ShouldBeNull();
-        result.ErrorMessage.ShouldBeNull();
+        result.Value.AccountId.ShouldBe(AccountId);
     }
 
     [Fact]
-    public void Failure_ShouldCreateFailureResultWithErrorMessage()
+    public void when_success_is_called_then_ok_value_has_correct_display_name()
     {
-        string errorMessage = "Authentication failed: Invalid credentials";
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
 
-        var result = AuthResult.Failure(errorMessage);
+        result.Value.DisplayName.ShouldBe(DisplayName);
+    }
 
-        result.IsSuccess.ShouldBeFalse();
-        result.IsCancelled.ShouldBeFalse();
-        result.ErrorMessage.ShouldBe(errorMessage);
-        result.AccessToken.ShouldBeNull();
-        result.AccountId.ShouldBeNull();
-        result.DisplayName.ShouldBeNull();
-        result.Email.ShouldBeNull();
+    [Fact]
+    public void when_success_is_called_then_ok_value_has_correct_email()
+    {
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+
+        result.Value.Email.ShouldBe(Email);
+    }
+
+    [Fact]
+    public void when_cancelled_is_called_then_result_is_error() =>
+        AuthResultFactory.Cancelled()
+            .ShouldBeOfType<Result<AuthResult, AuthError>.Error>();
+
+    [Fact]
+    public void when_cancelled_is_called_then_error_reason_is_auth_cancelled_error()
+    {
+        var result = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Cancelled();
+
+        result.Reason.ShouldBeOfType<AuthCancelledError>();
+    }
+
+    [Fact]
+    public void when_failure_is_called_then_result_is_error() =>
+        AuthResultFactory.Failure(ErrorMessage)
+            .ShouldBeOfType<Result<AuthResult, AuthError>.Error>();
+
+    [Fact]
+    public void when_failure_is_called_then_error_reason_is_auth_failed_error()
+    {
+        var result = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Failure(ErrorMessage);
+
+        result.Reason.ShouldBeOfType<AuthFailedError>();
+    }
+
+    [Fact]
+    public void when_failure_is_called_then_auth_failed_error_carries_the_message()
+    {
+        var result     = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Failure(ErrorMessage);
+        var authFailed = (AuthFailedError)result.Reason;
+
+        authFailed.Message.ShouldBe(ErrorMessage);
     }
 
     [Theory]
     [InlineData("token-1", "account-1", "User One", "user1@outlook.com")]
     [InlineData("token-2", "account-2", "User Two", "user2@outlook.com")]
     [InlineData("token-3", "account-3", "User Three", "user3@outlook.com")]
-    public void Success_ShouldPreserveDifferentTokenAndAccountData(
-        string accessToken,
-        string accountId,
-        string displayName,
-        string email)
+    public void when_success_is_called_then_all_token_and_account_data_are_preserved(string accessToken, string accountId, string displayName, string email)
     {
-        var result = AuthResult.Success(accessToken, accountId, displayName, email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(accessToken, accountId, displayName, email);
 
-        result.AccessToken.ShouldBe(accessToken);
-        result.AccountId.ShouldBe(accountId);
-        result.DisplayName.ShouldBe(displayName);
-        result.Email.ShouldBe(email);
+        result.Value.AccessToken.ShouldBe(accessToken);
+        result.Value.AccountId.ShouldBe(accountId);
+        result.Value.DisplayName.ShouldBe(displayName);
+        result.Value.Email.ShouldBe(email);
     }
 
     [Theory]
-    [InlineData("")]
     [InlineData("Simple error")]
     [InlineData("Authentication failed: Invalid credentials")]
     [InlineData("Network error: Connection timeout")]
-    public void Failure_ShouldPreserveDifferentErrorMessages(string errorMessage)
+    public void when_failure_is_called_then_error_message_is_preserved(string errorMessage)
     {
-        var result = AuthResult.Failure(errorMessage);
+        var result     = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Failure(errorMessage);
+        var authFailed = (AuthFailedError)result.Reason;
 
-        result.ErrorMessage.ShouldBe(errorMessage);
-        result.IsSuccess.ShouldBeFalse();
+        authFailed.Message.ShouldBe(errorMessage);
     }
 
     [Fact]
-    public void SuccessResult_ShouldNotBeEqual_ToFailureResult()
-    {
-        var successResult = AuthResult.Success("token", "account", "name", "email@test.com");
-        var failureResult = AuthResult.Failure("error message");
+    public void when_success_is_called_with_null_access_token_then_throws_argument_null_exception() =>
+        Should.Throw<ArgumentNullException>(() => AuthResultFactory.Success(null!, AccountId, DisplayName, Email));
 
-        successResult.IsSuccess.ShouldNotBe(failureResult.IsSuccess);
+    [Fact]
+    public void when_success_is_called_with_null_account_id_then_throws_argument_null_exception() =>
+        Should.Throw<ArgumentNullException>(() => AuthResultFactory.Success(AccessToken, null!, DisplayName, Email));
+
+    [Fact]
+    public void when_success_is_called_with_null_display_name_then_throws_argument_null_exception() =>
+        Should.Throw<ArgumentNullException>(() => AuthResultFactory.Success(AccessToken, AccountId, null!, Email));
+
+    [Fact]
+    public void when_success_is_called_with_null_email_then_throws_argument_null_exception() =>
+        Should.Throw<ArgumentNullException>(() => AuthResultFactory.Success(AccessToken, AccountId, DisplayName, null!));
+
+    [Fact]
+    public void when_success_and_failure_results_are_compared_then_they_are_different_subtypes()
+    {
+        var successResult = AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var failureResult = AuthResultFactory.Failure(ErrorMessage);
+
+        successResult.ShouldBeOfType<Result<AuthResult, AuthError>.Ok>();
+        failureResult.ShouldBeOfType<Result<AuthResult, AuthError>.Error>();
     }
 
     [Fact]
-    public void CancelledResult_ShouldNotBeEqual_ToFailureResult()
+    public void when_cancelled_and_failure_results_are_compared_then_their_error_reasons_differ()
     {
-        var cancelledResult = AuthResult.Cancelled;
-        var failureResult = AuthResult.Failure("error message");
+        var cancelledResult = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Cancelled();
+        var failureResult   = (Result<AuthResult, AuthError>.Error)AuthResultFactory.Failure(ErrorMessage);
 
-        cancelledResult.IsCancelled.ShouldNotBe(failureResult.IsCancelled);
-    }
-
-    [Fact]
-    public void SuccessResult_ShouldNotBeEqual_ToCancelledResult()
-    {
-        var successResult = AuthResult.Success("token", "account", "name", "email@test.com");
-        var cancelledResult = AuthResult.Cancelled;
-
-        successResult.IsSuccess.ShouldNotBe(cancelledResult.IsSuccess);
+        cancelledResult.Reason.ShouldBeOfType<AuthCancelledError>();
+        failureResult.Reason.ShouldBeOfType<AuthFailedError>();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -1,0 +1,84 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Models;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
+
+public sealed class GivenASyncServiceResolvingConflicts
+{
+    private readonly IAuthService            _authService         = Substitute.For<IAuthService>();
+    private readonly ISyncRepository         _syncRepository      = Substitute.For<ISyncRepository>();
+    private readonly IRemoteFolderEnumerator _remoteFolderEnumerator = Substitute.For<IRemoteFolderEnumerator>();
+    private readonly IRemoteDeletionDetector _remoteDeletionDetector = Substitute.For<IRemoteDeletionDetector>();
+    private readonly ILocalDeletionDetector  _localDeletionDetector  = Substitute.For<ILocalDeletionDetector>();
+    private readonly ILocalChangeDetector    _localChangeDetector    = Substitute.For<ILocalChangeDetector>();
+    private readonly ISyncJobExecutor        _syncJobExecutor        = Substitute.For<ISyncJobExecutor>();
+
+    private SyncService CreateSut()
+    {
+        var dependencies = new SyncServiceDependencies(
+            _remoteFolderEnumerator,
+            _remoteDeletionDetector,
+            _localDeletionDetector,
+            _localChangeDetector,
+            _syncJobExecutor);
+
+        return new SyncService(
+            _authService,
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<IDriveStateRepository>(),
+            _syncRepository,
+            Substitute.For<IHttpDownloader>(),
+            Substitute.For<IGraphService>(),
+            dependencies,
+            Substitute.For<IFileSystem>());
+    }
+
+    private static SyncConflict CreateConflict() => new()
+    {
+        Id             = Guid.NewGuid(),
+        AccountId      = "user-1",
+        LocalModified  = DateTimeOffset.UtcNow,
+        RemoteModified = DateTimeOffset.UtcNow.AddMinutes(-5),
+        State          = ConflictState.Pending
+    };
+
+    [Fact]
+    public async Task when_auth_succeeds_then_sync_repository_resolve_is_called()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+        var sut = CreateSut();
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+
+    [Fact]
+    public async Task when_auth_fails_with_auth_failed_error_then_sync_repository_resolve_is_not_called()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("Token refresh failed"));
+        var sut = CreateSut();
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+
+    [Fact]
+    public async Task when_auth_is_cancelled_then_sync_repository_resolve_is_not_called()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = CreateSut();
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -49,7 +49,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
 
     private void SetupAuthSuccess() =>
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
 
     private void SetupDeepSyncPrerequisites()
     {
@@ -74,7 +74,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             {
                 authCallOrder.Add("auth");
 
-                return Task.FromResult(AuthResult.Failure("fail"));
+                return Task.FromResult(AuthResultFactory.Failure("fail"));
             });
 
         var sut = CreateSut();
@@ -93,7 +93,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_sync_starts_then_authenticating_progress_has_syncing_state()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("fail"));
+            .Returns(AuthResultFactory.Failure("fail"));
 
         SyncState? capturedState = null;
         var sut = CreateSut();
@@ -109,11 +109,10 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_auth_fails_with_null_error_message_then_progress_message_is_auth_failed()
+    public async Task when_auth_returns_cancelled_result_then_progress_message_is_auth_failed()
     {
-        var authResult = new AuthResult(false, false, null, null, null, null, null);
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(authResult);
+            .Returns(AuthResultFactory.Cancelled());
 
         string? capturedMessage = null;
         var sut = CreateSut();
@@ -132,7 +131,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_auth_fails_with_error_message_then_that_message_appears_in_progress_with_error_state()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("Custom error message"));
+            .Returns(AuthResultFactory.Failure("Custom error message"));
 
         string? capturedMessage = null;
         SyncState? capturedState = null;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class SyncServiceTests
     public async Task when_sync_called_with_valid_account_then_auth_service_is_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns((DriveStateEntity?)null);
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
@@ -76,7 +76,7 @@ public sealed class SyncServiceTests
     public async Task when_auth_fails_then_error_progress_is_raised()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("Authentication failed"));
+            .Returns(AuthResultFactory.Failure("Authentication failed"));
 
         var service = BuildSut();
         var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
@@ -96,7 +96,7 @@ public sealed class SyncServiceTests
     public async Task when_local_sync_path_is_null_then_no_local_sync_path_progress_is_raised()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
 
         var service = BuildSut();
         var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com", LocalSyncPath = null };
@@ -116,7 +116,7 @@ public sealed class SyncServiceTests
     public async Task when_sync_called_then_sync_progress_changed_event_is_raised()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("fail"));
+            .Returns(AuthResultFactory.Failure("fail"));
 
         var service = BuildSut();
         var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
@@ -132,7 +132,7 @@ public sealed class SyncServiceTests
     public async Task when_resolve_conflict_called_with_valid_policy_then_sync_repository_resolve_is_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
 
         var service = BuildSut();
         var conflict = new SyncConflict
@@ -153,7 +153,7 @@ public sealed class SyncServiceTests
     public async Task when_resolve_conflict_auth_fails_then_sync_repository_resolve_is_not_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Failure("Auth failed"));
+            .Returns(AuthResultFactory.Failure("Auth failed"));
 
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };
@@ -171,7 +171,7 @@ public sealed class SyncServiceTests
     public async Task when_resolve_conflict_called_with_various_policies_then_policy_is_recorded(ConflictPolicy policy)
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
 
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -8,7 +8,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Onboarding;
 
 public sealed class GivenAnAddAccountWizardViewModel
 {
-    private readonly IAuthService _authService = Substitute.For<IAuthService>();
+    private readonly IAuthService  _authService  = Substitute.For<IAuthService>();
     private readonly IGraphService _graphService = Substitute.For<IGraphService>();
 
     private AddAccountWizardViewModel CreateSut() => new(_authService, _graphService);
@@ -16,7 +16,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     private async Task SignInAsync(AddAccountWizardViewModel sut)
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResult.Success("fake-token", "account-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("fake-token", "account-1", "Test User", "test@example.com"));
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
     }
@@ -265,5 +265,153 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
 
         sut.NextLabel.ShouldBe("Next");
+    }
+
+    [Fact]
+    public async Task when_sign_in_succeeds_then_is_signed_in_is_true()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.IsSignedIn.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_sign_in_succeeds_then_sign_in_status_text_contains_email()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInStatusText.ShouldContain("test@example.com");
+    }
+
+    [Fact]
+    public async Task when_sign_in_succeeds_then_sign_in_has_error_is_false()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInHasError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_sign_in_succeeds_then_confirmed_display_name_is_set()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.ConfirmedDisplayName.ShouldBe("Test User");
+    }
+
+    [Fact]
+    public async Task when_sign_in_succeeds_then_confirmed_email_is_set()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.ConfirmedEmail.ShouldBe("test@example.com");
+    }
+
+    [Fact]
+    public async Task when_sign_in_is_cancelled_then_is_signed_in_remains_false()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.IsSignedIn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_sign_in_is_cancelled_then_sign_in_status_text_is_sign_in_cancelled()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInStatusText.ShouldBe("Sign-in cancelled.");
+    }
+
+    [Fact]
+    public async Task when_sign_in_is_cancelled_then_sign_in_has_error_is_false()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Cancelled());
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInHasError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_sign_in_fails_then_sign_in_status_text_is_the_failure_message()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("MSAL token request failed"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInStatusText.ShouldBe("MSAL token request failed");
+    }
+
+    [Fact]
+    public async Task when_sign_in_fails_then_sign_in_has_error_is_true()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("MSAL token request failed"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.SignInHasError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_sign_in_fails_then_is_signed_in_remains_false()
+    {
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Failure("MSAL token request failed"));
+        var sut = CreateSut();
+
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+
+        sut.IsSignedIn.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_sign_in_is_in_progress_and_open_browser_is_called_again_then_second_call_is_ignored()
+    {
+        var tcs = new TaskCompletionSource<AStar.Dev.Functional.Extensions.Result<AuthResult, AuthError>>();
+        _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => tcs.Task);
+        var sut = CreateSut();
+
+        var firstCall = sut.OpenBrowserCommand.ExecuteAsync(null);
+        await sut.OpenBrowserCommand.ExecuteAsync(null);
+        tcs.SetResult(AuthResultFactory.Success("token", "acc-1", "User", "user@example.com"));
+        await firstCall;
+
+        await _authService.Received(1).SignInInteractiveAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
@@ -67,14 +68,16 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         {
             var authResult = await _authService.AcquireTokenSilentAsync(_account.Id.Id);
 
-            if (!authResult.IsSuccess)
+            if(authResult is not Result<AuthResult, AuthError>.Ok ok)
             {
-                LoadError = authResult.ErrorMessage ?? "Authentication failed.";
+                LoadError = authResult is Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }
+                    ? failed.Message
+                    : "Authentication failed.";
                 HasLoadError = true;
                 return;
             }
 
-            _accessToken = authResult.AccessToken!;
+            _accessToken = ok.Value.AccessToken;
             _driveId = await _graphService.GetDriveIdAsync(_accessToken);
 
             var existingRules = await _syncRuleRepository.GetByAccountIdAsync(_account.Id, CancellationToken.None);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthError.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthError.cs
@@ -1,0 +1,10 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+
+/// <summary>Base type for all authentication error cases.</summary>
+public abstract record AuthError;
+
+/// <summary>The user cancelled the authentication flow.</summary>
+public sealed record AuthCancelledError : AuthError;
+
+/// <summary>Authentication failed with a descriptive message.</summary>
+public sealed record AuthFailedError(string Message) : AuthError;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
@@ -1,7 +1,7 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 /// <summary>
-/// Outcome of an authentication operation.
-/// Use the static factory methods rather than constructing directly.
+/// The success payload returned when authentication succeeds.
+/// Use <see cref="AuthResultFactory"/> to obtain a <see cref="AStar.Dev.Functional.Extensions.Result{TSuccess,TError}"/> wrapping this value.
 /// </summary>
-public sealed record AuthResult(bool IsSuccess, bool IsCancelled, string? AccessToken, string? AccountId, string? DisplayName, string? Email, string? ErrorMessage);
+public sealed record AuthResult(string AccessToken, string AccountId, string DisplayName, string Email);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
@@ -1,38 +1,24 @@
+using AStar.Dev.Functional.Extensions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
+/// <summary>Creates <see cref="Result{TSuccess,TError}"/> instances for authentication outcomes.</summary>
 public static class AuthResultFactory
 {
-    extension(AuthResult)
+    /// <summary>Returns a cancelled authentication result.</summary>
+    public static Result<AuthResult, AuthError> Cancelled() => new Result<AuthResult, AuthError>.Error(new AuthCancelledError());
+
+    /// <summary>Returns a failed authentication result with the given <paramref name="message"/>.</summary>
+    public static Result<AuthResult, AuthError> Failure(string message) => new Result<AuthResult, AuthError>.Error(new AuthFailedError(message));
+
+    /// <summary>Returns a successful authentication result containing the token and account details.</summary>
+    public static Result<AuthResult, AuthError> Success(string accessToken, string accountId, string displayName, string email)
     {
-        /// <summary>
-        /// Represents a cancelled authentication operation. Consumers can check for this result to handle cancellations gracefully, such as by showing a message to the user or simply returning to the previous state without an error.
-        /// </summary>
-        /// <returns>An AuthResult representing a cancelled authentication.</returns>
-        public static AuthResult Cancelled => new(false, true, null, null, null, null, null);
+        ArgumentNullException.ThrowIfNull(accessToken);
+        ArgumentNullException.ThrowIfNull(accountId);
+        ArgumentNullException.ThrowIfNull(displayName);
+        ArgumentNullException.ThrowIfNull(email);
 
-        /// <summary>
-        /// Creates an AuthResult representing a failed authentication attempt, with an optional error message describing the failure. Consumers can use this information to display error messages or take corrective actions.
-        /// </summary>
-        /// <param name="errorMessage">The error message describing the failure.</param>
-        /// <returns>An AuthResult representing the failure.</returns>
-        public static AuthResult Failure(string errorMessage) => new(false, false, null, null, null, null, errorMessage);
-
-        /// <summary>
-        /// Creates an AuthResult representing a successful authentication attempt, with the necessary tokens and user information.
-        /// </summary>
-        /// <param name="accessToken">The access token for the authenticated user.</param>
-        /// <param name="accountId">The account ID of the authenticated user.</param>
-        /// <param name="displayName">The display name of the authenticated user.</param>
-        /// <param name="email">The email address of the authenticated user.</param>
-        /// <returns>An AuthResult representing the success.</returns>
-        public static AuthResult Success(string accessToken, string accountId, string displayName, string email)
-        {
-            ArgumentNullException.ThrowIfNull(accessToken);
-            ArgumentNullException.ThrowIfNull(accountId);
-            ArgumentNullException.ThrowIfNull(displayName);
-            ArgumentNullException.ThrowIfNull(email);
-            
-            return new(true, false, accessToken, accountId, displayName, email, null);
-        }
+        return new Result<AuthResult, AuthError>.Ok(new AuthResult(accessToken, accountId, displayName, email));
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
@@ -29,7 +30,8 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
     private readonly ITokenCacheService _cacheService = cacheService;
     private bool _cacheRegistered;
 
-    public async Task<AuthResult> SignInInteractiveAsync(CancellationToken ct = default)
+    /// <inheritdoc />
+    public async Task<Result<AuthResult, AuthError>> SignInInteractiveAsync(CancellationToken ct = default)
     {
         await EnsureCacheRegisteredAsync();
 
@@ -45,23 +47,24 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         }
         catch (MsalClientException ex) when (ex.ErrorCode is MsalError.AuthenticationCanceledError or "authentication_canceled" or "user_canceled")
         {
-            return AuthResult.Cancelled;
+            return AuthResultFactory.Cancelled();
         }
         catch (OperationCanceledException)
         {
-            return AuthResult.Cancelled;
+            return AuthResultFactory.Cancelled();
         }
         catch (MsalException ex)
         {
-            return AuthResult.Failure($"Authentication failed: {ex.Message}");
+            return AuthResultFactory.Failure($"Authentication failed: {ex.Message}");
         }
         catch (Exception ex)
         {
-            return AuthResult.Failure($"Unexpected error during sign-in: {ex.Message}");
+            return AuthResultFactory.Failure($"Unexpected error during sign-in: {ex.Message}");
         }
     }
 
-    public async Task<AuthResult> AcquireTokenSilentAsync(string accountId, CancellationToken ct = default)
+    /// <inheritdoc />
+    public async Task<Result<AuthResult, AuthError>> AcquireTokenSilentAsync(string accountId, CancellationToken ct = default)
     {
         await EnsureCacheRegisteredAsync();
 
@@ -71,7 +74,7 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
             var account = accounts.FirstOrDefault(a => a.HomeAccountId.Identifier == accountId);
 
             if (account is null)
-                return AuthResult.Failure("Account not found in token cache.");
+                return AuthResultFactory.Failure("Account not found in token cache.");
 
             var result = await _app
                 .AcquireTokenSilent(entraIdOptions.Value.Scopes, account)
@@ -81,18 +84,19 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         }
         catch (MsalUiRequiredException)
         {
-            return AuthResult.Failure("Re-authentication required.");
+            return AuthResultFactory.Failure("Re-authentication required.");
         }
         catch (OperationCanceledException)
         {
-            return AuthResult.Cancelled;
+            return AuthResultFactory.Cancelled();
         }
         catch (MsalException ex)
         {
-            return AuthResult.Failure($"Token refresh failed: {ex.Message}");
+            return AuthResultFactory.Failure($"Token refresh failed: {ex.Message}");
         }
     }
 
+    /// <inheritdoc />
     public async Task SignOutAsync(string accountId, CancellationToken ct = default)
     {
         await EnsureCacheRegisteredAsync();
@@ -104,6 +108,7 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
             await _app.RemoveAsync(account);
     }
 
+    /// <inheritdoc />
     public async Task<IReadOnlyList<string>> GetCachedAccountIdsAsync()
     {
         await EnsureCacheRegisteredAsync();
@@ -124,7 +129,7 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
         _cacheRegistered = true;
     }
 
-    private static AuthResult BuildSuccess(AuthenticationResult result)
+    private static Result<AuthResult, AuthError> BuildSuccess(AuthenticationResult result)
     {
         string? displayName = result.Account.Username;
         string? email = result.Account.Username;
@@ -141,6 +146,6 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
                 email = emailClaim;
         }
 
-        return AuthResult.Success(accessToken: result.AccessToken, accountId: result.Account.HomeAccountId.Identifier, displayName: displayName, email: email);
+        return AuthResultFactory.Success(accessToken: result.AccessToken, accountId: result.Account.HomeAccountId.Identifier, displayName: displayName ?? result.Account.Username, email: email ?? result.Account.Username);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/IAuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/IAuthService.cs
@@ -1,9 +1,11 @@
+using AStar.Dev.Functional.Extensions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 /// <summary>
 /// Abstracts MSAL authentication for OneDrive personal accounts.
 /// All operations are cancellable and never throw — failures are
-/// returned as <see cref="AuthResult.Failure"/> values.
+/// returned as <see cref="Result{TSuccess,TError}"/> error values.
 /// </summary>
 public interface IAuthService
 {
@@ -11,14 +13,13 @@ public interface IAuthService
     /// Launches the system browser for interactive sign-in.
     /// Returns when the user completes or cancels authentication.
     /// </summary>
-    Task<AuthResult> SignInInteractiveAsync(CancellationToken ct = default);
+    Task<Result<AuthResult, AuthError>> SignInInteractiveAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Attempts a silent token refresh for an already-authenticated account.
-    /// Does NOT open a browser — returns <see cref="AuthResult.Failure"/> if
-    /// the token cannot be refreshed silently.
+    /// Does NOT open a browser — returns an error result if the token cannot be refreshed silently.
     /// </summary>
-    Task<AuthResult> AcquireTokenSilentAsync(string accountId, CancellationToken ct = default);
+    Task<Result<AuthResult, AuthError>> AcquireTokenSilentAsync(string accountId, CancellationToken ct = default);
 
     /// <summary>
     /// Removes the account from the MSAL cache and deletes cached tokens.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -21,9 +22,12 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
 
         var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct);
 
-        if(!authResult.IsSuccess)
+        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
         {
-            RaiseProgress(account.Id.Id, 0, 0, authResult.ErrorMessage ?? "Auth failed", SyncState.Error);
+            var errorMessage = authResult is Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }
+                ? failed.Message
+                : "Auth failed";
+            RaiseProgress(account.Id.Id, 0, 0, errorMessage, SyncState.Error);
             return;
         }
 
@@ -35,7 +39,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
 
         try
         {
-            await SyncAccountInternalAsync(account, authResult.AccessToken!, ct);
+            await SyncAccountInternalAsync(account, authOk.Value.AccessToken, ct);
         }
         catch(OperationCanceledException)
         {
@@ -52,12 +56,12 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     {
         var authResult = await authService.AcquireTokenSilentAsync(conflict.AccountId, ct);
 
-        if(!authResult.IsSuccess)
+        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.LocalModified, conflict.RemoteModified);
 
-        await ApplyConflictOutcomeAsync(conflict, outcome, authResult.AccessToken!, ct);
+        await ApplyConflictOutcomeAsync(conflict, outcome, authOk.Value.AccessToken, ct);
         await syncRepository.ResolveConflictAsync(conflict.Id, policy);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -133,26 +134,26 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
         {
             var result = await authService.SignInInteractiveAsync(_authCts.Token);
 
-            if(result.IsCancelled)
+            switch(result)
             {
-                SignInStatusText = "Sign-in cancelled.";
-                SignInHasError = false;
-            }
-            else if(!result.IsSuccess)
-            {
-                SignInStatusText = result.ErrorMessage ?? "Sign-in failed.";
-                SignInHasError = true;
-            }
-            else
-            {
-                _accountId = result.AccountId!;
-                _accessToken = result.AccessToken;
-                ConfirmedDisplayName = result.DisplayName ?? string.Empty;
-                ConfirmedEmail = result.Email ?? string.Empty;
-                IsSignedIn = true;
-                SignInStatusText = $"Signed in as {ConfirmedEmail}";
-                SignInHasError = false;
-                NextCommand.NotifyCanExecuteChanged();
+                case Result<AuthResult, AuthError>.Ok ok:
+                    _accountId = ok.Value.AccountId;
+                    _accessToken = ok.Value.AccessToken;
+                    ConfirmedDisplayName = ok.Value.DisplayName;
+                    ConfirmedEmail = ok.Value.Email;
+                    IsSignedIn = true;
+                    SignInStatusText = $"Signed in as {ConfirmedEmail}";
+                    SignInHasError = false;
+                    NextCommand.NotifyCanExecuteChanged();
+                    break;
+                case Result<AuthResult, AuthError>.Error { Reason: AuthCancelledError }:
+                    SignInStatusText = "Sign-in cancelled.";
+                    SignInHasError = false;
+                    break;
+                case Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }:
+                    SignInStatusText = failed.Message;
+                    SignInHasError = true;
+                    break;
             }
         }
         finally


### PR DESCRIPTION
## Summary

- Replaces raw `AuthResult` return type on `IAuthService` with `Result<AuthResult, AuthError>` from `AStar.Dev.Functional.Extensions`
- `AuthResult` is now a success-only payload `(AccessToken, AccountId, DisplayName, Email)`
- New `AuthError` discriminated union: `AuthCancelledError` and `AuthFailedError(string Message)`
- `AuthResultFactory` updated to produce `Result<AuthResult, AuthError>` instances
- All call sites (`AddAccountWizardViewModel`, `AccountFilesViewModel`, `SyncService`) updated to pattern-match on result subtype
- 42 new/updated unit tests covering all branching paths

Closes #220

## Test plan

- [ ] `dotnet build apps/desktop/AStar.Dev.OneDrive.Sync.Client` — zero errors
- [ ] `dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — 698 pass, 8 pre-existing `ThemeServiceTests` failures (Avalonia singleton ordering, unrelated)
- [ ] Verify `GivenAnAuthResultFactory` covers `Success`, `Failure`, `Cancelled`, and null guards
- [ ] Verify `GivenAnAddAccountWizardViewModel` covers all three `OpenBrowserAsync` branches
- [ ] Verify `GivenAnAccountFilesViewModelWithAuthFailure` covers auth-failure early return paths
- [ ] Verify `GivenASyncServiceResolvingConflicts` covers silent short-circuit on auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)