### PR TITLE
fix(tests): apply correct naming conventions to test classes and methods (#215)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
@@ -1,14 +1,14 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 
-namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Conflicts;
 
-public sealed class ConflictResolverTests
+public sealed class GivenAConflictResolver
 {
     private static readonly MockFileSystem MockFs = new();
 
     [Fact]
-    public void Resolve_WithIgnorePolicy_ShouldReturnSkip()
+    public void when_resolving_with_ignore_policy_then_skip_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
@@ -19,7 +19,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLocalWinsPolicy_ShouldReturnUseLocal()
+    public void when_resolving_with_local_wins_policy_then_use_local_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = DateTimeOffset.UtcNow.AddHours(-1);
@@ -30,7 +30,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithRemoteWinsPolicy_ShouldReturnUseRemote()
+    public void when_resolving_with_remote_wins_policy_then_use_remote_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = DateTimeOffset.UtcNow.AddHours(-1);
@@ -41,7 +41,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithKeepBothPolicy_ShouldReturnKeepBoth()
+    public void when_resolving_with_keep_both_policy_then_keep_both_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-5);
@@ -52,7 +52,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_LocalIsNewer_ShouldReturnUseLocal()
+    public void when_resolving_with_last_write_wins_and_local_is_newer_then_use_local_is_returned()
     {
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var localModified = DateTimeOffset.UtcNow;
@@ -63,7 +63,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_RemoteIsNewer_ShouldReturnUseRemote()
+    public void when_resolving_with_last_write_wins_and_remote_is_newer_then_use_remote_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var remoteModified = DateTimeOffset.UtcNow;
@@ -74,7 +74,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_SameTimes_ShouldReturnUseLocal()
+    public void when_resolving_with_last_write_wins_and_same_times_then_use_local_is_returned()
     {
         var timestamp = DateTimeOffset.UtcNow;
 
@@ -84,7 +84,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_LocalJustOneSecondNewer_ShouldReturnUseLocal()
+    public void when_resolving_with_last_write_wins_and_local_is_one_second_newer_then_use_local_is_returned()
     {
         var remoteModified = DateTimeOffset.UtcNow;
         var localModified = remoteModified.AddSeconds(1);
@@ -95,7 +95,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_RemoteJustOneSecondNewer_ShouldReturnUseRemote()
+    public void when_resolving_with_last_write_wins_and_remote_is_one_second_newer_then_use_remote_is_returned()
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = localModified.AddSeconds(1);
@@ -106,7 +106,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void Resolve_WithLastWriteWins_OldTimestampsVsNewTimestamps_ShouldCompareCorrectly()
+    public void when_resolving_with_last_write_wins_and_old_vs_new_timestamps_then_comparison_is_correct()
     {
         var remoteModified = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var localModified = new DateTimeOffset(2025, 12, 31, 23, 59, 59, TimeSpan.Zero);
@@ -122,7 +122,7 @@ public sealed class ConflictResolverTests
     [InlineData(ConflictPolicy.RemoteWins)]
     [InlineData(ConflictPolicy.KeepBoth)]
     [InlineData(ConflictPolicy.LastWriteWins)]
-    public void Resolve_ShouldHandleAllPolicies(ConflictPolicy policy)
+    public void when_resolving_with_any_policy_then_a_valid_outcome_is_returned(ConflictPolicy policy)
     {
         var localModified = DateTimeOffset.UtcNow;
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-5);
@@ -138,7 +138,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_ShouldGenerateValidFilename()
+    public void when_making_keep_both_name_then_valid_filename_is_generated()
     {
         string localPath = "/home/jason/Documents/report.docx";
         var localModified = new DateTimeOffset(2024, 1, 15, 14, 32, 0, TimeSpan.Zero);
@@ -153,7 +153,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_WithPathContainingSpaces_ShouldPreserveExtension()
+    public void when_making_keep_both_name_with_spaces_in_path_then_extension_is_preserved()
     {
         string localPath = "/home/jason/My Documents/My Report.docx";
         var localModified = DateTimeOffset.UtcNow;
@@ -165,7 +165,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_WithFileHavingNoExtension_ShouldStillGenerateName()
+    public void when_making_keep_both_name_with_no_extension_then_name_is_still_generated()
     {
         string localPath = "/home/jason/Documents/README";
         var localModified = DateTimeOffset.UtcNow;
@@ -177,7 +177,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_WithMultipleDots_ShouldOnlyRemoveLastExtension()
+    public void when_making_keep_both_name_with_multiple_dots_then_only_last_extension_is_removed()
     {
         string localPath = "/home/jason/file.tar.gz";
         var localModified = DateTimeOffset.UtcNow;
@@ -189,7 +189,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_GeneratesIncreasinglyUniquePaths()
+    public void when_making_keep_both_name_with_different_times_then_unique_paths_are_generated()
     {
         string localPath = "/home/jason/Documents/report.docx";
         var time1 = new DateTimeOffset(2024, 1, 15, 14, 32, 0, TimeSpan.Zero);
@@ -204,7 +204,7 @@ public sealed class ConflictResolverTests
     }
 
     [Fact]
-    public void MakeKeepBothName_OutputPathIsOnSameDirectory()
+    public void when_making_keep_both_name_then_output_is_in_same_directory()
     {
         string localPath = "/home/jason/Documents/report.docx";
         var localModified = DateTimeOffset.UtcNow;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
@@ -7,10 +7,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
 
-public sealed class AccountRepositoryTests
+public sealed class GivenAnAccountRepository
 {
     [Fact]
-    public async Task GetAllAsync_WithNoAccounts_ShouldReturnEmptyList()
+    public async Task when_getting_all_with_no_accounts_then_empty_list_is_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -21,7 +21,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task GetAllAsync_WithSingleAccount_ShouldReturnAccount()
+    public async Task when_getting_all_with_single_account_then_account_is_returned()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -36,7 +36,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task GetAllAsync_ShouldReturnAccountsOrderedByEmail()
+    public async Task when_getting_all_then_accounts_are_ordered_by_email()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -56,7 +56,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task GetByIdAsync_WithExistingId_ShouldReturnSome()
+    public async Task when_getting_by_id_with_existing_id_then_some_is_returned()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -71,7 +71,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task GetByIdAsync_WithNonExistingId_ShouldReturnNone()
+    public async Task when_getting_by_id_with_non_existing_id_then_none_is_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -82,7 +82,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task UpsertAsync_WithNewAccount_ShouldInsert()
+    public async Task when_upserting_new_account_then_account_is_inserted()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -96,7 +96,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task UpsertAsync_WithExistingAccount_ShouldUpdate()
+    public async Task when_upserting_existing_account_then_account_is_updated()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -112,7 +112,7 @@ public sealed class AccountRepositoryTests
     }
 
     [Fact]
-    public async Task DeleteAsync_ShouldRemoveAccount()
+    public async Task when_deleting_account_then_account_is_removed()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -126,12 +126,11 @@ public sealed class AccountRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteDelete
         }
     }
 
     [Fact]
-    public async Task SetActiveAccountAsync_ShouldSetOneAccountActive()
+    public async Task when_setting_active_account_then_one_account_is_active()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new AccountRepository(factory);
@@ -147,7 +146,6 @@ public sealed class AccountRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 


### PR DESCRIPTION
## Summary

- Rename `ConflictResolverTests` → `GivenAConflictResolver` with all methods converted to `when_[action]_then_[outcome]` snake_case
- Rename `AccountRepositoryTests` → `GivenAnAccountRepository` with all methods converted to `when_[action]_then_[outcome]` snake_case
- Fix incorrect namespace on `GivenAConflictResolver` (`Services.Sync` → `Conflicts`)
- Remove redundant inline comments in `GivenAnAccountRepository`

Closes #215

## Test plan

- [x] `dotnet build` — 0 errors, 0 new warnings
- [x] `dotnet test` — 710 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)