### PR TITLE
fix(onedrive-sync-client): replace nullable DriveState lookup with Option<T>

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -56,7 +56,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns((DriveStateEntity?)null);
+            .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
@@ -157,7 +157,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns((DriveStateEntity?)null);
+            .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<RemoteEnumerationResult>(new OperationCanceledException()));
 
@@ -184,7 +184,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns((DriveStateEntity?)null);
+            .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<RemoteEnumerationResult>(new InvalidOperationException("unexpected")));
 
@@ -211,7 +211,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     {
         SetupAuthSuccess();
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns((DriveStateEntity?)null);
+            .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -53,7 +54,7 @@ public sealed class SyncServiceTests
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns((DriveStateEntity?)null);
+            .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/DriveStateRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/DriveStateRepository.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -6,11 +7,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 
 public sealed class DriveStateRepository(IDbContextFactory<AppDbContext> dbFactory) : IDriveStateRepository
 {
-    public async Task<DriveStateEntity?> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken)
+    public async Task<Option<DriveStateEntity>> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var entity = await db.DriveStates.FirstOrDefaultAsync(d => d.AccountId == accountId, cancellationToken);
 
-        return await db.DriveStates.FirstOrDefaultAsync(d => d.AccountId == accountId, cancellationToken);
+        return entity is null ? Option.None<DriveStateEntity>() : new Option<DriveStateEntity>.Some(entity);
     }
 
     public async Task UpsertAsync(DriveStateEntity driveState, CancellationToken cancellationToken)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IDriveStateRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IDriveStateRepository.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 
@@ -5,8 +6,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 
 public interface IDriveStateRepository
 {
-    /// <summary>Returns the drive state for the specified account, or null if none exists.</summary>
-    Task<DriveStateEntity?> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken);
+    /// <summary>Returns the drive state for the specified account, or <see cref="Option{T}.None"/> if none exists.</summary>
+    Task<Option<DriveStateEntity>> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken);
 
     /// <summary>Inserts or updates the drive state for the specified account.</summary>
     Task UpsertAsync(DriveStateEntity driveState, CancellationToken cancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -68,7 +68,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     private async Task SyncAccountInternalAsync(OneDriveAccount account, string token, CancellationToken ct)
     {
         var driveState = await driveStateRepository.GetByAccountIdAsync(account.Id, ct)
-                         ?? new DriveStateEntity { AccountId = account.Id };
+                             .OrElseAsync(new DriveStateEntity { AccountId = account.Id });
 
         driveState.LastSyncStartedAt = DateTimeOffset.UtcNow;
         driveState.DeltaLink         = null;


### PR DESCRIPTION
## Summary

- `IDriveStateRepository.GetByAccountIdAsync` return type changed from `Task<DriveStateEntity?>` to `Task<Option<DriveStateEntity>>` — aligns with `IAccountRepository.GetByIdAsync` convention
- `DriveStateRepository` returns `Option.None<DriveStateEntity>()` / `new Option<DriveStateEntity>.Some(entity)` explicitly (required to satisfy nullable-reference-type analysis with `TreatWarningsAsErrors=true`)
- `SyncService.SyncAccountInternalAsync` uses `.OrElseAsync(new DriveStateEntity { AccountId = account.Id })` instead of the `??` null-coalescing operator
- Test mocks updated from `.Returns((DriveStateEntity?)null)` to `.Returns(Option.None<DriveStateEntity>())` in both `SyncServiceTests` and `GivenASyncServiceSyncingAnAccount`

Closes #218

## Test plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test --filter SyncService` — 26 passed, 0 failed
- [ ] Full test run — 698 passed, 8 pre-existing `ThemeServiceTests` failures (unrelated to this change, present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)