### PR TITLE
refactor: extract methods from RemoteFolderEnumerator.EnumerateAsync

### DIFF
--- a/.serena/memories/code_style.md
+++ b/.serena/memories/code_style.md
@@ -1,0 +1,46 @@
+## C# Code Style & Conventions
+
+**Naming:**
+- Public: PascalCase
+- Private: camelCase (no underscore prefix)
+- Constants: PascalCase
+- No single-letter vars except loop indices (i, j, k)
+- Use `nameof()` in exceptions/logging
+
+**Methods & Classes:**
+- Single-line signatures always (no param splitting regardless of length)
+- One class per file, named after class
+- Max method: ~20 lines
+- Max class: ~300 lines
+- Extract methods instead of inline comments
+- Blank line before every `return` (except directly after if/else)
+
+**Immutability:**
+- Prefer `record` for data models/DTOs
+- Use `class` for entities with behavior
+- Use `init` properties
+- Immutable collections: IReadOnlyList<T>, IReadOnlyDictionary<K,V>
+- Factory classes: `<Name>Factory` with static `Create()` methods
+
+**Records:**
+- Properties on same line as declaration
+- Never call public constructor—use factory methods
+- Discriminated unions via record inheritance (abstract base + case records in same file)
+
+**Collections:**
+- IEnumerable<T>: no indexing needed
+- IReadOnlyList<T> / IReadOnlyCollection<T>: immutability desired
+- StringBuilder: only for loop concat or perf-critical
+- Collection initializers for clarity
+
+**Testing (Given prefix, when_then snake_case):**
+- Class: `GivenAnAccount`, `GivenADatabaseReadyForSync`
+- Method: `when_deleted_then_all_linked_rows_are_removed`
+- Pattern: Arrange-Act-Assert (no comments for sections)
+- Use Shouldly assertions + NSubstitute mocks
+
+**Comments:**
+- NEVER restate what code says
+- Only comment WHY if non-obvious
+- No comments in test classes
+- No comments in private methods

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,19 @@
+## AStar.Dev Mono-Repo
+
+**Purpose:** Multi-product platform with Blazor web apps, Astro web apps, Avalonia desktop apps, and ~25 published NuGet packages.
+
+**Tech Stack:**
+- C# / .NET 10
+- Blazor WebAssembly & Server
+- Avalonia (cross-platform desktop)
+- Astro (web)
+- NuGet packages (GitHub + NuGet.org)
+
+**Solution file:** `AStar.Dev.slnx`
+
+**Key NuGet packages to use:**
+- `AStar.Dev.Functional.Extensions`: Result<T>, Option<T>, Map/Bind variants
+- `AStar.Dev.Logging.Extensions`: Compile-time LogMessage templates
+- `AStar.Dev.Utilities`: String extensions, nullability checks
+
+**Key architectural principle:** DI and logging are NOT afterthoughts—implement from start.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,28 @@
+## Key Commands
+
+**Build & Restore:**
+- `dotnet restore` - restore dependencies
+- `dotnet build` - build all
+- `dotnet build packages/core/[PackageName]` - build specific package
+- `dotnet build apps/web/[AppName].Blazor` - build web app
+- `dotnet clean && dotnet build` - full rebuild (if Directory.Build.props changed)
+
+**Testing:**
+- `dotnet test` - run all tests
+- `dotnet test tests/[ProjectName].Tests` - run specific test project
+- Coverage output: `TestResults/`
+
+**Run Apps:**
+- `dotnet run --project apps/web/[AppName].Blazor` - run Blazor web
+- `dotnet run --project apps/desktop/[AppName].Desktop` - run Avalonia desktop
+- `cd apps/web/[appname] && npm run dev` - run Astro web
+
+**Git:**
+- Always create feature branch before coding: `git checkout -b feature/short-desc-issue-num`
+- Branch naming: `feature/...`, `bug/...`, `fix/...`, `doc/...`
+- Never commit to `main`
+
+**Commit & PR:**
+- Conventional Commits: `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
+- Raise PR after implementation
+- Tests must pass, zero build warnings

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,24 @@
+## Definition of Done
+
+Before marking task complete:
+
+1. **Create feature branch** (never on main)
+2. **TDD: write failing test first**, commit before production code
+3. **Build:** `dotnet build` affected projects—zero errors, zero warnings
+4. **Test:** `dotnet test` affected test projects—all pass
+5. **Logging:** all logging → Azure Application Insights via `AStar.Dev.Logging.Extensions` (compile-time `LogMessage` only)
+6. **DI:** language supports it? must implement from start
+7. **Code style:** Follow c-sharp-code-style.md
+8. **No redundant comments:** Extract methods instead
+9. **Request human review** before committing
+10. **Implement feedback if requested**
+11. **Commit with conventional message** to branch (only after approval)
+12. **Raise GitHub PR**
+
+## Key Principles
+
+- NEVER afterthought: logging + DI
+- Extract sub-methods for SRP violations
+- No magic strings/numbers—use constants/enums
+- Immutable-first for data
+- Factory pattern for records

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml
@@ -1,6 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:AStar.Dev.OneDrive.Sync.Client.Converters"
+             xmlns:home="clr-namespace:AStar.Dev.OneDrive.Sync.Client.Home"
+             xmlns:dashboard="clr-namespace:AStar.Dev.OneDrive.Sync.Client.Dashboard"
              x:Class="AStar.Dev.OneDrive.Sync.Client.App"
              RequestedThemeVariant="Default">
 
@@ -15,14 +17,14 @@
             <converters:SyncStateToForegroundConverter          x:Key="SyncStateToForegroundConverter"/>
             <converters:BoolToAccentConverter                   x:Key="BoolToAccentConverter"/>
             <converters:StringNotEmptyConverter                 x:Key="StringNotEmptyConverter"/>
-            <converters:DepthToIndentConverter                  x:Key="DepthToIndentConverter"/>
+            <home:DepthToIndentConverter                        x:Key="DepthToIndentConverter"/>
             <converters:SyncStateToBadgeBackgroundConverter     x:Key="SyncStateToBadgeBackgroundConverter"/>
             <converters:SyncStateToBadgeForegroundConverter     x:Key="SyncStateToBadgeForegroundConverter"/>
             <converters:BoolToExcludeIncludeLabelConverter      x:Key="BoolToExcludeIncludeLabelConverter"/>
             <converters:BoolToExcludeIncludeTooltipConverter    x:Key="BoolToExcludeIncludeTooltipConverter"/>
             <converters:BoolToCollapseExpandConverter           x:Key="BoolToCollapseExpandConverter"/>
-            <converters:ConflictCountToColorConverter x:Key="ConflictCountToColorConverter"/>
-            <converters:IntZeroToBoolConverter        x:Key="IntZeroToBoolConverter"/>
+            <dashboard:ConflictCountToColorConverter            x:Key="ConflictCountToColorConverter"/>
+            <converters:IntZeroToBoolConverter                  x:Key="IntZeroToBoolConverter"/>
 
         </ResourceDictionary>
     </Application.Resources>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -40,9 +40,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             if(ct.IsCancellationRequested)
                 break;
 
-            var folderId = rule.RemoteItemId
-                ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
-                ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct);
+            var folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId, ct);
 
             if(folderId is null)
             {
@@ -50,65 +48,84 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 continue;
             }
 
-            if(folderId != rule.RemoteItemId)
-            {
-                Serilog.Log.Debug("[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
-                await syncRuleRepository.UpsertAsync(account.Id, rule.RemotePath, RuleType.Include, folderId, ct);
-            }
-
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Email);
             var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct);
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
 
-            foreach(var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
-            {
-                seenRemoteIds.Add(item.Id);
-
-                if(!SyncRuleEvaluator.IsIncluded(item.RelativePath ?? item.Name, rules))
-                    continue;
-
-                if(item.IsFolder)
-                {
-                    await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, account.LocalSyncPath!.Value, syncedItems, ct);
-                    continue;
-                }
-
-                string localPath = BuildLocalPath(account.LocalSyncPath!.Value, (item.RelativePath ?? item.Name).TrimStart('/'));
-
-                syncedItems.TryGetValue(item.Id, out var knownItem);
-
-                if(knownItem?.ETag is not null && knownItem.ETag == item.ETag && fileSystem.File.Exists(localPath))
-                {
-                    Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.RelativePath);
-                    continue;
-                }
-
-                if(knownItem is not null && fileSystem.File.Exists(localPath))
-                {
-                    var localModified = new DateTimeOffset(fileSystem.FileInfo.New(localPath).LastWriteTimeUtc, TimeSpan.Zero);
-                    bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
-
-                    if(isConflict)
-                    {
-                        var conflict = BuildConflict(account, item, localPath, localModified);
-                        await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict);
-                        continue;
-                    }
-                }
-                else if(knownItem is null && fileSystem.File.Exists(localPath))
-                {
-                    Serilog.Log.Debug("[RemoteFolderEnumerator] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
-                    var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.RelativePath ?? item.Name, localPath);
-                    await syncedItemRepository.UpsertAsync(phantomItem, ct);
-                    syncedItems[item.Id] = phantomItem;
-                    continue;
-                }
-
-                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
-            }
+            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct);
         }
 
         return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
+    }
+
+    private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, string accessToken, string driveId, CancellationToken ct)
+    {
+        var folderId = rule.RemoteItemId
+            ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
+            ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct);
+
+        if(folderId is not null && folderId != rule.RemoteItemId)
+        {
+            Serilog.Log.Debug("[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
+            await syncRuleRepository.UpsertAsync(accountId, rule.RemotePath, RuleType.Include, folderId, ct);
+        }
+
+        return folderId;
+    }
+
+    private async Task ProcessItemsForRuleAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict, HashSet<string> seenRemoteIds, CancellationToken ct)
+    {
+        foreach(var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
+        {
+            seenRemoteIds.Add(item.Id);
+
+            if(!SyncRuleEvaluator.IsIncluded(item.RelativePath ?? item.Name, rules))
+                continue;
+
+            if(item.IsFolder)
+            {
+                await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, account.LocalSyncPath!.Value, syncedItems, ct);
+                continue;
+            }
+
+            await ProcessFileItemAsync(account, item, rules, syncedItems, downloadJobs, onConflict, ct);
+        }
+    }
+
+    private async Task ProcessFileItemAsync(OneDriveAccount account, DeltaItem item, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    {
+        string localPath = BuildLocalPath(account.LocalSyncPath!.Value, (item.RelativePath ?? item.Name).TrimStart('/'));
+
+        syncedItems.TryGetValue(item.Id, out var knownItem);
+
+        if(knownItem?.ETag is not null && knownItem.ETag == item.ETag && fileSystem.File.Exists(localPath))
+        {
+            Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.RelativePath);
+            return;
+        }
+
+        if(knownItem is not null && fileSystem.File.Exists(localPath))
+        {
+            var localModified = new DateTimeOffset(fileSystem.FileInfo.New(localPath).LastWriteTimeUtc, TimeSpan.Zero);
+            bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
+
+            if(isConflict)
+            {
+                var conflict = BuildConflict(account, item, localPath, localModified);
+                await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict);
+                return;
+            }
+        }
+        else if(knownItem is null && fileSystem.File.Exists(localPath))
+        {
+            Serilog.Log.Debug("[RemoteFolderEnumerator] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
+            var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.RelativePath ?? item.Name, localPath);
+            await syncedItemRepository.UpsertAsync(phantomItem, ct);
+            syncedItems[item.Id] = phantomItem;
+            return;
+        }
+
+        downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
     }
 
     private async Task HandleFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localBasePath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)


### PR DESCRIPTION
## Summary

- Refactors 105-line `EnumerateAsync` method that violated SRP and exceeded 20-30 line guideline
- Extracted three focused methods: `ResolveAndBackFillFolderIdAsync`, `ProcessItemsForRuleAsync`, `ProcessFileItemAsync`
- All 15 existing unit tests pass with zero changes required

## Also Fixed

- **App.axaml converter namespace refs**: Converters were moved to Home/Dashboard/Onboarding folders in #236 but XAML still referenced them from Converters namespace. Added namespace declarations and updated references.

## Test Results

```
Passed!  - Failed: 0, Passed: 15, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)