### PR TITLE
fix(tests): correct SyncServiceTests namespace to match folder path

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
@@ -8,7 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 
-namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync;
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class SyncServiceTests
 {


### PR DESCRIPTION
## Summary
- `SyncServiceTests.cs` declared namespace `AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Services.Sync` but lives in `Infrastructure/Sync/`
- Corrected to `AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync`
- `GivenAConflictResolver.cs` namespace was already correct

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings (excluding pre-existing Avalonia obsolete warning)
- [x] `dotnet test` — 710 passed, 0 failed

Closes #214