### PR TITLE
fix: add ConfigureAwait(false) to infrastructure async code

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -25,7 +25,7 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
                 workerId, job.Direction, job.RelativePath);
 
             await syncRepository.UpdateJobStateAsync(
-                job.Id, SyncJobState.InProgress);
+                job.Id, SyncJobState.InProgress).ConfigureAwait(false);
 
             string? error   = null;
             bool     success = false;
@@ -33,20 +33,20 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
             try
             {
-                currentJob = await ExecuteJobAsync(job, accessToken, ct);
+                currentJob = await ExecuteJobAsync(job, accessToken, ct).ConfigureAwait(false);
                 success = true;
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Completed);
+                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Completed).ConfigureAwait(false);
             }
             catch(OperationCanceledException)
             {
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Queued);
+                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Queued).ConfigureAwait(false);
                 throw;
             }
             catch(Exception ex)
             {
                 error = ex.Message;
                 Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}", workerId, ex.GetType().Name, ex.Message, job.LocalPath);
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Failed, ex.Message);
+                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Failed, ex.Message).ConfigureAwait(false);
             }
             finally
             {
@@ -66,13 +66,13 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
                     downloadUrl,
                     job.LocalPath,
                     job.RemoteModified,
-                    ct: ct);
+                    ct: ct).ConfigureAwait(false);
 
                 return job;
 
             case SyncDirection.Upload:
                 string remotePath = job.DownloadUrl ?? job.RelativePath;
-                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.LocalPath, remotePath, parentFolderId: job.FolderId, ct: ct);
+                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.LocalPath, remotePath, parentFolderId: job.FolderId, ct: ct).ConfigureAwait(false);
 
                 Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, job.RelativePath);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -15,7 +15,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
     /// <inheritdoc />
     public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Func<SyncConflict, Task> onConflict, CancellationToken ct)
     {
-        var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct);
+        var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
         if(rules.Count == 0)
         {
@@ -24,8 +24,8 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: true);
         }
 
-        var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct);
-        var driveId     = await graphService.GetDriveIdAsync(accessToken, ct);
+        var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
+        var driveId     = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
 
         var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules
@@ -40,7 +40,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             if(ct.IsCancellationRequested)
                 break;
 
-            var folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId, ct);
+            var folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId, ct).ConfigureAwait(false);
 
             if(folderId is null)
             {
@@ -49,10 +49,10 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Email);
-            var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct);
+            var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct).ConfigureAwait(false);
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
 
-            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct);
+            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
         }
 
         return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
@@ -62,12 +62,12 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
     {
         var folderId = rule.RemoteItemId
             ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
-            ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct);
+            ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct).ConfigureAwait(false);
 
         if(folderId is not null && folderId != rule.RemoteItemId)
         {
             Serilog.Log.Debug("[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
-            await syncRuleRepository.UpsertAsync(accountId, rule.RemotePath, RuleType.Include, folderId, ct);
+            await syncRuleRepository.UpsertAsync(accountId, rule.RemotePath, RuleType.Include, folderId, ct).ConfigureAwait(false);
         }
 
         return folderId;
@@ -84,11 +84,11 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
             if(item.IsFolder)
             {
-                await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, account.LocalSyncPath!.Value, syncedItems, ct);
+                await HandleFolderAsync(account.Id, item, item.RelativePath ?? item.Name, account.LocalSyncPath!.Value, syncedItems, ct).ConfigureAwait(false);
                 continue;
             }
 
-            await ProcessFileItemAsync(account, item, rules, syncedItems, downloadJobs, onConflict, ct);
+            await ProcessFileItemAsync(account, item, rules, syncedItems, downloadJobs, onConflict, ct).ConfigureAwait(false);
         }
     }
 
@@ -112,7 +112,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             if(isConflict)
             {
                 var conflict = BuildConflict(account, item, localPath, localModified);
-                await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict);
+                await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict).ConfigureAwait(false);
                 return;
             }
         }
@@ -120,7 +120,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         {
             Serilog.Log.Debug("[RemoteFolderEnumerator] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
             var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.RelativePath ?? item.Name, localPath);
-            await syncedItemRepository.UpsertAsync(phantomItem, ct);
+            await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
             syncedItems[item.Id] = phantomItem;
             return;
         }
@@ -134,13 +134,13 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         _ = fileSystem.Directory.CreateDirectory(localPath);
 
         var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
-        await syncedItemRepository.UpsertAsync(entity, ct);
+        await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
         syncedItems[item.Id] = entity;
     }
 
     private async Task HandleConflictAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, SyncConflict conflict, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict)
     {
-        await onConflict(conflict);
+        await onConflict(conflict).ConfigureAwait(false);
 
         var outcome = ConflictResolver.Resolve(account.ConflictPolicy, localModified, item.LastModified ?? DateTimeOffset.MinValue);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -27,7 +27,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         Serilog.Log.Information("[SyncService] SyncAccountAsync for {Email}", account.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
-        var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct);
+        var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
 
         if (authResult is not Result<AuthResult, AuthError>.Ok authOk)
         {
@@ -46,7 +46,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
 
         try
         {
-            await SyncAccountInternalAsync(account, authOk.Value.AccessToken, ct);
+            await SyncAccountInternalAsync(account, authOk.Value.AccessToken, ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -62,35 +62,35 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     /// <inheritdoc />
     public async Task ResolveConflictAsync(SyncConflict conflict, ConflictPolicy policy, CancellationToken ct = default)
     {
-        var authResult = await authService.AcquireTokenSilentAsync(conflict.AccountId, ct);
+        var authResult = await authService.AcquireTokenSilentAsync(conflict.AccountId, ct).ConfigureAwait(false);
 
         if (authResult is not Result<AuthResult, AuthError>.Ok authOk)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.LocalModified, conflict.RemoteModified);
 
-        await ApplyConflictOutcomeAsync(conflict, outcome, authOk.Value.AccessToken, ct);
-        await syncRepository.ResolveConflictAsync(conflict.Id, policy);
+        await ApplyConflictOutcomeAsync(conflict, outcome, authOk.Value.AccessToken, ct).ConfigureAwait(false);
+        await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
     }
 
     private async Task SyncAccountInternalAsync(OneDriveAccount account, string token, CancellationToken ct)
     {
         var driveState = await driveStateRepository.GetByAccountIdAsync(account.Id, ct)
-                             .OrElseAsync(new DriveStateEntity { AccountId = account.Id });
+                             .OrElseAsync(new DriveStateEntity { AccountId = account.Id }).ConfigureAwait(false);
 
         driveState.LastSyncStartedAt = DateTimeOffset.UtcNow;
         driveState.DeltaLink = null;
-        await driveStateRepository.UpsertAsync(driveState, ct);
+        await driveStateRepository.UpsertAsync(driveState, ct).ConfigureAwait(false);
 
         var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(
             account,
             token,
             async conflict =>
             {
-                await syncRepository.AddConflictAsync(conflict);
+                await syncRepository.AddConflictAsync(conflict).ConfigureAwait(false);
                 ConflictDetected?.Invoke(this, conflict);
             },
-            ct);
+            ct).ConfigureAwait(false);
 
         if (enumerationResult.HadNoRules)
         {
@@ -99,10 +99,10 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         }
 
         RaiseProgress(account.Id.Id, 0, 0, "Detecting remote deletions...", SyncState.Syncing);
-        await dependencies.RemoteDeletionDetector.DetectAndApplyAsync(account.Id, enumerationResult.SyncedItems, enumerationResult.SeenRemoteIds, enumerationResult.Rules, ct);
+        await dependencies.RemoteDeletionDetector.DetectAndApplyAsync(account.Id, enumerationResult.SyncedItems, enumerationResult.SeenRemoteIds, enumerationResult.Rules, ct).ConfigureAwait(false);
 
         RaiseProgress(account.Id.Id, 0, 0, "Detecting local changes...", SyncState.Syncing);
-        await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, token, enumerationResult.SyncedItems, ct);
+        await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, token, enumerationResult.SyncedItems, ct).ConfigureAwait(false);
 
         var syncedItemsByLocalPath = enumerationResult.SyncedItems.Values.ToDictionary(i => i.LocalPath, StringComparer.OrdinalIgnoreCase);
         var uploadJobs = dependencies.LocalChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, account.LocalSyncPath!.Value, enumerationResult.Rules, syncedItemsByLocalPath);
@@ -121,7 +121,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 enumerationResult.SyncedItems,
                 args => SyncProgressChanged?.Invoke(this, args),
                 args => JobCompleted?.Invoke(this, args),
-                ct);
+                ct).ConfigureAwait(false);
         }
         else
         {
@@ -132,8 +132,8 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
             .TapAsync(async entity =>
             {
                 entity.LastSyncedAt = DateTimeOffset.UtcNow;
-                await accountRepository.UpsertAsync(entity, ct);
-            });
+                await accountRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
+            }).ConfigureAwait(false);
 
         account.LastSyncedAt = DateTimeOffset.UtcNow;
 
@@ -149,7 +149,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 string downloadUrl = await graphService.GetDownloadUrlAsync(accessToken, conflict.RemoteItemId, ct).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.RelativePath}' (itemId={conflict.RemoteItemId}).");
 
-                await httpDownloader.DownloadAsync(downloadUrl, conflict.LocalPath, conflict.RemoteModified, ct: ct);
+                await httpDownloader.DownloadAsync(downloadUrl, conflict.LocalPath, conflict.RemoteModified, ct: ct).ConfigureAwait(false);
                 break;
 
             case ConflictOutcome.KeepBoth:


### PR DESCRIPTION
## Summary
- Add `.ConfigureAwait(false)` to all await expressions in `SyncService`, `DownloadWorker`, and `RemoteFolderEnumerator`
- Prevents synchronization context capture in infrastructure code  
- Fixes potential deadlocks and performance issues in background workers

## Test plan
- [x] All 710 unit tests pass
- [x] Build succeeds with no errors
- [x] ConfigureAwait applied to all infrastructure async calls

Fixes #188 #189 #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)