### PR TITLE
feat(models): make SyncJob an immutable record with primary constructor

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
@@ -13,15 +13,8 @@ public sealed class GivenAnActivityItemViewModel
     private const string ErrorMessageValue = "Network timeout";
     private const long FileSizeValue = 2048L;
 
-    private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null) => new()
-    {
-        AccountId = AccountIdValue,
-        Direction = direction,
-        RelativePath = relativePath,
-        FileSize = FileSizeValue,
-        CompletedAt = completedAt,
-        ErrorMessage = errorMessage
-    };
+    private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null)
+        => SyncJobFactory.Create(accountId: AccountIdValue, folderId: "", remoteItemId: "", relativePath: relativePath, localPath: "", direction: direction, fileSize: FileSizeValue, remoteModified: default) with { CompletedAt = completedAt, ErrorMessage = errorMessage };
 
     private static SyncConflict BuildSyncConflict(string relativePath = RelativePathValue, DateTimeOffset? detectedAt = null) => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRepositoryTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRepositoryTests.cs
@@ -8,6 +8,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
 
 public sealed class SyncRepositoryTests
 {
+    private static SyncJob MinimalJob(string accountId = "user-1", string folderId = "", SyncJobState state = SyncJobState.Queued)
+        => SyncJobFactory.Create(accountId: accountId, folderId: folderId, remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default) with { State = state };
+
     [Fact]
     public async Task EnqueueJobsAsync_WithEmptyList_ShouldNotThrow()
     {
@@ -24,8 +27,8 @@ public sealed class SyncRepositoryTests
         var repository = new SyncRepository(factory);
         var jobs = new List<SyncJob>
         {
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", FolderId = "folder-1", State = SyncJobState.Queued },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", FolderId = "folder-2", State = SyncJobState.Queued }
+            MinimalJob(folderId: "folder-1"),
+            MinimalJob(folderId: "folder-2")
         };
 
         await repository.EnqueueJobsAsync(jobs);
@@ -51,9 +54,9 @@ public sealed class SyncRepositoryTests
         var repository = new SyncRepository(factory);
         var jobs = new List<SyncJob>
         {
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", FolderId = "folder-1", State = SyncJobState.Queued },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", FolderId = "folder-2", State = SyncJobState.Completed },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", FolderId = "folder-3", State = SyncJobState.Failed }
+            MinimalJob(folderId: "folder-1", state: SyncJobState.Queued),
+            MinimalJob(folderId: "folder-2", state: SyncJobState.Completed),
+            MinimalJob(folderId: "folder-3", state: SyncJobState.Failed)
         };
         await repository.EnqueueJobsAsync(jobs);
 
@@ -71,9 +74,9 @@ public sealed class SyncRepositoryTests
         var now = DateTimeOffset.UtcNow;
         var jobs = new List<SyncJob>
         {
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Queued, QueuedAt = now.AddSeconds(3) },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Queued, QueuedAt = now.AddSeconds(1) },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Queued, QueuedAt = now.AddSeconds(2) }
+            MinimalJob() with { QueuedAt = now.AddSeconds(3) },
+            MinimalJob() with { QueuedAt = now.AddSeconds(1) },
+            MinimalJob() with { QueuedAt = now.AddSeconds(2) }
         };
         await repository.EnqueueJobsAsync(jobs);
 
@@ -90,7 +93,7 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = new SyncJob { Id = jobId, AccountId = "user-1", State = SyncJobState.Queued };
+        var job = MinimalJob() with { Id = jobId };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -109,7 +112,7 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = new SyncJob { Id = jobId, AccountId = "user-1", State = SyncJobState.Queued };
+        var job = MinimalJob() with { Id = jobId };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -128,7 +131,7 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = new SyncJob { Id = jobId, AccountId = "user-1", State = SyncJobState.Queued };
+        var job = MinimalJob() with { Id = jobId };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -148,9 +151,9 @@ public sealed class SyncRepositoryTests
         var repository = new SyncRepository(factory);
         var jobs = new List<SyncJob>
         {
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Completed },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Queued },
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Completed }
+            MinimalJob(state: SyncJobState.Completed),
+            MinimalJob(state: SyncJobState.Queued),
+            MinimalJob(state: SyncJobState.Completed)
         };
         await repository.EnqueueJobsAsync(jobs);
 
@@ -290,8 +293,8 @@ public sealed class SyncRepositoryTests
         var repository = new SyncRepository(factory);
         var jobs = new List<SyncJob>
         {
-            new() { Id = Guid.NewGuid(), AccountId = "user-1", State = SyncJobState.Queued },
-            new() { Id = Guid.NewGuid(), AccountId = "user-2", State = SyncJobState.Queued }
+            MinimalJob(accountId: "user-1"),
+            MinimalJob(accountId: "user-2")
         };
         await repository.EnqueueJobsAsync(jobs);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
@@ -19,15 +19,8 @@ public sealed class GivenADownloadWorker
 
     private DownloadWorker CreateSut(int workerId = 1) => new(workerId, _downloader, _graphService, _syncRepository, _fileSystem);
 
-    private static SyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file") => new()
-    {
-        RemoteItemId   = ItemId,
-        RelativePath   = "Desktop/file.txt",
-        LocalPath      = "/tmp/file.txt",
-        Direction      = SyncDirection.Download,
-        DownloadUrl    = downloadUrl,
-        RemoteModified = DateTimeOffset.UtcNow
-    };
+    private static SyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file")
+        => SyncJobFactory.Create(remoteItemId: ItemId, relativePath: "Desktop/file.txt", localPath: "/tmp/file.txt", direction: SyncDirection.Download, remoteModified: DateTimeOffset.UtcNow, downloadUrl: downloadUrl, accountId: "", folderId: "", fileSize: 0);
 
     private static async Task<(List<SyncJob> Completed, List<string?> Errors)> RunWorkerWithJobsAsync(DownloadWorker worker, IEnumerable<SyncJob> jobs, CancellationToken ct)
     {
@@ -128,15 +121,7 @@ public sealed class GivenADownloadWorker
     [Fact]
     public async Task when_upload_job_is_processed_then_graph_service_upload_is_called()
     {
-        var job = new SyncJob
-        {
-            RemoteItemId   = ItemId,
-            FolderId       = "folder-1",
-            RelativePath   = "Desktop/file.txt",
-            LocalPath      = "/tmp/file.txt",
-            Direction      = SyncDirection.Upload,
-            RemoteModified = DateTimeOffset.UtcNow
-        };
+        var job = SyncJobFactory.Create(remoteItemId: ItemId, folderId: "folder-1", relativePath: "Desktop/file.txt", localPath: "/tmp/file.txt", direction: SyncDirection.Upload, remoteModified: DateTimeOffset.UtcNow, accountId: "", fileSize: 0);
 
         _graphService.UploadFileAsync(AccessToken, job.LocalPath, Arg.Any<string>(), job.FolderId, Arg.Any<CancellationToken>())
             .Returns("remote-item-id");
@@ -149,14 +134,7 @@ public sealed class GivenADownloadWorker
     [Fact]
     public async Task when_delete_job_is_processed_then_no_downloader_or_graph_download_calls_are_made()
     {
-        var job = new SyncJob
-        {
-            RemoteItemId   = ItemId,
-            RelativePath   = "Desktop/file.txt",
-            LocalPath      = "/tmp/nonexistent-file-that-does-not-exist.txt",
-            Direction      = SyncDirection.Delete,
-            RemoteModified = DateTimeOffset.UtcNow
-        };
+        var job = SyncJobFactory.Create(remoteItemId: ItemId, relativePath: "Desktop/file.txt", localPath: "/tmp/nonexistent-file-that-does-not-exist.txt", direction: SyncDirection.Delete, remoteModified: DateTimeOffset.UtcNow, accountId: "", folderId: "", fileSize: 0);
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
@@ -20,14 +20,8 @@ public sealed class GivenAParallelDownloadPipeline
 
     private ParallelDownloadPipeline CreateSut() => new(_syncRepository, _graphService, _downloader, _fileSystem);
 
-    private static SyncJob MakeDownloadJob(string relativePath = "folder/file.txt") => new()
-    {
-        RelativePath   = relativePath,
-        LocalPath      = "/tmp/test-file.txt",
-        Direction      = SyncDirection.Download,
-        DownloadUrl    = "https://example.com/file",
-        RemoteModified = DateTimeOffset.UtcNow
-    };
+    private static SyncJob MakeDownloadJob(string relativePath = "folder/file.txt")
+        => SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: relativePath, localPath: "/tmp/test-file.txt", direction: SyncDirection.Download, fileSize: 0, remoteModified: DateTimeOffset.UtcNow, downloadUrl: "https://example.com/file");
 
     [Fact]
     public async Task when_job_list_is_empty_then_on_progress_is_never_called()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
@@ -31,7 +31,7 @@ public sealed class GivenASyncEventAggregator
         var sut = CreateSut();
         JobCompletedEventArgs? captured = null;
         sut.JobCompleted += (_, args) => captured = args;
-        var job = new SyncJob { AccountId = "acc-2" };
+        var job = SyncJobFactory.Create(accountId: "acc-2", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default);
         var eventArgs = new JobCompletedEventArgs(job);
 
         _syncService.JobCompleted += Raise.EventWith(eventArgs);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -23,16 +23,7 @@ public sealed class GivenASyncJobExecutor
     private SyncJobExecutor CreateSut(MockFileSystem mockFs) => new(_syncRepository, _syncedItemRepository, _pipeline, mockFs);
 
     private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
-        => new()
-        {
-            AccountId      = "user-1",
-            RemoteItemId   = remoteId,
-            RelativePath   = "Documents/file.txt",
-            LocalPath      = localPath,
-            Direction      = direction,
-            FileSize       = 100L,
-            RemoteModified = DateTimeOffset.UtcNow.AddDays(-1)
-        };
+        => SyncJobFactory.Create(accountId: "user-1", folderId: "", remoteItemId: remoteId, relativePath: "Documents/file.txt", localPath: localPath, direction: direction, fileSize: 100L, remoteModified: DateTimeOffset.UtcNow.AddDays(-1));
 
     [Fact]
     public async Task when_jobs_list_is_empty_then_pipeline_is_not_called()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Models/SyncJobTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Models/SyncJobTests.cs
@@ -4,10 +4,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Models;
 
 public sealed class SyncJobTests
 {
+    private static SyncJob CreateMinimalJob() => SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default);
+
     [Fact]
     public void Constructor_ShouldInitializeWithDefaultValues()
     {
-        var syncJob = new SyncJob();
+        var syncJob = CreateMinimalJob();
 
         syncJob.Id.ShouldNotBe(Guid.Empty);
         syncJob.AccountId.ShouldBe(string.Empty);
@@ -28,8 +30,8 @@ public sealed class SyncJobTests
     [Fact]
     public void Id_ShouldBeUnique()
     {
-        var job1 = new SyncJob();
-        var job2 = new SyncJob();
+        var job1 = CreateMinimalJob();
+        var job2 = CreateMinimalJob();
 
         job1.Id.ShouldNotBe(job2.Id);
     }
@@ -46,19 +48,9 @@ public sealed class SyncJobTests
         var direction = SyncDirection.Download;
         long fileSize = 1024L;
         var remoteModified = DateTimeOffset.UtcNow.AddHours(-1);
+        var queuedAt = DateTimeOffset.UtcNow;
 
-        var syncJob = new SyncJob
-        {
-            Id = id,
-            AccountId = accountId,
-            FolderId = folderId,
-            RemoteItemId = remoteItemId,
-            RelativePath = relativePath,
-            LocalPath = localPath,
-            Direction = direction,
-            FileSize = fileSize,
-            RemoteModified = remoteModified
-        };
+        var syncJob = SyncJobFactory.Create(accountId, folderId, remoteItemId, relativePath, localPath, direction, fileSize, remoteModified) with { Id = id, QueuedAt = queuedAt };
 
         syncJob.Id.ShouldBe(id);
         syncJob.AccountId.ShouldBe(accountId);
@@ -72,12 +64,9 @@ public sealed class SyncJobTests
     }
 
     [Fact]
-    public void State_ShouldBeSettable()
+    public void when_copied_with_new_state_then_state_is_updated()
     {
-        var syncJob = new SyncJob
-        {
-            State = SyncJobState.InProgress
-        };
+        var syncJob = CreateMinimalJob() with { State = SyncJobState.InProgress };
 
         syncJob.State.ShouldBe(SyncJobState.InProgress);
     }
@@ -90,43 +79,37 @@ public sealed class SyncJobTests
     [InlineData(SyncJobState.Skipped)]
     public void State_ShouldSupportAllStates(SyncJobState state)
     {
-        var syncJob = new SyncJob
-        {
-            State = state
-        };
+        var syncJob = CreateMinimalJob() with { State = state };
 
         syncJob.State.ShouldBe(state);
     }
 
     [Fact]
-    public void ErrorMessage_ShouldBeSettable()
+    public void when_copied_with_error_message_then_error_message_is_set()
     {
-        var syncJob = new SyncJob();
         string errorMessage = "File is locked by another process";
 
-        syncJob.ErrorMessage = errorMessage;
+        var syncJob = CreateMinimalJob() with { ErrorMessage = errorMessage };
 
         syncJob.ErrorMessage.ShouldBe(errorMessage);
     }
 
     [Fact]
-    public void DownloadUrl_ShouldBeSettable()
+    public void when_copied_with_download_url_then_download_url_is_set()
     {
-        var syncJob = new SyncJob();
         string downloadUrl = "https://graph.microsoft.com/v1.0/drives/abc123/items/xyz789/content";
 
-        syncJob.DownloadUrl = downloadUrl;
+        var syncJob = CreateMinimalJob() with { DownloadUrl = downloadUrl };
 
         syncJob.DownloadUrl.ShouldBe(downloadUrl);
     }
 
     [Fact]
-    public void CompletedAt_ShouldBeSettable()
+    public void when_copied_with_completed_at_then_completed_at_is_set()
     {
-        var syncJob = new SyncJob();
         var completedAt = DateTimeOffset.UtcNow;
 
-        syncJob.CompletedAt = completedAt;
+        var syncJob = CreateMinimalJob() with { CompletedAt = completedAt };
 
         syncJob.CompletedAt.ShouldBe(completedAt);
     }
@@ -137,7 +120,7 @@ public sealed class SyncJobTests
     [InlineData(SyncDirection.Delete)]
     public void Direction_ShouldSupportAllDirections(SyncDirection direction)
     {
-        var syncJob = new SyncJob { Direction = direction };
+        var syncJob = SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: direction, fileSize: 0, remoteModified: default);
 
         syncJob.Direction.ShouldBe(direction);
     }
@@ -147,7 +130,7 @@ public sealed class SyncJobTests
     {
         var beforeCreation = DateTimeOffset.UtcNow;
 
-        var syncJob = new SyncJob();
+        var syncJob = CreateMinimalJob();
 
         syncJob.QueuedAt.ShouldBeGreaterThanOrEqualTo(beforeCreation);
         syncJob.QueuedAt.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
@@ -158,8 +141,8 @@ public sealed class SyncJobTests
     {
         var id = Guid.NewGuid();
         var queuedAt = DateTimeOffset.UtcNow;
-        var job1 = new SyncJob { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
-        var job2 = new SyncJob { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
+        var job1 = CreateMinimalJob() with { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
+        var job2 = CreateMinimalJob() with { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
 
         job1.ShouldBe(job2);
     }
@@ -168,8 +151,8 @@ public sealed class SyncJobTests
     public void IsRecord_ShouldDifferOnPropertyChange()
     {
         var id = Guid.NewGuid();
-        var job1 = new SyncJob { Id = id, AccountId = "account-123" };
-        var job2 = new SyncJob { Id = id, AccountId = "account-456" };
+        var job1 = CreateMinimalJob() with { Id = id, AccountId = "account-123" };
+        var job2 = CreateMinimalJob() with { Id = id, AccountId = "account-456" };
 
         job1.ShouldNotBe(job2);
     }
@@ -177,14 +160,7 @@ public sealed class SyncJobTests
     [Fact]
     public void DownloadJob_ShouldHaveCorrectProperties()
     {
-        var downloadJob = new SyncJob
-        {
-            AccountId = "account-123",
-            FolderId = "folder-456",
-            RemoteItemId = "item-789",
-            Direction = SyncDirection.Download,
-            State = SyncJobState.Queued
-        };
+        var downloadJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Download, fileSize: 0, remoteModified: default);
 
         downloadJob.Direction.ShouldBe(SyncDirection.Download);
         downloadJob.State.ShouldBe(SyncJobState.Queued);
@@ -193,14 +169,7 @@ public sealed class SyncJobTests
     [Fact]
     public void UploadJob_ShouldHaveCorrectProperties()
     {
-        var uploadJob = new SyncJob
-        {
-            AccountId = "account-123",
-            FolderId = "folder-456",
-            RemoteItemId = "item-789",
-            Direction = SyncDirection.Upload,
-            State = SyncJobState.Queued
-        };
+        var uploadJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Upload, fileSize: 0, remoteModified: default);
 
         uploadJob.Direction.ShouldBe(SyncDirection.Upload);
         uploadJob.State.ShouldBe(SyncJobState.Queued);
@@ -209,14 +178,7 @@ public sealed class SyncJobTests
     [Fact]
     public void DeleteJob_ShouldHaveCorrectProperties()
     {
-        var deleteJob = new SyncJob
-        {
-            AccountId = "account-123",
-            FolderId = "folder-456",
-            RemoteItemId = "item-789",
-            Direction = SyncDirection.Delete,
-            State = SyncJobState.Queued
-        };
+        var deleteJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Delete, fileSize: 0, remoteModified: default);
 
         deleteJob.Direction.ShouldBe(SyncDirection.Delete);
         deleteJob.State.ShouldBe(SyncJobState.Queued);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -13,6 +13,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// </summary>
 public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGraphService graphService, ISyncRepository syncRepository, IFileSystem fileSystem)
 {
+    /// <summary>Runs the worker, draining all jobs from <paramref name="reader"/> until the channel is complete or <paramref name="ct"/> is cancelled.</summary>
     public async Task RunAsync(ChannelReader<SyncJob> reader, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
     {
         await foreach(var job in reader.ReadAllAsync(ct))
@@ -28,10 +29,11 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
             string? error   = null;
             bool     success = false;
+            var currentJob = job;
 
             try
             {
-                await ExecuteJobAsync(job, accessToken, ct);
+                currentJob = await ExecuteJobAsync(job, accessToken, ct);
                 success = true;
                 await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Completed);
             }
@@ -48,12 +50,12 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
             }
             finally
             {
-                onJobComplete(job, success, error);
+                onJobComplete(currentJob, success, error);
             }
         }
     }
 
-    private async Task ExecuteJobAsync(SyncJob job, string accessToken, CancellationToken ct)
+    private async Task<SyncJob> ExecuteJobAsync(SyncJob job, string accessToken, CancellationToken ct)
     {
         switch(job.Direction)
         {
@@ -65,20 +67,25 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
                     job.LocalPath,
                     job.RemoteModified,
                     ct: ct);
-                break;
+
+                return job;
 
             case SyncDirection.Upload:
                 string remotePath = job.DownloadUrl ?? job.RelativePath;
-
-                job.UploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.LocalPath, remotePath, parentFolderId: job.FolderId, ct: ct);
+                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.LocalPath, remotePath, parentFolderId: job.FolderId, ct: ct);
 
                 Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, job.RelativePath);
-                break;
+
+                return job with { UploadedRemoteItemId = uploadedRemoteItemId };
 
             case SyncDirection.Delete:
                 if(fileSystem.File.Exists(job.LocalPath))
                     fileSystem.File.Delete(job.LocalPath);
-                break;
+
+                return job;
+
+            default:
+                return job;
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
@@ -57,18 +57,7 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDe
 
                 string relativePathForUpload = remotePath.TrimStart('/');
 
-                jobs.Add(new SyncJob
-                {
-                    AccountId      = accountId,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = known?.RemoteItemId.Id ?? string.Empty,
-                    RelativePath   = relativePathForUpload,
-                    LocalPath      = filePath,
-                    Direction      = SyncDirection.Upload,
-                    FileSize       = info.Length,
-                    RemoteModified = localModified,
-                    DownloadUrl    = relativePathForUpload
-                });
+                jobs.Add(SyncJobFactory.Create(accountId, string.Empty, known?.RemoteItemId.Id ?? string.Empty, relativePathForUpload, filePath, SyncDirection.Upload, info.Length, localModified, downloadUrl: relativePathForUpload));
             }
 
             foreach(string subDir in fileSystem.Directory.EnumerateDirectories(localDir))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -104,18 +104,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                     continue;
                 }
 
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
+                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
             }
         }
 
@@ -144,49 +133,17 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 break;
 
             case ConflictOutcome.UseRemote:
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
+                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
                 break;
 
             case ConflictOutcome.UseLocal:
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Upload,
-                    FileSize       = fileSystem.FileInfo.New(localPath).Length,
-                    RemoteModified = localModified
-                });
+                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Upload, fileSystem.FileInfo.New(localPath).Length, localModified));
                 break;
 
             case ConflictOutcome.KeepBoth:
                 string newName = ConflictResolver.MakeKeepBothName(localPath, localModified, fileSystem);
                 fileSystem.File.Move(localPath, newName);
-                downloadJobs.Add(new SyncJob
-                {
-                    AccountId      = account.Id.Id,
-                    FolderId       = string.Empty,
-                    RemoteItemId   = item.Id,
-                    RelativePath   = item.RelativePath ?? item.Name,
-                    LocalPath      = localPath,
-                    Direction      = SyncDirection.Download,
-                    DownloadUrl    = item.DownloadUrl,
-                    FileSize       = item.Size,
-                    RemoteModified = item.LastModified ?? DateTimeOffset.MinValue
-                });
+                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
                 break;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Models/SyncJob.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Models/SyncJob.cs
@@ -4,21 +4,6 @@ namespace AStar.Dev.OneDrive.Sync.Client.Models;
 /// Represents a single file operation queued by the sync engine.
 /// Created from delta query results and processed in order.
 /// </summary>
-public sealed record SyncJob
-{
-    public Guid Id { get; init; } = Guid.NewGuid();
-    public string AccountId { get; init; } = string.Empty;
-    public string FolderId { get; init; } = string.Empty;
-    public string RemoteItemId { get; init; } = string.Empty;
-    public string RelativePath { get; init; } = string.Empty;
-    public string LocalPath { get; init; } = string.Empty;
-    public SyncDirection Direction { get; init; }
-    public SyncJobState State { get; set; } = SyncJobState.Queued;
-    public string? ErrorMessage { get; set; }
-    public string? DownloadUrl { get; set; }
-    public long FileSize { get; init; }
-    public DateTimeOffset RemoteModified { get; init; }
-    public DateTimeOffset QueuedAt { get; init; } = DateTimeOffset.UtcNow;
-    public DateTimeOffset? CompletedAt { get; set; }
-    public string? UploadedRemoteItemId { get; set; }
-}
+public sealed record SyncJob(string AccountId, string FolderId, string RemoteItemId, string RelativePath, string LocalPath, SyncDirection Direction, long FileSize, DateTimeOffset RemoteModified,
+    Guid Id, DateTimeOffset QueuedAt, SyncJobState State = SyncJobState.Queued, string? ErrorMessage = null, string? DownloadUrl = null, DateTimeOffset? CompletedAt = null,
+    string? UploadedRemoteItemId = null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Models/SyncJobFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Models/SyncJobFactory.cs
@@ -1,0 +1,9 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Models;
+
+/// <summary>Creates <see cref="SyncJob"/> instances with auto-generated identity fields.</summary>
+public static class SyncJobFactory
+{
+    /// <summary>Creates a new <see cref="SyncJob"/> with a generated <see cref="SyncJob.Id"/> and <see cref="SyncJob.QueuedAt"/> timestamp.</summary>
+    public static SyncJob Create(string accountId, string folderId, string remoteItemId, string relativePath, string localPath, SyncDirection direction, long fileSize, DateTimeOffset remoteModified, string? downloadUrl = null)
+        => new(accountId, folderId, remoteItemId, relativePath, localPath, direction, fileSize, remoteModified, Guid.NewGuid(), DateTimeOffset.UtcNow, DownloadUrl: downloadUrl);
+}


### PR DESCRIPTION
## Summary
- Converts `SyncJob` from a property-bag record with mutable `set` properties to a primary-constructor record (all properties `init`-only via primary constructor)
- Adds `SyncJobFactory` with a `Create` method that supplies runtime defaults (`Id = Guid.NewGuid()`, `QueuedAt = DateTimeOffset.UtcNow`)
- Fixes `DownloadWorker.ExecuteJobAsync` to return `Task<SyncJob>` and use `with { UploadedRemoteItemId = ... }` instead of direct property mutation
- Updates all construction sites (`LocalChangeDetector`, `RemoteFolderEnumerator`) to use `SyncJobFactory.Create`
- Rewrites mutation-testing tests in `SyncJobTests` to use `with` expressions
- Updates all test files that construct `SyncJob` directly to use `SyncJobFactory.Create`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings (excluding pre-existing version warning)
- [x] `dotnet test` — 710 passed, 0 failed

Closes #213