### PR TITLE
refactor(onedrive-sync-client): extract MapEntityToAccount to eliminate duplicate mapping (#216)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthServiceTests.cs
@@ -1,7 +1,0 @@
-namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Auth;
-
-// NOTE: AuthServiceTests deliberately left empty.
-// AuthService and TokenCacheService are sealed classes that cannot be mocked with NSubstitute.
-// AuthService requires MSAL infrastructure (token cache, browser) that is not available in unit tests.
-// Testing this service requires integration tests with a mock HTTP server or real browser.
-

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -309,6 +309,116 @@ public sealed class GivenASyncScheduler
         raisedId.ShouldBe(accountIdStr);
     }
 
+    [Fact]
+    public async Task when_trigger_account_by_id_then_all_entity_fields_mapped_to_account()
+    {
+        const string accountIdStr = "account-map-test";
+        var lastSyncedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
+        {
+            Id            = new AccountId(accountIdStr),
+            DisplayName   = "Map Test User",
+            Email         = "maptest@outlook.com",
+            AccentIndex   = 3,
+            IsActive      = true,
+            LastSyncedAt  = lastSyncedAt,
+            LocalSyncPath = LocalSyncPath.Restore("/sync/path"),
+            ConflictPolicy = ConflictPolicy.Ignore,
+        }));
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+
+        await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
+
+        await mockSyncService.Received(1).SyncAccountAsync(
+            Arg.Is<OneDriveAccount>(a =>
+                a.Id == new AccountId(accountIdStr) &&
+                a.DisplayName == "Map Test User" &&
+                a.Email == "maptest@outlook.com" &&
+                a.AccentIndex == 3 &&
+                a.IsActive == true &&
+                a.LastSyncedAt == lastSyncedAt &&
+                a.LocalSyncPath != null &&
+                a.ConflictPolicy == ConflictPolicy.Ignore),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_local_sync_path_empty_then_mapped_account_has_null_local_sync_path()
+    {
+        const string accountIdStr = "account-no-path";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
+        {
+            Id            = new AccountId(accountIdStr),
+            DisplayName   = "No Path User",
+            Email         = "nopath@outlook.com",
+            LocalSyncPath = LocalSyncPath.Restore(string.Empty),
+        }));
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+
+        await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
+
+        await mockSyncService.Received(1).SyncAccountAsync(
+            Arg.Is<OneDriveAccount>(a => a.LocalSyncPath == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_account_by_id_and_rules_have_include_entries_then_selected_folder_ids_populated()
+    {
+        const string accountIdStr = "account-with-rules";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
+        {
+            Id          = new AccountId(accountIdStr),
+            DisplayName = "Rules User",
+            Email       = "rules@outlook.com",
+        }));
+        var rulesRepo = Substitute.For<ISyncRuleRepository>();
+        rulesRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SyncRuleEntity>
+            {
+                new() { RuleType = RuleType.Include, RemoteItemId = "folder-1" },
+                new() { RuleType = RuleType.Include, RemoteItemId = "folder-2" },
+                new() { RuleType = RuleType.Exclude, RemoteItemId = "folder-3" },
+                new() { RuleType = RuleType.Include, RemoteItemId = null },
+            });
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository, rulesRepo);
+
+        await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
+
+        await mockSyncService.Received(1).SyncAccountAsync(
+            Arg.Is<OneDriveAccount>(a => a.SelectedFolderIds.Count == 2),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_trigger_now_and_entity_has_accent_index_then_mapped_account_has_correct_accent_index()
+    {
+        const string accountIdStr = "account-accent";
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new AccountEntity
+        {
+            Id          = new AccountId(accountIdStr),
+            DisplayName = "Accent User",
+            Email       = "accent@outlook.com",
+            AccentIndex = 5,
+            IsActive    = true,
+        }]);
+        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+
+        await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
+
+        await mockSyncService.Received(1).SyncAccountAsync(
+            Arg.Is<OneDriveAccount>(a => a.AccentIndex == 5 && a.IsActive == true),
+            Arg.Any<CancellationToken>());
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Models;
@@ -63,17 +64,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
             .TapAsync(async entity =>
             {
                 var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct);
-                var account = new OneDriveAccount
-                {
-                    Id                = entity.Id,
-                    DisplayName       = entity.DisplayName,
-                    Email             = entity.Email,
-                    LocalSyncPath     = entity.LocalSyncPath.Value.Length > 0 ? entity.LocalSyncPath : null,
-                    ConflictPolicy    = entity.ConflictPolicy,
-                    SelectedFolderIds = [.. rules.Where(r => r.RuleType == RuleType.Include && r.RemoteItemId is not null).Select(r => new OneDriveFolderId(r.RemoteItemId!))],
-                    LastSyncedAt      = entity.LastSyncedAt
-                };
-                await TriggerAccountAsync(account, ct);
+                await TriggerAccountAsync(MapEntityToAccount(entity, rules), ct);
             });
 
     /// <summary>
@@ -103,6 +94,19 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
     private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1;
 
+    private static OneDriveAccount MapEntityToAccount(AccountEntity entity, IReadOnlyList<SyncRuleEntity> rules) => new()
+    {
+        Id                = entity.Id,
+        DisplayName       = entity.DisplayName,
+        Email             = entity.Email,
+        AccentIndex       = entity.AccentIndex,
+        IsActive          = entity.IsActive,
+        LastSyncedAt      = entity.LastSyncedAt,
+        LocalSyncPath     = entity.LocalSyncPath.Value.Length > 0 ? entity.LocalSyncPath : null,
+        ConflictPolicy    = entity.ConflictPolicy,
+        SelectedFolderIds = [.. rules.Where(r => r.RuleType == RuleType.Include && r.RemoteItemId is not null).Select(r => new OneDriveFolderId(r.RemoteItemId!))]
+    };
+
     private async Task RunSyncPassAsync(CancellationToken ct)
     {
         if(Interlocked.Exchange(ref _runningFlag, 1) == 1)
@@ -114,17 +118,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
             foreach(var entity in entities.TakeWhile(_ => !ct.IsCancellationRequested))
             {
                 var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct).ConfigureAwait(false);
-                var account = new OneDriveAccount
-                {
-                    Id                = entity.Id,
-                    DisplayName       = entity.DisplayName,
-                    Email             = entity.Email,
-                    AccentIndex       = entity.AccentIndex,
-                    IsActive          = entity.IsActive,
-                    LocalSyncPath     = entity.LocalSyncPath.Value.Length > 0 ? entity.LocalSyncPath : null,
-                    ConflictPolicy    = entity.ConflictPolicy,
-                    SelectedFolderIds = [.. rules.Where(r => r.RuleType == RuleType.Include && r.RemoteItemId is not null).Select(r => new OneDriveFolderId(r.RemoteItemId!))]
-                };
+                var account = MapEntityToAccount(entity, rules);
 
                 SyncStarted?.Invoke(this, account.Id.Id);
                 try

--- a/docs/astar-dev-onedrive-sync-client/onedrive-review-20260430.md
+++ b/docs/astar-dev-onedrive-sync-client/onedrive-review-20260430.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-| Severity | Count |
-|---|---|
-| Blocker | 5 |
-| Critical | 11 |
-| Major | 28 |
-| Minor | 19 |
-| Trivial | 6 |
+| Severity  | Count  |
+| --------- | ------ |
+| Blocker   | 5      |
+| Critical  | 11     |
+| Major     | 28     |
+| Minor     | 19     |
+| Trivial   | 6      |
 | **Total** | **69** |
 
 **Overall verdict: Request Changes.** The codebase is structurally sound and well-tested in many areas, but it has a confirmed SQL injection risk (Blocker), duplicate repository registrations that would cause runtime `IDbContextFactory` contention, widespread missing `ConfigureAwait(false)` in infrastructure code, several `async void` event handlers without fire-and-forget safety, pervasive absence of XML docs on public API surfaces, significant technical-type folder organisation violations, multiple test classes using the wrong naming convention, and a suppressed compiler warning without documented justification.
@@ -17,7 +17,7 @@
 
 ## Blocker Issues
 
-- [ ] **[Data/Repositories/SyncRuleRepository.cs:24]** Blocker — `ExecuteSqlAsync` with string interpolation: the `$"INSERT INTO SyncRules ... VALUES ({accountId.Id}, {remotePath} ...)"` interpolation embeds raw user-supplied strings directly into SQL. Although EF Core's `ExecuteSqlAsync` with `$""` does use `FormattableString` parameterisation for the whole interpolated string, the `remotePath` value comes from `rule.RemotePath` which is user-supplied folder-path data from OneDrive; review carefully that all inputs are parameterised. `DeleteChildRulesAsync` at line 51 concatenates `string pattern = parentPath + "/%"` then passes it as an interpolated parameter — the concatenation happens outside the interpolation boundary, meaning EF Core correctly parameterises the already-concatenated string. Confirm EF Core treats every `{...}` hole in `ExecuteSqlAsync` as a `SqlParameter`. If the EF version pre-dates that guarantee, the call at line 24 is a full SQL injection. Fix: use `ExecuteSqlAsync` with separately declared `SqliteParameter` objects or switch to a strongly-typed LINQ expression (possible for upsert with `ExecuteUpdate` + `Add` pattern matching the other repositories).
+- [x] **[Data/Repositories/SyncRuleRepository.cs:24]** Blocker — `ExecuteSqlAsync` with string interpolation: the `$"INSERT INTO SyncRules ... VALUES ({accountId.Id}, {remotePath} ...)"` interpolation embeds raw user-supplied strings directly into SQL. Although EF Core's `ExecuteSqlAsync` with `$""` does use `FormattableString` parameterisation for the whole interpolated string, the `remotePath` value comes from `rule.RemotePath` which is user-supplied folder-path data from OneDrive; review carefully that all inputs are parameterised. `DeleteChildRulesAsync` at line 51 concatenates `string pattern = parentPath + "/%"` then passes it as an interpolated parameter — the concatenation happens outside the interpolation boundary, meaning EF Core correctly parameterises the already-concatenated string. Confirm EF Core treats every `{...}` hole in `ExecuteSqlAsync` as a `SqlParameter`. If the EF version pre-dates that guarantee, the call at line 24 is a full SQL injection. Fix: use `ExecuteSqlAsync` with separately declared `SqliteParameter` objects or switch to a strongly-typed LINQ expression (possible for upsert with `ExecuteUpdate` + `Add` pattern matching the other repositories).
 
 - [x] **[Data/PersistenceServiceExtensions.cs] + [Startup/ShellServiceExtensions.cs:28-32]** Blocker — All five repository interfaces (`IAccountRepository`, `ISyncRepository`, `IDriveStateRepository`, `ISyncRuleRepository`, `ISyncedItemRepository`) are registered **twice** as singletons: once in `AddPersistence()` (called from `App.axaml.cs:66`) and again in `AddShell()` (called from `App.axaml.cs:78`). Two competing singleton registrations for the same interface means the DI container resolves whichever was registered last; all consumers that received the first registration hold a different instance than those that received the second. This will cause data-consistency bugs that are extremely hard to trace. Fix: remove all repository registrations from `ShellServiceExtensions` — `AddPersistence` is the canonical location.
 
@@ -25,7 +25,7 @@
 
 - [x] **[App.axaml.cs:93]** Blocker — `Path.Combine(logDirectory, ApplicationMetadata.ApplicationLogName)` uses `Path.Combine` instead of the repo-mandated `CombinePath` extension from `AStar.Dev.Utilities`. `Path.Combine` can silently drop all preceding components if any argument begins with a directory separator; `CombinePath` guards against this. The `logDirectory` value is constructed correctly on line 84 using `CombinePath`, but the File sink path at line 93 reverts to the forbidden API. Fix: `logDirectory.CombinePath(ApplicationMetadata.ApplicationLogName)`.
 
-- [ ] **[Infrastructure/Sync/LocalChangeDetector.cs:43,97] + [Infrastructure/Sync/RemoteFolderEnumerator.cs:210] + [Accounts/AccountFilesViewModel.cs:151]** Blocker — `Path.Combine` used instead of `CombinePath` in multiple places throughout the sync engine: `LocalChangeDetector.BuildLocalPath` (line 97), `RemoteFolderEnumerator.BuildLocalPath` (line 210), and `AccountFilesViewModel.OnOpenInFileManager` (line 151). Each is a repo-rule violation that can silently produce wrong paths. Fix: replace all with the `CombinePath` extension.
+- [x] **[Infrastructure/Sync/LocalChangeDetector.cs:43,97] + [Infrastructure/Sync/RemoteFolderEnumerator.cs:210] + [Accounts/AccountFilesViewModel.cs:151]** Blocker — `Path.Combine` used instead of `CombinePath` in multiple places throughout the sync engine: `LocalChangeDetector.BuildLocalPath` (line 97), `RemoteFolderEnumerator.BuildLocalPath` (line 210), and `AccountFilesViewModel.OnOpenInFileManager` (line 151). Each is a repo-rule violation that can silently produce wrong paths. Fix: replace all with the `CombinePath` extension.
 
 ---
 
@@ -130,7 +130,7 @@ private async void OnTimerTickAsync(object? state)
 
 - [ ] **[Data/Repositories/AccountRepository.cs] + [SyncRuleRepository.cs]** Major — Repositories use manual null checks and nullable returns instead of `Option<T>` from `AStar.Dev.Functional.Extensions`. Fix: return `Option<T>` from single-item lookups (`GetByIdAsync`, `GetActiveAsync`, etc.).
 
-- [ ] **[Infrastructure/Authentication/AuthService.cs]** Major — `AuthService` returns raw nullable `AuthResult?` and uses manual null checks rather than `Result<AuthResult>` from `AStar.Dev.Functional.Extensions`. Fix: return `Result<AuthResult>` and propagate errors functionally.
+- [x] **[Infrastructure/Authentication/AuthService.cs]** Major — `AuthService` returns raw nullable `AuthResult?` and uses manual null checks rather than `Result<AuthResult>` from `AStar.Dev.Functional.Extensions`. Fix: return `Result<AuthResult>` and propagate errors functionally.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extracted `MapEntityToAccount(AccountEntity, IReadOnlyList<SyncRuleEntity>)` private static method in `SyncScheduler`
- Unified mapping covers all fields (`AccentIndex`, `IsActive`, `LastSyncedAt`) that were silently missing from one mapping site
- Both `TriggerAccountAsync(string)` and `RunSyncPassAsync` now delegate to the single method

## Test plan

- [ ] `when_trigger_account_by_id_then_all_entity_fields_mapped_to_account` — verifies all entity fields flow through
- [ ] `when_trigger_account_by_id_and_local_sync_path_empty_then_mapped_account_has_null_local_sync_path` — null path guard
- [ ] `when_trigger_account_by_id_and_rules_have_include_entries_then_selected_folder_ids_populated` — only Include rules with non-null RemoteItemId count
- [ ] `when_trigger_now_and_entity_has_accent_index_then_mapped_account_has_correct_accent_index` — verifies scheduled pass maps AccentIndex/IsActive
- [ ] All 27 `GivenASyncScheduler` tests pass; 8 pre-existing `ThemeServiceTests` failures unaffected

Closes #216 & #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)