### PR TITLE
Feature/syncjob data clump refactors

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,26 @@ project_name: "astar-dev-mono"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -125,3 +127,14 @@ ignored_memory_patterns: []
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
@@ -15,7 +15,7 @@ public sealed class GivenAnActivityItemViewModel
 
     private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null)
     {
-        var remote = RemoteItemRefFactory.Create(AccountIdValue, "", "");
+        var remote = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(""), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", relativePath);
         var metadata = SyncFileMetadataFactory.Create(FileSizeValue, default);
         var status = SyncJobStatusFactory.Create() with { CompletedAt = completedAt, ErrorMessage = errorMessage };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
@@ -14,7 +14,14 @@ public sealed class GivenAnActivityItemViewModel
     private const long FileSizeValue = 2048L;
 
     private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null)
-        => SyncJobFactory.Create(accountId: AccountIdValue, folderId: "", remoteItemId: "", relativePath: relativePath, localPath: "", direction: direction, fileSize: FileSizeValue, remoteModified: default) with { CompletedAt = completedAt, ErrorMessage = errorMessage };
+    {
+        var remote = RemoteItemRefFactory.Create(AccountIdValue, "", "");
+        var target = SyncFileTargetFactory.Create("", relativePath);
+        var metadata = SyncFileMetadataFactory.Create(FileSizeValue, default);
+        var status = SyncJobStatusFactory.Create() with { CompletedAt = completedAt, ErrorMessage = errorMessage };
+
+        return SyncJobFactory.Create(remote, target, metadata, direction, status);
+    }
 
     private static SyncConflict BuildSyncConflict(string relativePath = RelativePathValue, DateTimeOffset? detectedAt = null) => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
 
-public sealed class SyncRepositoryTests
+public sealed class GivenASyncRepository
 {
     private static SyncJob MinimalJob(string accountId = "user-1", string folderId = "", SyncJobState state = SyncJobState.Queued)
     {
-        var remote = RemoteItemRefFactory.Create(accountId, folderId, "");
+        var remote = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId(folderId), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create() with { State = state };
@@ -18,7 +18,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task EnqueueJobsAsync_WithEmptyList_ShouldNotThrow()
+    public async Task when_enqueue_jobs_is_called_with_empty_list_then_no_exception_is_thrown()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -27,7 +27,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task EnqueueJobsAsync_WithJobs_ShouldInsertAll()
+    public async Task when_enqueue_jobs_is_called_with_jobs_then_all_are_inserted()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -43,7 +43,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingJobsAsync_WithNoJobs_ShouldReturnEmpty()
+    public async Task when_get_pending_jobs_is_called_with_no_jobs_then_result_is_empty()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -54,7 +54,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingJobsAsync_ShouldReturnOnlyQueuedJobs()
+    public async Task when_get_pending_jobs_is_called_then_only_queued_jobs_are_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -73,20 +73,19 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingJobsAsync_ShouldReturnJobsOrderedByQueuedAt()
+    public async Task when_get_pending_jobs_is_called_then_jobs_are_ordered_by_queued_at()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var now = DateTimeOffset.UtcNow;
-        var baseStatus = SyncJobStatusFactory.Create();
-        var remote = RemoteItemRefFactory.Create("user-1", "", "");
+        var remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(""), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var jobs = new List<SyncJob>
         {
-            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(3) }),
-            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(1) }),
-            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(2) })
+            SyncJobFactory.Create(remote, target, metadata, default, SyncJobStatusFactory.Create() with { QueuedAt = now.AddSeconds(3) }),
+            SyncJobFactory.Create(remote, target, metadata, default, SyncJobStatusFactory.Create() with { QueuedAt = now.AddSeconds(1) }),
+            SyncJobFactory.Create(remote, target, metadata, default, SyncJobStatusFactory.Create() with { QueuedAt = now.AddSeconds(2) })
         };
         await repository.EnqueueJobsAsync(jobs);
 
@@ -98,7 +97,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task UpdateJobStateAsync_ShouldUpdateState()
+    public async Task when_update_job_state_is_called_then_state_is_updated()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -117,7 +116,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task UpdateJobStateAsync_WithCompletedState_ShouldSetCompletedAt()
+    public async Task when_update_job_state_is_called_with_completed_state_then_completed_at_is_set()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -136,7 +135,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task UpdateJobStateAsync_WithErrorMessage_ShouldSetError()
+    public async Task when_update_job_state_is_called_with_error_message_then_error_is_set()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -155,7 +154,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task ClearCompletedJobsAsync_ShouldRemoveCompletedJobs()
+    public async Task when_clear_completed_jobs_is_called_then_completed_jobs_are_removed()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -177,7 +176,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task AddConflictAsync_ShouldInsertConflict()
+    public async Task when_add_conflict_is_called_then_conflict_is_inserted()
     {
         var (db, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -197,7 +196,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingConflictsAsync_ShouldReturnOnlyPendingConflicts()
+    public async Task when_get_pending_conflicts_is_called_then_only_pending_conflicts_are_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -214,7 +213,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingConflictsAsync_ShouldReturnOrderedByDetectedAt()
+    public async Task when_get_pending_conflicts_is_called_then_conflicts_are_ordered_by_detected_at()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -231,7 +230,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task ResolveConflictAsync_ShouldUpdateState()
+    public async Task when_resolve_conflict_is_called_then_state_is_updated()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -248,7 +247,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task ResolveConflictAsync_ShouldSetResolvedAt()
+    public async Task when_resolve_conflict_is_called_then_resolved_at_is_set()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -265,7 +264,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingConflictCountAsync_WithNoPendingConflicts_ShouldReturnZero()
+    public async Task when_get_pending_conflict_count_is_called_with_no_pending_conflicts_then_zero_is_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -276,7 +275,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingConflictCountAsync_ShouldReturnOnlyPendingCount()
+    public async Task when_get_pending_conflict_count_is_called_then_only_pending_count_is_returned()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
@@ -294,7 +293,7 @@ public sealed class SyncRepositoryTests
     }
 
     [Fact]
-    public async Task GetPendingJobsAsync_DifferentAccountsIsolated()
+    public async Task when_get_pending_jobs_is_called_for_different_accounts_then_results_are_isolated()
     {
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRepositoryTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRepositoryTests.cs
@@ -8,7 +8,14 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
 public sealed class SyncRepositoryTests
 {
     private static SyncJob MinimalJob(string accountId = "user-1", string folderId = "", SyncJobState state = SyncJobState.Queued)
-        => SyncJobFactory.Create(accountId: accountId, folderId: folderId, remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default) with { State = state };
+    {
+        var remote = RemoteItemRefFactory.Create(accountId, folderId, "");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create() with { State = state };
+
+        return SyncJobFactory.Create(remote, target, metadata, default, status);
+    }
 
     [Fact]
     public async Task EnqueueJobsAsync_WithEmptyList_ShouldNotThrow()
@@ -71,11 +78,15 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var now = DateTimeOffset.UtcNow;
+        var baseStatus = SyncJobStatusFactory.Create();
+        var remote = RemoteItemRefFactory.Create("user-1", "", "");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
         var jobs = new List<SyncJob>
         {
-            MinimalJob() with { QueuedAt = now.AddSeconds(3) },
-            MinimalJob() with { QueuedAt = now.AddSeconds(1) },
-            MinimalJob() with { QueuedAt = now.AddSeconds(2) }
+            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(3) }),
+            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(1) }),
+            SyncJobFactory.Create(remote, target, metadata, default, baseStatus with { QueuedAt = now.AddSeconds(2) })
         };
         await repository.EnqueueJobsAsync(jobs);
 
@@ -92,7 +103,8 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = MinimalJob() with { Id = jobId };
+        var baseJob = MinimalJob();
+        var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -101,7 +113,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 
@@ -111,7 +122,8 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = MinimalJob() with { Id = jobId };
+        var baseJob = MinimalJob();
+        var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -120,7 +132,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 
@@ -130,7 +141,8 @@ public sealed class SyncRepositoryTests
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var jobId = Guid.NewGuid();
-        var job = MinimalJob() with { Id = jobId };
+        var baseJob = MinimalJob();
+        var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
         await repository.EnqueueJobsAsync(new[] { job });
 
         try
@@ -139,7 +151,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 
@@ -162,7 +173,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteDelete
         }
     }
 
@@ -234,7 +244,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 
@@ -252,7 +261,6 @@ public sealed class SyncRepositoryTests
         }
         catch(InvalidOperationException)
         {
-            // Expected - in-memory provider doesn't support ExecuteUpdate
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARemoteItemRef.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARemoteItemRef.cs
@@ -4,39 +4,39 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
 
 public sealed class GivenARemoteItemRef
 {
-    private const string AccountId = "account-123";
-    private const string FolderId = "folder-456";
-    private const string RemoteItemId = "item-789";
+    private const string AccountIdValue = "account-123";
+    private const string FolderIdValue = "folder-456";
+    private const string RemoteItemIdValue = "item-789";
 
     [Fact]
     public void when_created_then_account_id_is_set_correctly()
     {
-        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var remoteItemRef = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
 
-        remoteItemRef.AccountId.ShouldBe(AccountId);
+        remoteItemRef.AccountId.Id.ShouldBe(AccountIdValue);
     }
 
     [Fact]
     public void when_created_then_folder_id_is_set_correctly()
     {
-        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var remoteItemRef = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
 
-        remoteItemRef.FolderId.ShouldBe(FolderId);
+        remoteItemRef.FolderId.Id.ShouldBe(FolderIdValue);
     }
 
     [Fact]
     public void when_created_then_remote_item_id_is_set_correctly()
     {
-        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var remoteItemRef = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
 
-        remoteItemRef.RemoteItemId.ShouldBe(RemoteItemId);
+        remoteItemRef.RemoteItemId.Id.ShouldBe(RemoteItemIdValue);
     }
 
     [Fact]
     public void when_two_instances_have_same_values_then_they_are_equal()
     {
-        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
-        var second = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var first = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
+        var second = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
 
         first.ShouldBe(second);
     }
@@ -44,8 +44,8 @@ public sealed class GivenARemoteItemRef
     [Fact]
     public void when_two_instances_have_different_account_ids_then_they_are_not_equal()
     {
-        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
-        var second = RemoteItemRefFactory.Create("account-different", FolderId, RemoteItemId);
+        var first = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
+        var second = RemoteItemRefFactory.Create(new AccountId("account-different"), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
 
         first.ShouldNotBe(second);
     }
@@ -53,8 +53,8 @@ public sealed class GivenARemoteItemRef
     [Fact]
     public void when_two_instances_have_different_folder_ids_then_they_are_not_equal()
     {
-        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
-        var second = RemoteItemRefFactory.Create(AccountId, "folder-different", RemoteItemId);
+        var first = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
+        var second = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId("folder-different"), new OneDriveItemId(RemoteItemIdValue));
 
         first.ShouldNotBe(second);
     }
@@ -62,8 +62,8 @@ public sealed class GivenARemoteItemRef
     [Fact]
     public void when_two_instances_have_different_remote_item_ids_then_they_are_not_equal()
     {
-        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
-        var second = RemoteItemRefFactory.Create(AccountId, FolderId, "item-different");
+        var first = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId(RemoteItemIdValue));
+        var second = RemoteItemRefFactory.Create(new AccountId(AccountIdValue), new OneDriveFolderId(FolderIdValue), new OneDriveItemId("item-different"));
 
         first.ShouldNotBe(second);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARemoteItemRef.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARemoteItemRef.cs
@@ -1,0 +1,70 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenARemoteItemRef
+{
+    private const string AccountId = "account-123";
+    private const string FolderId = "folder-456";
+    private const string RemoteItemId = "item-789";
+
+    [Fact]
+    public void when_created_then_account_id_is_set_correctly()
+    {
+        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+
+        remoteItemRef.AccountId.ShouldBe(AccountId);
+    }
+
+    [Fact]
+    public void when_created_then_folder_id_is_set_correctly()
+    {
+        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+
+        remoteItemRef.FolderId.ShouldBe(FolderId);
+    }
+
+    [Fact]
+    public void when_created_then_remote_item_id_is_set_correctly()
+    {
+        var remoteItemRef = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+
+        remoteItemRef.RemoteItemId.ShouldBe(RemoteItemId);
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_values_then_they_are_equal()
+    {
+        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var second = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_account_ids_then_they_are_not_equal()
+    {
+        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var second = RemoteItemRefFactory.Create("account-different", FolderId, RemoteItemId);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_folder_ids_then_they_are_not_equal()
+    {
+        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var second = RemoteItemRefFactory.Create(AccountId, "folder-different", RemoteItemId);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_remote_item_ids_then_they_are_not_equal()
+    {
+        var first = RemoteItemRefFactory.Create(AccountId, FolderId, RemoteItemId);
+        var second = RemoteItemRefFactory.Create(AccountId, FolderId, "item-different");
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncFileMetadata.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncFileMetadata.cs
@@ -1,0 +1,52 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenASyncFileMetadata
+{
+    private const long FileSize = 4096L;
+    private static readonly DateTimeOffset RemoteModified = new(2026, 3, 15, 9, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void when_created_then_file_size_is_set_correctly()
+    {
+        var metadata = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+
+        metadata.FileSize.ShouldBe(FileSize);
+    }
+
+    [Fact]
+    public void when_created_then_remote_modified_is_set_correctly()
+    {
+        var metadata = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+
+        metadata.RemoteModified.ShouldBe(RemoteModified);
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_values_then_they_are_equal()
+    {
+        var first = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+        var second = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_file_sizes_then_they_are_not_equal()
+    {
+        var first = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+        var second = SyncFileMetadataFactory.Create(8192L, RemoteModified);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_remote_modified_dates_then_they_are_not_equal()
+    {
+        var first = SyncFileMetadataFactory.Create(FileSize, RemoteModified);
+        var second = SyncFileMetadataFactory.Create(FileSize, RemoteModified.AddHours(1));
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncFileTarget.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncFileTarget.cs
@@ -1,0 +1,52 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenASyncFileTarget
+{
+    private const string LocalPath = "/home/user/Documents/report.pdf";
+    private const string RelativePath = "Documents/report.pdf";
+
+    [Fact]
+    public void when_created_then_local_path_is_set_correctly()
+    {
+        var target = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+
+        target.LocalPath.ShouldBe(LocalPath);
+    }
+
+    [Fact]
+    public void when_created_then_relative_path_is_set_correctly()
+    {
+        var target = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+
+        target.RelativePath.ShouldBe(RelativePath);
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_values_then_they_are_equal()
+    {
+        var first = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+        var second = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_local_paths_then_they_are_not_equal()
+    {
+        var first = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+        var second = SyncFileTargetFactory.Create("/home/user/Other/report.pdf", RelativePath);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_relative_paths_then_they_are_not_equal()
+    {
+        var first = SyncFileTargetFactory.Create(LocalPath, RelativePath);
+        var second = SyncFileTargetFactory.Create(LocalPath, "Other/report.pdf");
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJob.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJob.cs
@@ -2,11 +2,11 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
 
-public sealed class SyncJobTests
+public sealed class GivenASyncJob
 {
     private static SyncJob CreateMinimalJob()
     {
-        var remote = RemoteItemRefFactory.Create("", "", "");
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId(""), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create();
@@ -27,7 +27,7 @@ public sealed class SyncJobTests
     {
         var syncJob = CreateMinimalJob();
 
-        syncJob.Remote.AccountId.ShouldBe(string.Empty);
+        syncJob.Remote.AccountId.Id.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class SyncJobTests
     {
         var syncJob = CreateMinimalJob();
 
-        syncJob.Remote.FolderId.ShouldBe(string.Empty);
+        syncJob.Remote.FolderId.Id.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public sealed class SyncJobTests
     {
         var syncJob = CreateMinimalJob();
 
-        syncJob.Remote.RemoteItemId.ShouldBe(string.Empty);
+        syncJob.Remote.RemoteItemId.Id.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -148,16 +148,16 @@ public sealed class SyncJobTests
         const string localPath = "/home/jason/Documents/report.pdf";
         const long fileSize = 1024L;
 
-        var remote = RemoteItemRefFactory.Create(accountId, folderId, remoteItemId);
+        var remote = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId(folderId), new OneDriveItemId(remoteItemId));
         var target = SyncFileTargetFactory.Create(localPath, relativePath);
         var metadata = SyncFileMetadataFactory.Create(fileSize, remoteModified);
         var status = SyncJobStatusFactory.Create();
         var syncJob = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status) with { Status = status with { Id = jobId, QueuedAt = queuedAt } };
 
         syncJob.Status.Id.ShouldBe(jobId);
-        syncJob.Remote.AccountId.ShouldBe(accountId);
-        syncJob.Remote.FolderId.ShouldBe(folderId);
-        syncJob.Remote.RemoteItemId.ShouldBe(remoteItemId);
+        syncJob.Remote.AccountId.Id.ShouldBe(accountId);
+        syncJob.Remote.FolderId.Id.ShouldBe(folderId);
+        syncJob.Remote.RemoteItemId.Id.ShouldBe(remoteItemId);
         syncJob.Target.RelativePath.ShouldBe(relativePath);
         syncJob.Target.LocalPath.ShouldBe(localPath);
         syncJob.Direction.ShouldBe(SyncDirection.Download);
@@ -224,7 +224,7 @@ public sealed class SyncJobTests
     [InlineData(SyncDirection.Delete)]
     public void when_direction_is_set_then_all_directions_are_supported(SyncDirection direction)
     {
-        var remote = RemoteItemRefFactory.Create("", "", "");
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId(""), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create();
@@ -250,7 +250,7 @@ public sealed class SyncJobTests
     {
         var jobId = Guid.NewGuid();
         var queuedAt = DateTimeOffset.UtcNow;
-        var remote = RemoteItemRefFactory.Create("account-123", "", "");
+        var remote = RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId(""), new OneDriveItemId(""));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create() with { Id = jobId, QueuedAt = queuedAt };
@@ -268,8 +268,8 @@ public sealed class SyncJobTests
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create() with { Id = jobId, QueuedAt = queuedAt };
-        var job1 = SyncJobFactory.Create(RemoteItemRefFactory.Create("account-123", "", ""), target, metadata, default, status);
-        var job2 = SyncJobFactory.Create(RemoteItemRefFactory.Create("account-456", "", ""), target, metadata, default, status);
+        var job1 = SyncJobFactory.Create(RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId(""), new OneDriveItemId("")), target, metadata, default, status);
+        var job2 = SyncJobFactory.Create(RemoteItemRefFactory.Create(new AccountId("account-456"), new OneDriveFolderId(""), new OneDriveItemId("")), target, metadata, default, status);
 
         job1.ShouldNotBe(job2);
     }
@@ -277,7 +277,7 @@ public sealed class SyncJobTests
     [Fact]
     public void when_direction_is_download_then_state_defaults_to_queued()
     {
-        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var remote = RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId("folder-456"), new OneDriveItemId("item-789"));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create();
@@ -291,7 +291,7 @@ public sealed class SyncJobTests
     [Fact]
     public void when_direction_is_upload_then_state_defaults_to_queued()
     {
-        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var remote = RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId("folder-456"), new OneDriveItemId("item-789"));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create();
@@ -305,7 +305,7 @@ public sealed class SyncJobTests
     [Fact]
     public void when_direction_is_delete_then_state_defaults_to_queued()
     {
-        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var remote = RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId("folder-456"), new OneDriveItemId("item-789"));
         var target = SyncFileTargetFactory.Create("", "");
         var metadata = SyncFileMetadataFactory.Create(0L, default);
         var status = SyncJobStatusFactory.Create();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
@@ -1,0 +1,144 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenASyncJobExtensions
+{
+    private static SyncJob CreateMinimalJob()
+    {
+        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var target = SyncFileTargetFactory.Create("/home/user/file.txt", "file.txt");
+        var metadata = SyncFileMetadataFactory.Create(1024L, DateTimeOffset.UtcNow.AddHours(-1));
+        var status = SyncJobStatusFactory.Create();
+
+        return SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status);
+    }
+
+    [Fact]
+    public void when_complete_is_called_then_state_is_set_to_completed()
+    {
+        var job = CreateMinimalJob();
+
+        var completed = job.Complete();
+
+        completed.Status.State.ShouldBe(SyncJobState.Completed);
+    }
+
+    [Fact]
+    public void when_complete_is_called_then_completed_at_is_approximately_utc_now()
+    {
+        var job = CreateMinimalJob();
+        var before = DateTimeOffset.UtcNow;
+
+        var completed = job.Complete();
+
+        completed.Status.CompletedAt.ShouldNotBeNull();
+        completed.Status.CompletedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        completed.Status.CompletedAt.Value.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void when_complete_is_called_then_all_other_fields_are_preserved()
+    {
+        var job = CreateMinimalJob();
+
+        var completed = job.Complete();
+
+        completed.Remote.ShouldBe(job.Remote);
+        completed.Target.ShouldBe(job.Target);
+        completed.Metadata.ShouldBe(job.Metadata);
+        completed.Direction.ShouldBe(job.Direction);
+        completed.Status.Id.ShouldBe(job.Status.Id);
+        completed.Status.QueuedAt.ShouldBe(job.Status.QueuedAt);
+        completed.DownloadUrl.ShouldBe(job.DownloadUrl);
+        completed.UploadedRemoteItemId.ShouldBe(job.UploadedRemoteItemId);
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_null_error_message_then_state_is_set_to_failed()
+    {
+        var job = CreateMinimalJob();
+
+        var failed = job.Fail(null);
+
+        failed.Status.State.ShouldBe(SyncJobState.Failed);
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_null_error_message_then_error_message_is_null()
+    {
+        var job = CreateMinimalJob();
+
+        var failed = job.Fail(null);
+
+        failed.Status.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_null_error_message_then_completed_at_is_approximately_utc_now()
+    {
+        var job = CreateMinimalJob();
+        var before = DateTimeOffset.UtcNow;
+
+        var failed = job.Fail(null);
+
+        failed.Status.CompletedAt.ShouldNotBeNull();
+        failed.Status.CompletedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        failed.Status.CompletedAt.Value.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_an_error_message_then_state_is_set_to_failed()
+    {
+        var job = CreateMinimalJob();
+
+        var failed = job.Fail("Upload timed out");
+
+        failed.Status.State.ShouldBe(SyncJobState.Failed);
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_an_error_message_then_error_message_is_set()
+    {
+        var job = CreateMinimalJob();
+        const string errorMessage = "Upload timed out";
+
+        var failed = job.Fail(errorMessage);
+
+        failed.Status.ErrorMessage.ShouldBe(errorMessage);
+    }
+
+    [Fact]
+    public void when_fail_is_called_with_an_error_message_then_completed_at_is_approximately_utc_now()
+    {
+        var job = CreateMinimalJob();
+        var before = DateTimeOffset.UtcNow;
+
+        var failed = job.Fail("Upload timed out");
+
+        failed.Status.CompletedAt.ShouldNotBeNull();
+        failed.Status.CompletedAt.Value.ShouldBeGreaterThanOrEqualTo(before);
+        failed.Status.CompletedAt.Value.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void when_complete_is_called_then_original_job_is_unchanged()
+    {
+        var job = CreateMinimalJob();
+
+        _ = job.Complete();
+
+        job.Status.State.ShouldBe(SyncJobState.Queued);
+        job.Status.CompletedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_complete_is_called_then_a_new_instance_is_returned()
+    {
+        var job = CreateMinimalJob();
+
+        var completed = job.Complete();
+
+        completed.ShouldNotBeSameAs(job);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
@@ -6,7 +6,7 @@ public sealed class GivenASyncJobExtensions
 {
     private static SyncJob CreateMinimalJob()
     {
-        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var remote = RemoteItemRefFactory.Create(new AccountId("account-123"), new OneDriveFolderId("folder-456"), new OneDriveItemId("item-789"));
         var target = SyncFileTargetFactory.Create("/home/user/file.txt", "file.txt");
         var metadata = SyncFileMetadataFactory.Create(1024L, DateTimeOffset.UtcNow.AddHours(-1));
         var status = SyncJobStatusFactory.Create();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobStatus.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobStatus.cs
@@ -1,0 +1,58 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenASyncJobStatus
+{
+    [Fact]
+    public void when_created_then_id_is_not_empty()
+    {
+        var status = SyncJobStatusFactory.Create();
+
+        status.Id.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_queued_at_is_approximately_utc_now()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var status = SyncJobStatusFactory.Create();
+
+        status.QueuedAt.ShouldBeGreaterThanOrEqualTo(before);
+        status.QueuedAt.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void when_created_then_state_defaults_to_queued()
+    {
+        var status = SyncJobStatusFactory.Create();
+
+        status.State.ShouldBe(SyncJobState.Queued);
+    }
+
+    [Fact]
+    public void when_created_then_error_message_is_null()
+    {
+        var status = SyncJobStatusFactory.Create();
+
+        status.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_created_then_completed_at_is_null()
+    {
+        var status = SyncJobStatusFactory.Create();
+
+        status.CompletedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_created_twice_then_ids_are_different()
+    {
+        var firstStatus = SyncJobStatusFactory.Create();
+        var secondStatus = SyncJobStatusFactory.Create();
+
+        firstStatus.Id.ShouldNotBe(secondStatus.Id);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/SyncJobTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/SyncJobTests.cs
@@ -4,71 +4,173 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
 
 public sealed class SyncJobTests
 {
-    private static SyncJob CreateMinimalJob() => SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default);
-
-    [Fact]
-    public void Constructor_ShouldInitializeWithDefaultValues()
+    private static SyncJob CreateMinimalJob()
     {
-        var syncJob = CreateMinimalJob();
+        var remote = RemoteItemRefFactory.Create("", "", "");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
 
-        syncJob.Id.ShouldNotBe(Guid.Empty);
-        syncJob.AccountId.ShouldBe(string.Empty);
-        syncJob.FolderId.ShouldBe(string.Empty);
-        syncJob.RemoteItemId.ShouldBe(string.Empty);
-        syncJob.RelativePath.ShouldBe(string.Empty);
-        syncJob.LocalPath.ShouldBe(string.Empty);
-        syncJob.Direction.ShouldBe(default);
-        syncJob.State.ShouldBe(SyncJobState.Queued);
-        syncJob.ErrorMessage.ShouldBeNull();
-        syncJob.DownloadUrl.ShouldBeNull();
-        syncJob.FileSize.ShouldBe(0L);
-        syncJob.RemoteModified.ShouldBe(default);
-        syncJob.QueuedAt.ShouldNotBe(default);
-        syncJob.CompletedAt.ShouldBeNull();
+        return SyncJobFactory.Create(remote, target, metadata, default, status);
     }
 
     [Fact]
-    public void Id_ShouldBeUnique()
+    public void when_created_then_status_id_is_not_empty()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Status.Id.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_remote_account_id_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Remote.AccountId.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_remote_folder_id_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Remote.FolderId.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_remote_item_id_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Remote.RemoteItemId.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_target_relative_path_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Target.RelativePath.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_target_local_path_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Target.LocalPath.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_created_then_direction_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Direction.ShouldBe(default(SyncDirection));
+    }
+
+    [Fact]
+    public void when_created_then_status_state_defaults_to_queued()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Status.State.ShouldBe(SyncJobState.Queued);
+    }
+
+    [Fact]
+    public void when_created_then_status_error_message_is_null()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Status.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_created_then_download_url_is_null()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.DownloadUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_created_then_metadata_file_size_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Metadata.FileSize.ShouldBe(0L);
+    }
+
+    [Fact]
+    public void when_created_then_metadata_remote_modified_matches_factory_input()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Metadata.RemoteModified.ShouldBe(default(DateTimeOffset));
+    }
+
+    [Fact]
+    public void when_created_then_status_queued_at_is_not_default()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Status.QueuedAt.ShouldNotBe(default(DateTimeOffset));
+    }
+
+    [Fact]
+    public void when_created_then_status_completed_at_is_null()
+    {
+        var syncJob = CreateMinimalJob();
+
+        syncJob.Status.CompletedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_created_twice_then_status_ids_are_different()
     {
         var job1 = CreateMinimalJob();
         var job2 = CreateMinimalJob();
 
-        job1.Id.ShouldNotBe(job2.Id);
+        job1.Status.Id.ShouldNotBe(job2.Status.Id);
     }
 
     [Fact]
-    public void CanCreateWithInitProperties()
+    public void when_created_with_all_properties_then_values_are_correct()
     {
-        var id = Guid.NewGuid();
-        string accountId = "account-123";
-        string folderId = "folder-456";
-        string remoteItemId = "item-789";
-        string relativePath = "Documents/report.pdf";
-        string localPath = "/home/jason/Documents/report.pdf";
-        var direction = SyncDirection.Download;
-        long fileSize = 1024L;
-        var remoteModified = DateTimeOffset.UtcNow.AddHours(-1);
+        var jobId = Guid.NewGuid();
         var queuedAt = DateTimeOffset.UtcNow;
+        var remoteModified = DateTimeOffset.UtcNow.AddHours(-1);
+        const string accountId = "account-123";
+        const string folderId = "folder-456";
+        const string remoteItemId = "item-789";
+        const string relativePath = "Documents/report.pdf";
+        const string localPath = "/home/jason/Documents/report.pdf";
+        const long fileSize = 1024L;
 
-        var syncJob = SyncJobFactory.Create(accountId, folderId, remoteItemId, relativePath, localPath, direction, fileSize, remoteModified) with { Id = id, QueuedAt = queuedAt };
+        var remote = RemoteItemRefFactory.Create(accountId, folderId, remoteItemId);
+        var target = SyncFileTargetFactory.Create(localPath, relativePath);
+        var metadata = SyncFileMetadataFactory.Create(fileSize, remoteModified);
+        var status = SyncJobStatusFactory.Create();
+        var syncJob = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status) with { Status = status with { Id = jobId, QueuedAt = queuedAt } };
 
-        syncJob.Id.ShouldBe(id);
-        syncJob.AccountId.ShouldBe(accountId);
-        syncJob.FolderId.ShouldBe(folderId);
-        syncJob.RemoteItemId.ShouldBe(remoteItemId);
-        syncJob.RelativePath.ShouldBe(relativePath);
-        syncJob.LocalPath.ShouldBe(localPath);
-        syncJob.Direction.ShouldBe(direction);
-        syncJob.FileSize.ShouldBe(fileSize);
-        syncJob.RemoteModified.ShouldBe(remoteModified);
+        syncJob.Status.Id.ShouldBe(jobId);
+        syncJob.Remote.AccountId.ShouldBe(accountId);
+        syncJob.Remote.FolderId.ShouldBe(folderId);
+        syncJob.Remote.RemoteItemId.ShouldBe(remoteItemId);
+        syncJob.Target.RelativePath.ShouldBe(relativePath);
+        syncJob.Target.LocalPath.ShouldBe(localPath);
+        syncJob.Direction.ShouldBe(SyncDirection.Download);
+        syncJob.Metadata.FileSize.ShouldBe(fileSize);
+        syncJob.Metadata.RemoteModified.ShouldBe(remoteModified);
     }
 
     [Fact]
     public void when_copied_with_new_state_then_state_is_updated()
     {
-        var syncJob = CreateMinimalJob() with { State = SyncJobState.InProgress };
+        var syncJob = CreateMinimalJob() with { Status = CreateMinimalJob().Status with { State = SyncJobState.InProgress } };
 
-        syncJob.State.ShouldBe(SyncJobState.InProgress);
+        syncJob.Status.State.ShouldBe(SyncJobState.InProgress);
     }
 
     [Theory]
@@ -77,27 +179,28 @@ public sealed class SyncJobTests
     [InlineData(SyncJobState.Completed)]
     [InlineData(SyncJobState.Failed)]
     [InlineData(SyncJobState.Skipped)]
-    public void State_ShouldSupportAllStates(SyncJobState state)
+    public void when_status_state_is_set_then_all_states_are_supported(SyncJobState state)
     {
-        var syncJob = CreateMinimalJob() with { State = state };
+        var syncJob = CreateMinimalJob() with { Status = CreateMinimalJob().Status with { State = state } };
 
-        syncJob.State.ShouldBe(state);
+        syncJob.Status.State.ShouldBe(state);
     }
 
     [Fact]
     public void when_copied_with_error_message_then_error_message_is_set()
     {
-        string errorMessage = "File is locked by another process";
+        const string errorMessage = "File is locked by another process";
+        var original = CreateMinimalJob();
 
-        var syncJob = CreateMinimalJob() with { ErrorMessage = errorMessage };
+        var syncJob = original with { Status = original.Status with { ErrorMessage = errorMessage } };
 
-        syncJob.ErrorMessage.ShouldBe(errorMessage);
+        syncJob.Status.ErrorMessage.ShouldBe(errorMessage);
     }
 
     [Fact]
     public void when_copied_with_download_url_then_download_url_is_set()
     {
-        string downloadUrl = "https://graph.microsoft.com/v1.0/drives/abc123/items/xyz789/content";
+        const string downloadUrl = "https://graph.microsoft.com/v1.0/drives/abc123/items/xyz789/content";
 
         var syncJob = CreateMinimalJob() with { DownloadUrl = downloadUrl };
 
@@ -108,79 +211,108 @@ public sealed class SyncJobTests
     public void when_copied_with_completed_at_then_completed_at_is_set()
     {
         var completedAt = DateTimeOffset.UtcNow;
+        var original = CreateMinimalJob();
 
-        var syncJob = CreateMinimalJob() with { CompletedAt = completedAt };
+        var syncJob = original with { Status = original.Status with { CompletedAt = completedAt } };
 
-        syncJob.CompletedAt.ShouldBe(completedAt);
+        syncJob.Status.CompletedAt.ShouldBe(completedAt);
     }
 
     [Theory]
     [InlineData(SyncDirection.Download)]
     [InlineData(SyncDirection.Upload)]
     [InlineData(SyncDirection.Delete)]
-    public void Direction_ShouldSupportAllDirections(SyncDirection direction)
+    public void when_direction_is_set_then_all_directions_are_supported(SyncDirection direction)
     {
-        var syncJob = SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: direction, fileSize: 0, remoteModified: default);
+        var remote = RemoteItemRefFactory.Create("", "", "");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
+
+        var syncJob = SyncJobFactory.Create(remote, target, metadata, direction, status);
 
         syncJob.Direction.ShouldBe(direction);
     }
 
     [Fact]
-    public void QueuedAt_ShouldBeSetToCurrentUtcTimeByDefault()
+    public void when_created_then_status_queued_at_is_set_to_approximately_utc_now()
     {
         var beforeCreation = DateTimeOffset.UtcNow;
 
         var syncJob = CreateMinimalJob();
 
-        syncJob.QueuedAt.ShouldBeGreaterThanOrEqualTo(beforeCreation);
-        syncJob.QueuedAt.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
+        syncJob.Status.QueuedAt.ShouldBeGreaterThanOrEqualTo(beforeCreation);
+        syncJob.Status.QueuedAt.ShouldBeLessThanOrEqualTo(DateTimeOffset.UtcNow);
     }
 
     [Fact]
-    public void IsRecord_ShouldAllowValueEquality()
+    public void when_two_jobs_have_same_values_then_they_are_equal()
     {
-        var id = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
         var queuedAt = DateTimeOffset.UtcNow;
-        var job1 = CreateMinimalJob() with { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
-        var job2 = CreateMinimalJob() with { Id = id, AccountId = "account-123", QueuedAt = queuedAt };
+        var remote = RemoteItemRefFactory.Create("account-123", "", "");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create() with { Id = jobId, QueuedAt = queuedAt };
+        var job1 = SyncJobFactory.Create(remote, target, metadata, default, status);
+        var job2 = SyncJobFactory.Create(remote, target, metadata, default, status);
 
         job1.ShouldBe(job2);
     }
 
     [Fact]
-    public void IsRecord_ShouldDifferOnPropertyChange()
+    public void when_two_jobs_differ_on_account_id_then_they_are_not_equal()
     {
-        var id = Guid.NewGuid();
-        var job1 = CreateMinimalJob() with { Id = id, AccountId = "account-123" };
-        var job2 = CreateMinimalJob() with { Id = id, AccountId = "account-456" };
+        var jobId = Guid.NewGuid();
+        var queuedAt = DateTimeOffset.UtcNow;
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create() with { Id = jobId, QueuedAt = queuedAt };
+        var job1 = SyncJobFactory.Create(RemoteItemRefFactory.Create("account-123", "", ""), target, metadata, default, status);
+        var job2 = SyncJobFactory.Create(RemoteItemRefFactory.Create("account-456", "", ""), target, metadata, default, status);
 
         job1.ShouldNotBe(job2);
     }
 
     [Fact]
-    public void DownloadJob_ShouldHaveCorrectProperties()
+    public void when_direction_is_download_then_state_defaults_to_queued()
     {
-        var downloadJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Download, fileSize: 0, remoteModified: default);
+        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
+
+        var downloadJob = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status);
 
         downloadJob.Direction.ShouldBe(SyncDirection.Download);
-        downloadJob.State.ShouldBe(SyncJobState.Queued);
+        downloadJob.Status.State.ShouldBe(SyncJobState.Queued);
     }
 
     [Fact]
-    public void UploadJob_ShouldHaveCorrectProperties()
+    public void when_direction_is_upload_then_state_defaults_to_queued()
     {
-        var uploadJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Upload, fileSize: 0, remoteModified: default);
+        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
+
+        var uploadJob = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Upload, status);
 
         uploadJob.Direction.ShouldBe(SyncDirection.Upload);
-        uploadJob.State.ShouldBe(SyncJobState.Queued);
+        uploadJob.Status.State.ShouldBe(SyncJobState.Queued);
     }
 
     [Fact]
-    public void DeleteJob_ShouldHaveCorrectProperties()
+    public void when_direction_is_delete_then_state_defaults_to_queued()
     {
-        var deleteJob = SyncJobFactory.Create(accountId: "account-123", folderId: "folder-456", remoteItemId: "item-789", relativePath: "", localPath: "", direction: SyncDirection.Delete, fileSize: 0, remoteModified: default);
+        var remote = RemoteItemRefFactory.Create("account-123", "folder-456", "item-789");
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
+
+        var deleteJob = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Delete, status);
 
         deleteJob.Direction.ShouldBe(SyncDirection.Delete);
-        deleteJob.State.ShouldBe(SyncJobState.Queued);
+        deleteJob.Status.State.ShouldBe(SyncJobState.Queued);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
@@ -20,7 +20,14 @@ public sealed class GivenADownloadWorker
     private DownloadWorker CreateSut(int workerId = 1) => new(workerId, _downloader, _graphService, _syncRepository, _fileSystem);
 
     private static SyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file")
-        => SyncJobFactory.Create(remoteItemId: ItemId, relativePath: "Desktop/file.txt", localPath: "/tmp/file.txt", direction: SyncDirection.Download, remoteModified: DateTimeOffset.UtcNow, downloadUrl: downloadUrl, accountId: "", folderId: "", fileSize: 0);
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId(""), new OneDriveItemId(ItemId));
+        var target = SyncFileTargetFactory.Create("/tmp/file.txt", "Desktop/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(0L, DateTimeOffset.UtcNow);
+        var status = SyncJobStatusFactory.Create();
+
+        return SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status, downloadUrl: downloadUrl);
+    }
 
     private static async Task<(List<SyncJob> Completed, List<string?> Errors)> RunWorkerWithJobsAsync(DownloadWorker worker, IEnumerable<SyncJob> jobs, CancellationToken ct)
     {
@@ -50,7 +57,7 @@ public sealed class GivenADownloadWorker
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _downloader.Received(1).DownloadAsync(url, job.LocalPath, job.RemoteModified, ct: Arg.Any<CancellationToken>());
+        await _downloader.Received(1).DownloadAsync(url, job.Target.LocalPath, job.Metadata.RemoteModified, ct: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -65,7 +72,7 @@ public sealed class GivenADownloadWorker
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
         await _graphService.Received(1).GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>());
-        await _downloader.Received(1).DownloadAsync(fetchedUrl, job.LocalPath, job.RemoteModified, ct: Arg.Any<CancellationToken>());
+        await _downloader.Received(1).DownloadAsync(fetchedUrl, job.Target.LocalPath, job.Metadata.RemoteModified, ct: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -94,7 +101,7 @@ public sealed class GivenADownloadWorker
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).UpdateJobStateAsync(job.Id, SyncJobState.Failed, Arg.Any<string>());
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, Arg.Any<string>());
     }
 
     [Fact]
@@ -104,7 +111,7 @@ public sealed class GivenADownloadWorker
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).UpdateJobStateAsync(job.Id, SyncJobState.Completed);
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed);
     }
 
     [Fact]
@@ -121,20 +128,28 @@ public sealed class GivenADownloadWorker
     [Fact]
     public async Task when_upload_job_is_processed_then_graph_service_upload_is_called()
     {
-        var job = SyncJobFactory.Create(remoteItemId: ItemId, folderId: "folder-1", relativePath: "Desktop/file.txt", localPath: "/tmp/file.txt", direction: SyncDirection.Upload, remoteModified: DateTimeOffset.UtcNow, accountId: "", fileSize: 0);
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId("folder-1"), new OneDriveItemId(ItemId));
+        var target = SyncFileTargetFactory.Create("/tmp/file.txt", "Desktop/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(0L, DateTimeOffset.UtcNow);
+        var status = SyncJobStatusFactory.Create();
+        var job = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Upload, status);
 
-        _graphService.UploadFileAsync(AccessToken, job.LocalPath, Arg.Any<string>(), job.FolderId, Arg.Any<CancellationToken>())
+        _graphService.UploadFileAsync(AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
             .Returns("remote-item-id");
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _graphService.Received(1).UploadFileAsync(AccessToken, job.LocalPath, Arg.Any<string>(), job.FolderId, Arg.Any<CancellationToken>());
+        await _graphService.Received(1).UploadFileAsync(AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task when_delete_job_is_processed_then_no_downloader_or_graph_download_calls_are_made()
     {
-        var job = SyncJobFactory.Create(remoteItemId: ItemId, relativePath: "Desktop/file.txt", localPath: "/tmp/nonexistent-file-that-does-not-exist.txt", direction: SyncDirection.Delete, remoteModified: DateTimeOffset.UtcNow, accountId: "", folderId: "", fileSize: 0);
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId(""), new OneDriveItemId(ItemId));
+        var target = SyncFileTargetFactory.Create("/tmp/nonexistent-file-that-does-not-exist.txt", "Desktop/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(0L, DateTimeOffset.UtcNow);
+        var status = SyncJobStatusFactory.Create();
+        var job = SyncJobFactory.Create(remote, target, metadata, SyncDirection.Delete, status);
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
@@ -90,7 +90,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].AccountId.ShouldBe(AccountId);
+        jobs[0].Remote.AccountId.Id.ShouldBe(AccountId);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].LocalPath.ShouldBe(filePath);
+        jobs[0].Target.LocalPath.ShouldBe(filePath);
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].RelativePath.ShouldBe("Documents/report.txt");
+        jobs[0].Target.RelativePath.ShouldBe("Documents/report.txt");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].DownloadUrl.ShouldBe(jobs[0].RelativePath);
+        jobs[0].DownloadUrl.ShouldBe(jobs[0].Target.RelativePath);
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].FolderId.ShouldBe(string.Empty);
+        jobs[0].Remote.FolderId.Id.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
 
-        jobs[0].RemoteItemId.ShouldBe(knownRemoteItemId);
+        jobs[0].Remote.RemoteItemId.Id.ShouldBe(knownRemoteItemId);
     }
 
     [Fact]
@@ -311,7 +311,7 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].RelativePath.ShouldBe("Documents/Reports/q1.txt");
+        jobs[0].Target.RelativePath.ShouldBe("Documents/Reports/q1.txt");
     }
 
     [Fact]
@@ -355,7 +355,7 @@ public sealed class GivenALocalChangeDetector
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
         jobs.Count.ShouldBe(1);
-        jobs[0].LocalPath.ShouldStartWith(BasePath);
+        jobs[0].Target.LocalPath.ShouldStartWith(BasePath);
     }
 
     [Fact]
@@ -369,6 +369,6 @@ public sealed class GivenALocalChangeDetector
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
         jobs.Count.ShouldBe(1);
-        jobs[0].RelativePath.ShouldBe("Documents/2024/report.txt");
+        jobs[0].Target.RelativePath.ShouldBe("Documents/2024/report.txt");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
@@ -8,8 +8,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenAParallelDownloadPipeline
 {
-    private const string AccountId  = "account-1";
-    private const string FolderId   = "folder-1";
+    private const string AccountIdValue = "account-1";
+    private const string FolderIdValue  = "folder-1";
     private const string AccessToken = "test-token";
 
     private readonly IHttpDownloader  _downloader     = Substitute.For<IHttpDownloader>();
@@ -20,7 +20,14 @@ public sealed class GivenAParallelDownloadPipeline
     private ParallelDownloadPipeline CreateSut() => new(_syncRepository, _graphService, _downloader, _fileSystem);
 
     private static SyncJob MakeDownloadJob(string relativePath = "folder/file.txt")
-        => SyncJobFactory.Create(accountId: "", folderId: "", remoteItemId: "", relativePath: relativePath, localPath: "/tmp/test-file.txt", direction: SyncDirection.Download, fileSize: 0, remoteModified: DateTimeOffset.UtcNow, downloadUrl: "https://example.com/file");
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId(""), new OneDriveFolderId(""), new OneDriveItemId(""));
+        var target = SyncFileTargetFactory.Create("/tmp/test-file.txt", relativePath);
+        var metadata = SyncFileMetadataFactory.Create(0L, DateTimeOffset.UtcNow);
+        var status = SyncJobStatusFactory.Create();
+
+        return SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status, downloadUrl: "https://example.com/file");
+    }
 
     [Fact]
     public async Task when_job_list_is_empty_then_on_progress_is_never_called()
@@ -28,7 +35,7 @@ public sealed class GivenAParallelDownloadPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, progressEvents.Add, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents.ShouldBeEmpty();
     }
@@ -39,7 +46,7 @@ public sealed class GivenAParallelDownloadPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, _ => { }, completedEvents.Add, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.ShouldBeEmpty();
     }
@@ -49,7 +56,7 @@ public sealed class GivenAParallelDownloadPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, _ => { }, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>());
     }
@@ -60,7 +67,7 @@ public sealed class GivenAParallelDownloadPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(1);
     }
@@ -72,7 +79,7 @@ public sealed class GivenAParallelDownloadPipeline
         var jobs = new[] { MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt"), MakeDownloadJob("a/3.txt") };
         var sut = CreateSut();
 
-        await sut.RunAsync(jobs, AccessToken, _ => { }, completedEvents.Add, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(jobs, AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(3);
     }
@@ -82,7 +89,7 @@ public sealed class GivenAParallelDownloadPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).ClearCompletedJobsAsync(Arg.Any<AccountId>());
     }
@@ -92,9 +99,9 @@ public sealed class GivenAParallelDownloadPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountId));
+        await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountIdValue));
     }
 
     [Fact]
@@ -103,7 +110,7 @@ public sealed class GivenAParallelDownloadPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].SyncState.ShouldBe(SyncState.Idle);
     }
@@ -114,7 +121,7 @@ public sealed class GivenAParallelDownloadPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].CurrentFile.ShouldBe(string.Empty);
     }
@@ -125,9 +132,9 @@ public sealed class GivenAParallelDownloadPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
-        completedEvents[0].Job.State.ShouldBe(SyncJobState.Completed);
+        completedEvents[0].Job.Status.State.ShouldBe(SyncJobState.Completed);
     }
 
     [Fact]
@@ -140,7 +147,7 @@ public sealed class GivenAParallelDownloadPipeline
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
-        }, _ => { }, AccountId, FolderId, ct: TestContext.Current.CancellationToken);
+        }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         perJobProgressEvents.Count.ShouldBe(1);
         perJobProgressEvents[0].SyncState.ShouldBe(SyncState.Idle);
@@ -157,7 +164,7 @@ public sealed class GivenAParallelDownloadPipeline
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
-        }, _ => { }, AccountId, FolderId, workerCount: 1, ct: TestContext.Current.CancellationToken);
+        }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 1, ct: TestContext.Current.CancellationToken);
 
         perJobProgressEvents.Count.ShouldBe(2);
         perJobProgressEvents[0].SyncState.ShouldBe(SyncState.Syncing);
@@ -172,7 +179,7 @@ public sealed class GivenAParallelDownloadPipeline
 
         try
         {
-            await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountId, FolderId, ct: cts.Token);
+            await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: cts.Token);
         }
         catch(OperationCanceledException) { }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -150,7 +150,7 @@ public sealed class GivenARemoteFolderEnumerator
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].RemoteItemId.ShouldBe("item-a");
+        result.DownloadJobs[0].Remote.RemoteItemId.Id.ShouldBe("item-a");
         result.DownloadJobs[0].Direction.ShouldBe(SyncDirection.Download);
     }
 
@@ -280,7 +280,7 @@ public sealed class GivenARemoteFolderEnumerator
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].LocalPath.ShouldStartWith(BasePath);
+        result.DownloadJobs[0].Target.LocalPath.ShouldStartWith(BasePath);
     }
 
     [Fact]
@@ -295,6 +295,6 @@ public sealed class GivenARemoteFolderEnumerator
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].LocalPath.ShouldNotBe(BasePath);
+        result.DownloadJobs[0].Target.LocalPath.ShouldNotBe(BasePath);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncEventAggregator.cs
@@ -31,13 +31,18 @@ public sealed class GivenASyncEventAggregator
         var sut = CreateSut();
         JobCompletedEventArgs? captured = null;
         sut.JobCompleted += (_, args) => captured = args;
-        var job = SyncJobFactory.Create(accountId: "acc-2", folderId: "", remoteItemId: "", relativePath: "", localPath: "", direction: default, fileSize: 0, remoteModified: default);
+
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-2"), new OneDriveFolderId(""), new OneDriveItemId(""));
+        var target = SyncFileTargetFactory.Create("", "");
+        var metadata = SyncFileMetadataFactory.Create(0L, default);
+        var status = SyncJobStatusFactory.Create();
+        var job = SyncJobFactory.Create(remote, target, metadata, default, status);
         var eventArgs = new JobCompletedEventArgs(job);
 
         _syncService.JobCompleted += Raise.EventWith(eventArgs);
 
         captured.ShouldNotBeNull();
-        captured.Job.AccountId.ShouldBe("acc-2");
+        captured.Job.Remote.AccountId.Id.ShouldBe("acc-2");
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -23,7 +23,14 @@ public sealed class GivenASyncJobExecutor
     private SyncJobExecutor CreateSut(MockFileSystem mockFs) => new(_syncRepository, _syncedItemRepository, _pipeline, mockFs);
 
     private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
-        => SyncJobFactory.Create(accountId: "user-1", folderId: "", remoteItemId: remoteId, relativePath: "Documents/file.txt", localPath: localPath, direction: direction, fileSize: 100L, remoteModified: DateTimeOffset.UtcNow.AddDays(-1));
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(""), new OneDriveItemId(remoteId));
+        var target = SyncFileTargetFactory.Create(localPath, "Documents/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
+        var status = SyncJobStatusFactory.Create();
+
+        return SyncJobFactory.Create(remote, target, metadata, direction, status);
+    }
 
     [Fact]
     public async Task when_jobs_list_is_empty_then_pipeline_is_not_called()
@@ -49,14 +56,14 @@ public sealed class GivenASyncJobExecutor
     [Fact]
     public async Task when_pipeline_completes_download_job_successfully_then_synced_item_is_upserted()
     {
-        var job = MakeJob("item-1", SyncDirection.Download) with { State = SyncJobState.Queued };
+        var job = MakeJob("item-1", SyncDirection.Download);
         var jobs = new List<SyncJob> { job };
 
         _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
-                onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Completed }));
+                onJobCompleted(new JobCompletedEventArgs(job.Complete()));
             });
 
         var sut = CreateSut(new MockFileSystem());
@@ -79,7 +86,7 @@ public sealed class GivenASyncJobExecutor
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
-                onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Completed, UploadedRemoteItemId = "uploaded-remote-id" }));
+                onJobCompleted(new JobCompletedEventArgs(job.Complete() with { UploadedRemoteItemId = "uploaded-remote-id" }));
             });
 
         var sut = CreateSut(mockFs);
@@ -99,7 +106,7 @@ public sealed class GivenASyncJobExecutor
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
-                onJobCompleted(new JobCompletedEventArgs(job with { State = SyncJobState.Failed, ErrorMessage = "disk full" }));
+                onJobCompleted(new JobCompletedEventArgs(job.Fail("disk full")));
             });
 
         var sut = CreateSut(new MockFileSystem());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityItemViewModel.cs
@@ -31,12 +31,12 @@ public sealed partial class ActivityItemViewModel : ObservableObject
 
     public string TypeIcon => Type switch
     {
-        ActivityItemType.Downloaded => "\u2193",
-        ActivityItemType.Uploaded => "\u2191",
-        ActivityItemType.Deleted => "\u00D7",
-        ActivityItemType.Conflict => "\u26A0",
-        ActivityItemType.Error => "\u26A0",
-        _ => "\u2022"
+        ActivityItemType.Downloaded => "↓",
+        ActivityItemType.Uploaded => "↑",
+        ActivityItemType.Deleted => "×",
+        ActivityItemType.Conflict => "⚠",
+        ActivityItemType.Error => "⚠",
+        _ => "•"
     };
 
     public string TimeAgoText
@@ -59,11 +59,11 @@ public sealed partial class ActivityItemViewModel : ObservableObject
 
     public static ActivityItemViewModel FromJob(SyncJob job, string accountEmail, string folderName = "") => new()
     {
-        AccountId = job.AccountId,
+        AccountId = job.Remote.AccountId.Id,
         AccountEmail = accountEmail,
         FolderName = folderName,
-        FileName = Path.GetFileName(job.RelativePath),
-        RelativePath = job.RelativePath,
+        FileName = Path.GetFileName(job.Target.RelativePath),
+        RelativePath = job.Target.RelativePath,
         Type = job.Direction switch
         {
             SyncDirection.Download => ActivityItemType.Downloaded,
@@ -71,9 +71,9 @@ public sealed partial class ActivityItemViewModel : ObservableObject
             SyncDirection.Delete => ActivityItemType.Deleted,
             _ => ActivityItemType.Info
         },
-        FileSize = job.FileSize,
-        OccurredAt = job.CompletedAt ?? DateTimeOffset.UtcNow,
-        ErrorMessage = job.ErrorMessage
+        FileSize = job.Metadata.FileSize,
+        OccurredAt = job.Status.CompletedAt ?? DateTimeOffset.UtcNow,
+        ErrorMessage = job.Status.ErrorMessage
     };
 
     public static ActivityItemViewModel FromConflict(SyncConflict conflict, string accountEmail, string folderName) => new()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -118,8 +118,8 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
 
     private void OnJobCompleted(object? sender, JobCompletedEventArgs args)
     {
-        var section = AccountSections.FirstOrDefault(s => s.AccountId == args.Job.AccountId);
-        string accountEmail = section?.Email ?? args.Job.AccountId;
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == args.Job.Remote.AccountId.Id);
+        string accountEmail = section?.Email ?? args.Job.Remote.AccountId.Id;
         var item = ActivityItemViewModel.FromJob(args.Job, accountEmail);
         AddActivityItem(item);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -29,12 +29,12 @@ public static class SyncedItemEntityFactory
         => new()
         {
             AccountId        = accountId,
-            RemoteItemId     = new OneDriveItemId(job.RemoteItemId),
+            RemoteItemId     = job.Remote.RemoteItemId,
             RemoteParentId   = string.Empty,
             RemotePath       = remotePath,
-            LocalPath        = job.LocalPath,
+            LocalPath        = job.Target.LocalPath,
             IsFolder         = false,
-            RemoteModifiedAt = job.RemoteModified
+            RemoteModifiedAt = job.Metadata.RemoteModified
         };
 
     /// <summary>Creates a tracking entity for a successfully completed upload job.</summary>
@@ -45,8 +45,8 @@ public static class SyncedItemEntityFactory
             RemoteItemId     = new OneDriveItemId(job.UploadedRemoteItemId!),
             RemoteParentId   = string.Empty,
             RemotePath       = remotePath,
-            LocalPath        = job.LocalPath,
+            LocalPath        = job.Target.LocalPath,
             IsFolder         = false,
-            RemoteModifiedAt = new DateTimeOffset(fileSystem.FileInfo.New(job.LocalPath).LastWriteTimeUtc, TimeSpan.Zero)
+            RemoteModifiedAt = new DateTimeOffset(fileSystem.FileInfo.New(job.Target.LocalPath).LastWriteTimeUtc, TimeSpan.Zero)
         };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
@@ -18,18 +18,18 @@ public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : 
 
         var entities = jobs.Select(j => new SyncJobEntity
         {
-            Id             = j.Id,
-            AccountId      = new AccountId(j.AccountId),
-            FolderId       = new OneDriveFolderId(j.FolderId),
-            RemoteItemId   = new OneDriveItemId(j.RemoteItemId),
-            RelativePath   = j.RelativePath,
-            LocalPath      = j.LocalPath,
+            Id             = j.Status.Id,
+            AccountId      = j.Remote.AccountId,
+            FolderId       = j.Remote.FolderId,
+            RemoteItemId   = j.Remote.RemoteItemId,
+            RelativePath   = j.Target.RelativePath,
+            LocalPath      = j.Target.LocalPath,
             Direction      = j.Direction,
-            State          = j.State,
+            State          = j.Status.State,
             DownloadUrl    = j.DownloadUrl,
-            FileSize       = j.FileSize,
-            RemoteModified = j.RemoteModified,
-            QueuedAt       = j.QueuedAt
+            FileSize       = j.Metadata.FileSize,
+            RemoteModified = j.Metadata.RemoteModified,
+            QueuedAt       = j.Status.QueuedAt
         });
 
         db.SyncJobs.AddRange(entities);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RemoteItemRef.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RemoteItemRef.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Identifies a specific item in a OneDrive drive folder.</summary>
+public sealed record RemoteItemRef(AccountId AccountId, OneDriveFolderId FolderId, OneDriveItemId RemoteItemId);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RemoteItemRefFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RemoteItemRefFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="RemoteItemRef"/>.</summary>
+public static class RemoteItemRefFactory
+{
+    /// <summary>Creates a <see cref="RemoteItemRef"/> identifying a specific remote drive item.</summary>
+    public static RemoteItemRef Create(AccountId accountId, OneDriveFolderId folderId, OneDriveItemId remoteItemId) => new(accountId, folderId, remoteItemId);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadata.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadata.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Remote file attributes captured at the time the sync job was queued.</summary>
+public sealed record SyncFileMetadata(long FileSize, DateTimeOffset RemoteModified);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadataFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadataFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncFileMetadata"/>.</summary>
+public static class SyncFileMetadataFactory
+{
+    /// <summary>Creates a <see cref="SyncFileMetadata"/> from the given file attributes.</summary>
+    public static SyncFileMetadata Create(long fileSize, DateTimeOffset remoteModified) => new(fileSize, remoteModified);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileTarget.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileTarget.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>The local paths involved in a sync operation.</summary>
+public sealed record SyncFileTarget(string LocalPath, string RelativePath);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileTargetFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileTargetFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncFileTarget"/>.</summary>
+public static class SyncFileTargetFactory
+{
+    /// <summary>Creates a <see cref="SyncFileTarget"/> for the given local paths.</summary>
+    public static SyncFileTarget Create(string localPath, string relativePath) => new(localPath, relativePath);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJob.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJob.cs
@@ -3,7 +3,6 @@ namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 /// <summary>
 /// Represents a single file operation queued by the sync engine.
 /// Created from delta query results and processed in order.
+/// Construct via <see cref="SyncJobFactory"/>.
 /// </summary>
-public sealed record SyncJob(string AccountId, string FolderId, string RemoteItemId, string RelativePath, string LocalPath, SyncDirection Direction, long FileSize, DateTimeOffset RemoteModified,
-    Guid Id, DateTimeOffset QueuedAt, SyncJobState State = SyncJobState.Queued, string? ErrorMessage = null, string? DownloadUrl = null, DateTimeOffset? CompletedAt = null,
-    string? UploadedRemoteItemId = null);
+public sealed record SyncJob(RemoteItemRef Remote, SyncFileTarget Target, SyncFileMetadata Metadata, SyncDirection Direction, SyncJobStatus Status, string? DownloadUrl = null, string? UploadedRemoteItemId = null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobExtensions.cs
@@ -1,0 +1,11 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>State-transition extensions for <see cref="SyncJob"/>.</summary>
+public static class SyncJobExtensions
+{
+    /// <summary>Returns a copy of <paramref name="job"/> transitioned to <see cref="SyncJobState.Completed"/>.</summary>
+    public static SyncJob Complete(this SyncJob job) => job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } };
+
+    /// <summary>Returns a copy of <paramref name="job"/> transitioned to <see cref="SyncJobState.Failed"/>.</summary>
+    public static SyncJob Fail(this SyncJob job, string? errorMessage = null) => job with { Status = job.Status with { State = SyncJobState.Failed, ErrorMessage = errorMessage, CompletedAt = DateTimeOffset.UtcNow } };
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobFactory.cs
@@ -1,9 +1,9 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
-/// <summary>Creates <see cref="SyncJob"/> instances with auto-generated identity fields.</summary>
+/// <summary>Creates <see cref="SyncJob"/> instances.</summary>
 public static class SyncJobFactory
 {
-    /// <summary>Creates a new <see cref="SyncJob"/> with a generated <see cref="SyncJob.Id"/> and <see cref="SyncJob.QueuedAt"/> timestamp.</summary>
-    public static SyncJob Create(string accountId, string folderId, string remoteItemId, string relativePath, string localPath, SyncDirection direction, long fileSize, DateTimeOffset remoteModified, string? downloadUrl = null)
-        => new(accountId, folderId, remoteItemId, relativePath, localPath, direction, fileSize, remoteModified, Guid.NewGuid(), DateTimeOffset.UtcNow, DownloadUrl: downloadUrl);
+    /// <summary>Creates a new <see cref="SyncJob"/> from pre-constructed domain objects.</summary>
+    public static SyncJob Create(RemoteItemRef remote, SyncFileTarget target, SyncFileMetadata metadata, SyncDirection direction, SyncJobStatus status, string? downloadUrl = null, string? uploadedRemoteItemId = null)
+        => new(remote, target, metadata, direction, status, downloadUrl, uploadedRemoteItemId);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobStatus.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobStatus.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Identity and execution state of a sync job.</summary>
+public sealed record SyncJobStatus(Guid Id, DateTimeOffset QueuedAt, SyncJobState State = SyncJobState.Queued, string? ErrorMessage = null, DateTimeOffset? CompletedAt = null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobStatusFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncJobStatusFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncJobStatus"/>.</summary>
+public static class SyncJobStatusFactory
+{
+    /// <summary>Creates a new <see cref="SyncJobStatus"/> with a generated <see cref="SyncJobStatus.Id"/> and <see cref="SyncJobStatus.QueuedAt"/> timestamp.</summary>
+    public static SyncJobStatus Create() => new(Guid.NewGuid(), DateTimeOffset.UtcNow);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -22,10 +22,10 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
             Serilog.Log.Debug(
                 "[Worker {Id}] Processing {Direction} {Path}",
-                workerId, job.Direction, job.RelativePath);
+                workerId, job.Direction, job.Target.RelativePath);
 
             await syncRepository.UpdateJobStateAsync(
-                job.Id, SyncJobState.InProgress).ConfigureAwait(false);
+                job.Status.Id, SyncJobState.InProgress).ConfigureAwait(false);
 
             string? error   = null;
             bool     success = false;
@@ -35,18 +35,18 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
             {
                 currentJob = await ExecuteJobAsync(job, accessToken, ct).ConfigureAwait(false);
                 success = true;
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Completed).ConfigureAwait(false);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed).ConfigureAwait(false);
             }
             catch(OperationCanceledException)
             {
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Queued).ConfigureAwait(false);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued).ConfigureAwait(false);
                 throw;
             }
             catch(Exception ex)
             {
                 error = ex.Message;
-                Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}", workerId, ex.GetType().Name, ex.Message, job.LocalPath);
-                await syncRepository.UpdateJobStateAsync(job.Id, SyncJobState.Failed, ex.Message).ConfigureAwait(false);
+                Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}", workerId, ex.GetType().Name, ex.Message, job.Target.LocalPath);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, ex.Message).ConfigureAwait(false);
             }
             finally
             {
@@ -64,23 +64,23 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
                 await downloader.DownloadAsync(
                     downloadUrl,
-                    job.LocalPath,
-                    job.RemoteModified,
+                    job.Target.LocalPath,
+                    job.Metadata.RemoteModified,
                     ct: ct).ConfigureAwait(false);
 
                 return job;
 
             case SyncDirection.Upload:
-                string remotePath = job.DownloadUrl ?? job.RelativePath;
-                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.LocalPath, remotePath, parentFolderId: job.FolderId, ct: ct).ConfigureAwait(false);
+                string remotePath = job.DownloadUrl ?? job.Target.RelativePath;
+                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, job.Target.LocalPath, remotePath, parentFolderId: job.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
 
-                Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, job.RelativePath);
+                Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, job.Target.RelativePath);
 
                 return job with { UploadedRemoteItemId = uploadedRemoteItemId };
 
             case SyncDirection.Delete:
-                if(fileSystem.File.Exists(job.LocalPath))
-                    fileSystem.File.Delete(job.LocalPath);
+                if(fileSystem.File.Exists(job.Target.LocalPath))
+                    fileSystem.File.Delete(job.Target.LocalPath);
 
                 return job;
 
@@ -94,10 +94,10 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
         if(job.DownloadUrl is not null)
             return job.DownloadUrl;
 
-        Serilog.Log.Debug("[Worker {Id}] DownloadUrl absent for {Path} — fetching on-demand", workerId, job.RelativePath);
+        Serilog.Log.Debug("[Worker {Id}] DownloadUrl absent for {Path} — fetching on-demand", workerId, job.Target.RelativePath);
 
-        var url = await graphService.GetDownloadUrlAsync(accessToken, job.RemoteItemId, ct).ConfigureAwait(false);
+        var url = await graphService.GetDownloadUrlAsync(accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
 
-        return url ?? throw new InvalidOperationException($"No download URL could be resolved for '{job.RelativePath}' (itemId={job.RemoteItemId}).");
+        return url ?? throw new InvalidOperationException($"No download URL could be resolved for '{job.Target.RelativePath}' (itemId={job.Remote.RemoteItemId.Id}).");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
@@ -57,7 +57,12 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDe
 
                 string relativePathForUpload = remotePath.TrimStart('/');
 
-                jobs.Add(SyncJobFactory.Create(accountId, string.Empty, known?.RemoteItemId.Id ?? string.Empty, relativePathForUpload, filePath, SyncDirection.Upload, info.Length, localModified, downloadUrl: relativePathForUpload));
+                var remote = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId(string.Empty), known?.RemoteItemId ?? new OneDriveItemId(string.Empty));
+                var target = SyncFileTargetFactory.Create(filePath, relativePathForUpload);
+                var metadata = SyncFileMetadataFactory.Create(info.Length, localModified);
+                var status = SyncJobStatusFactory.Create();
+
+                jobs.Add(SyncJobFactory.Create(remote, target, metadata, SyncDirection.Upload, status, downloadUrl: relativePathForUpload));
             }
 
             foreach(string subDir in fileSystem.Directory.EnumerateDirectories(localDir))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
@@ -49,14 +49,9 @@ public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGr
                 completedSoFar = done;
             }
 
-            var completedJob = job with
-            {
-                State = success ? SyncJobState.Completed : SyncJobState.Failed,
-                ErrorMessage = error,
-                CompletedAt = DateTimeOffset.UtcNow
-            };
+            var completedJob = success ? job.Complete() : job.Fail(error);
 
-            onProgress(new SyncProgressEventArgs(accountId: accountId, folderId: folderId, completed: completedSoFar, total: total, currentFile: job.RelativePath, syncState: completedSoFar == total ? SyncState.Idle : SyncState.Syncing));
+            onProgress(new SyncProgressEventArgs(accountId: accountId, folderId: folderId, completed: completedSoFar, total: total, currentFile: job.Target.RelativePath, syncState: completedSoFar == total ? SyncState.Idle : SyncState.Syncing));
 
             onJobCompleted(new JobCompletedEventArgs(completedJob));
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -125,7 +125,12 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             return;
         }
 
-        downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
+        var remote = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), new OneDriveItemId(item.Id));
+        var target = SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name);
+        var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+        var status = SyncJobStatusFactory.Create();
+
+        downloadJobs.Add(SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status, downloadUrl: item.DownloadUrl));
     }
 
     private async Task HandleFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localBasePath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
@@ -150,17 +155,33 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 break;
 
             case ConflictOutcome.UseRemote:
-                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
+                var remoteR = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), new OneDriveItemId(item.Id));
+                var targetR = SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name);
+                var metadataR = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+                var statusR = SyncJobStatusFactory.Create();
+
+                downloadJobs.Add(SyncJobFactory.Create(remoteR, targetR, metadataR, SyncDirection.Download, statusR, downloadUrl: item.DownloadUrl));
                 break;
 
             case ConflictOutcome.UseLocal:
-                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Upload, fileSystem.FileInfo.New(localPath).Length, localModified));
+                var remoteL = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), new OneDriveItemId(item.Id));
+                var targetL = SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name);
+                var metadataL = SyncFileMetadataFactory.Create(fileSystem.FileInfo.New(localPath).Length, localModified);
+                var statusL = SyncJobStatusFactory.Create();
+
+                downloadJobs.Add(SyncJobFactory.Create(remoteL, targetL, metadataL, SyncDirection.Upload, statusL));
                 break;
 
             case ConflictOutcome.KeepBoth:
                 string newName = ConflictResolver.MakeKeepBothName(localPath, localModified, fileSystem);
                 fileSystem.File.Move(localPath, newName);
-                downloadJobs.Add(SyncJobFactory.Create(account.Id.Id, string.Empty, item.Id, item.RelativePath ?? item.Name, localPath, SyncDirection.Download, item.Size, item.LastModified ?? DateTimeOffset.MinValue, downloadUrl: item.DownloadUrl));
+
+                var remoteK = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), new OneDriveItemId(item.Id));
+                var targetK = SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name);
+                var metadataK = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+                var statusK = SyncJobStatusFactory.Create();
+
+                downloadJobs.Add(SyncJobFactory.Create(remoteK, targetK, metadataK, SyncDirection.Download, statusK, downloadUrl: item.DownloadUrl));
                 break;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncJobExecutor.cs
@@ -26,7 +26,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             onProgress,
             args =>
             {
-                if(args.Job.State == SyncJobState.Completed)
+                if(args.Job.Status.State == SyncJobState.Completed)
                     successfulJobs.Add(args.Job);
 
                 onJobCompleted(args);
@@ -37,13 +37,13 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
 
         foreach(var job in successfulJobs)
         {
-            var remotePath = NormaliseRemotePath(job.RelativePath);
+            var remotePath = NormaliseRemotePath(job.Target.RelativePath);
 
             if(job.Direction == SyncDirection.Download)
             {
                 var entity = SyncedItemEntityFactory.CreateFromDownloadJob(account.Id, job, remotePath);
                 await syncedItemRepository.UpsertAsync(entity, ct);
-                syncedItems[job.RemoteItemId] = entity;
+                syncedItems[job.Remote.RemoteItemId.Id] = entity;
             }
             else if(job.Direction == SyncDirection.Upload && job.UploadedRemoteItemId is not null)
             {

--- a/docs/astar-dev-onedrive-sync-client/syncjob-dataclump-refactor.md
+++ b/docs/astar-dev-onedrive-sync-client/syncjob-dataclump-refactor.md
@@ -9,7 +9,8 @@ Extracting them into named records:
 - reduces parameter count (15 → 7)
 - names the concept, not just the values
 - reveals intent at construction and read sites
-- makes `SyncJobFactory.Create` signature shorter with no call-site disruption (factory signature is the public API; internal record structure is an implementation detail)
+- makes `SyncJobFactory.Create` signature shorter; call sites migrate to per-concept factory methods, making construction self-documenting
+- replaces verbose nested `with` state updates with named transition extension methods (`Complete()`, `Fail()`)
 
 This is independent of — and complementary to — the `SyncDirection` discriminated union refactor described in `syncjob-refactor.md`.
 
@@ -71,15 +72,16 @@ This is independent of — and complementary to — the `SyncDirection` discrimi
 
 **Question answered:** *What is this job's identity and current execution state?*
 
-**Tradeoff:** State updates currently use flat `with`:
-```csharp
-job with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow }
-```
-After extraction they become nested:
+**Tradeoff addressed via extension methods:** Naively, state updates become nested `with`:
 ```csharp
 job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } }
 ```
-This is safe and correct — C# `with` preserves the concrete type — but it is more verbose. Recommended regardless, since the cohesion gain outweighs the verbosity cost.
+This is eliminated by `SyncJobExtensions` — see section below. Call sites reduce to:
+```csharp
+job.Complete()
+job.Fail(error)
+success ? job.Complete() : job.Fail(error)
+```
 
 ---
 
@@ -186,6 +188,26 @@ public static class SyncJobStatusFactory
 
 ---
 
+### `SyncJobExtensions.cs`
+
+Extension methods on `SyncJob` for state transitions. Eliminates nested `with` at every call site; names the intent, not the mechanism.
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>State-transition extensions for <see cref="SyncJob"/>.</summary>
+public static class SyncJobExtensions
+{
+    /// <summary>Returns a copy of <paramref name="job"/> transitioned to <see cref="SyncJobState.Completed"/>.</summary>
+    public static SyncJob Complete(this SyncJob job) => job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } };
+
+    /// <summary>Returns a copy of <paramref name="job"/> transitioned to <see cref="SyncJobState.Failed"/>.</summary>
+    public static SyncJob Fail(this SyncJob job, string? errorMessage = null) => job with { Status = job.Status with { State = SyncJobState.Failed, ErrorMessage = errorMessage, CompletedAt = DateTimeOffset.UtcNow } };
+}
+```
+
+---
+
 ## Updated `SyncJob.cs`
 
 ```csharp
@@ -228,16 +250,15 @@ public static class SyncJobFactory
 
 ### Call-site pattern
 
-Every call site must build each argument via its own factory:
+Build each argument explicitly before the final factory call:
 
 ```csharp
-SyncJobFactory.Create(
-    RemoteItemRefFactory.Create(account.Id.Id, string.Empty, item.Id),
-    SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name),
-    SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue),
-    SyncDirection.Download,
-    SyncJobStatusFactory.Create(),
-    downloadUrl: item.DownloadUrl);
+var remote = RemoteItemRefFactory.Create(account.Id.Id, string.Empty, item.Id);
+var target = SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name);
+var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+var status = SyncJobStatusFactory.Create();
+
+SyncJobFactory.Create(remote, target, metadata, SyncDirection.Download, status, downloadUrl: item.DownloadUrl);
 ```
 
 ---
@@ -275,13 +296,22 @@ job with { UploadedRemoteItemId = uploadedId }
 job with { UploadedRemoteItemId = uploadedId }
 ```
 
-Status updates — nest into `Status`:
+Status transitions — use `SyncJobExtensions`:
 ```csharp
-// before
+// before — completed
 job with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow }
-
 // after
-job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } }
+job.Complete()
+
+// before — failed
+job with { State = SyncJobState.Failed, ErrorMessage = error, CompletedAt = DateTimeOffset.UtcNow }
+// after
+job.Fail(error)
+
+// before — conditional (ParallelDownloadPipeline pattern)
+job with { State = success ? SyncJobState.Completed : SyncJobState.Failed, ErrorMessage = error, CompletedAt = DateTimeOffset.UtcNow }
+// after
+success ? job.Complete() : job.Fail(error)
 ```
 
 ### Files requiring changes
@@ -292,6 +322,7 @@ All files affected are internal to the desktop client project.
 |------|-----------------|
 | `Domain/SyncJob.cs` | Replace with grouped record |
 | `Domain/SyncJobFactory.cs` | New signature — accepts record objects, not primitives |
+| `Domain/SyncJobExtensions.cs` | New file — `Complete()` and `Fail(error?)` transition extension methods |
 | `Infrastructure/Sync/LocalChangeDetector.cs` | `SyncJobFactory.Create(accountId, ...)` → build args via sub-factories |
 | `Infrastructure/Sync/RemoteFolderEnumerator.cs` | `SyncJobFactory.Create(account.Id.Id, ...)` × 4 calls → build args via sub-factories |
 | `Data/Repositories/SyncRepository.cs` | `j.AccountId` → `j.Remote.AccountId` etc. (entity mapping block) |
@@ -307,14 +338,15 @@ All files affected are internal to the desktop client project.
 ## Implementation Order
 
 1. Add new record and factory files (`RemoteItemRef`, `SyncFileTarget`, `SyncFileMetadata`, `SyncJobStatus` and their factories) — compiles immediately alongside old `SyncJob`.
-2. Replace `SyncJob.cs` with the 7-parameter version and update `SyncJobFactory.cs` with new record-object signature — project fails to build.
-3. Fix `LocalChangeDetector` — replace flat `SyncJobFactory.Create` call with sub-factory arguments.
-4. Fix `RemoteFolderEnumerator` — replace 4 flat `SyncJobFactory.Create` calls with sub-factory arguments.
-5. Fix `SyncRepository.EnqueueJobsAsync` mapping block.
-6. Fix `DownloadWorker` property accesses.
-7. Fix `SyncJobExecutor` and `ParallelDownloadPipeline` `with` expressions.
-8. Fix `ActivityItemViewModel.FromJob`.
-9. Fix `SyncedItemEntityFactory`.
-10. Fix test helper methods (`MakeJob`, `BuildSyncJob`, `MinimalJob`, `CreateMinimalJob`) — update both call sites and property access chains.
-11. `dotnet build` — zero errors, zero warnings.
-12. `dotnet test` — all existing tests pass.
+2. Add `SyncJobExtensions.cs` — compiles immediately (references only `SyncJob` which still exists).
+3. Replace `SyncJob.cs` with the 7-parameter version and update `SyncJobFactory.cs` with new record-object signature — project fails to build.
+4. Fix `LocalChangeDetector` — replace flat `SyncJobFactory.Create` call with sub-factory arguments.
+5. Fix `RemoteFolderEnumerator` — replace 4 flat `SyncJobFactory.Create` calls with sub-factory arguments.
+6. Fix `SyncRepository.EnqueueJobsAsync` mapping block.
+7. Fix `DownloadWorker` property accesses.
+8. Fix `SyncJobExecutor` (`args.Job.Status.State`) and `ParallelDownloadPipeline` (`success ? job.Complete() : job.Fail(error)`).
+9. Fix `ActivityItemViewModel.FromJob`.
+10. Fix `SyncedItemEntityFactory`.
+11. Fix test helper methods (`MakeJob`, `BuildSyncJob`, `MinimalJob`, `CreateMinimalJob`) — update both call sites and property access chains.
+12. `dotnet build` — zero errors, zero warnings.
+13. `dotnet test` — all existing tests pass.

--- a/docs/astar-dev-onedrive-sync-client/syncjob-dataclump-refactor.md
+++ b/docs/astar-dev-onedrive-sync-client/syncjob-dataclump-refactor.md
@@ -1,0 +1,320 @@
+# SyncJob — Data Clump Extraction Refactor
+
+## Motivation
+
+`SyncJob` currently has 15 positional parameters. Several are raw primitives that always travel together and answer the same conceptual question. These are textbook **data clumps**: groups of values that appear as a unit at construction, mapping, and consumption sites but are scattered as individual primitives.
+
+Extracting them into named records:
+
+- reduces parameter count (15 → 7)
+- names the concept, not just the values
+- reveals intent at construction and read sites
+- makes `SyncJobFactory.Create` signature shorter with no call-site disruption (factory signature is the public API; internal record structure is an implementation detail)
+
+This is independent of — and complementary to — the `SyncDirection` discriminated union refactor described in `syncjob-refactor.md`.
+
+---
+
+## Identified Data Clumps
+
+### Clump 1 — Remote file identity
+
+**Fields:** `AccountId`, `FolderId`, `RemoteItemId`
+
+**Evidence:**
+- `EnqueueJobsAsync` maps all three to entity in the same block
+- `ExecuteJobAsync` uses `FolderId` for Graph API upload call
+- `SyncedItemEntityFactory.CreateFromDownloadJob` reads `RemoteItemId`
+- `SyncedItemEntityFactory.CreateFromUploadJob` reads `LocalPath` alongside `RemoteItemId`
+
+**Question answered:** *Which remote item are we syncing?*
+
+---
+
+### Clump 2 — Local file target
+
+**Fields:** `LocalPath`, `RelativePath`
+
+**Evidence:**
+- `EnqueueJobsAsync` maps both together
+- `ExecuteJobAsync` uses `LocalPath` for download/delete/upload; `RelativePath` for logging and as upload path fallback
+- `ActivityItemViewModel.FromJob` reads both (`RelativePath` for display, `Path.GetFileName(RelativePath)`)
+- `SyncedItemEntityFactory` uses `LocalPath` in both download and upload factory methods
+
+**Question answered:** *Where does this file live locally?*
+
+---
+
+### Clump 3 — Remote file attributes
+
+**Fields:** `FileSize`, `RemoteModified`
+
+**Evidence:**
+- `EnqueueJobsAsync` maps both together
+- `ExecuteJobAsync` passes `RemoteModified` to the file downloader (for timestamp preservation)
+- `SyncedItemEntityFactory.CreateFromDownloadJob` reads `RemoteModified`
+- `ActivityItemViewModel.FromJob` reads `FileSize`
+
+**Question answered:** *What are the remote file's current attributes?*
+
+---
+
+### Clump 4 — Job lifecycle status *(optional — see tradeoff below)*
+
+**Fields:** `Id`, `QueuedAt`, `State`, `ErrorMessage?`, `CompletedAt?`
+
+**Evidence:**
+- `EnqueueJobsAsync` maps `Id`, `State`, `QueuedAt` together
+- `RunAsync` passes `job.Id` to every `UpdateJobStateAsync` call
+- `ActivityItemViewModel.FromJob` reads `CompletedAt` and `ErrorMessage` together
+- `ParallelDownloadPipeline` applies `with { State = ..., CompletedAt = ... }` together
+
+**Question answered:** *What is this job's identity and current execution state?*
+
+**Tradeoff:** State updates currently use flat `with`:
+```csharp
+job with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow }
+```
+After extraction they become nested:
+```csharp
+job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } }
+```
+This is safe and correct — C# `with` preserves the concrete type — but it is more verbose. Recommended regardless, since the cohesion gain outweighs the verbosity cost.
+
+---
+
+## Proposed New Records
+
+All files placed in `Domain/`. Each record ships with its factory class per repo convention.
+
+### `RemoteItemRef.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Identifies a specific item in a OneDrive drive folder.</summary>
+public sealed record RemoteItemRef(string AccountId, string FolderId, string RemoteItemId);
+```
+
+### `RemoteItemRefFactory.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="RemoteItemRef"/>.</summary>
+public static class RemoteItemRefFactory
+{
+    /// <summary>Creates a <see cref="RemoteItemRef"/> identifying a specific remote drive item.</summary>
+    public static RemoteItemRef Create(string accountId, string folderId, string remoteItemId)
+        => new(accountId, folderId, remoteItemId);
+}
+```
+
+---
+
+### `SyncFileTarget.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>The local paths involved in a sync operation.</summary>
+public sealed record SyncFileTarget(string LocalPath, string RelativePath);
+```
+
+### `SyncFileTargetFactory.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncFileTarget"/>.</summary>
+public static class SyncFileTargetFactory
+{
+    /// <summary>Creates a <see cref="SyncFileTarget"/> for the given local paths.</summary>
+    public static SyncFileTarget Create(string localPath, string relativePath)
+        => new(localPath, relativePath);
+}
+```
+
+---
+
+### `SyncFileMetadata.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Remote file attributes captured at the time the sync job was queued.</summary>
+public sealed record SyncFileMetadata(long FileSize, DateTimeOffset RemoteModified);
+```
+
+### `SyncFileMetadataFactory.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncFileMetadata"/>.</summary>
+public static class SyncFileMetadataFactory
+{
+    /// <summary>Creates a <see cref="SyncFileMetadata"/> from the given file attributes.</summary>
+    public static SyncFileMetadata Create(long fileSize, DateTimeOffset remoteModified)
+        => new(fileSize, remoteModified);
+}
+```
+
+---
+
+### `SyncJobStatus.cs` *(Clump 4)*
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Identity and execution state of a sync job.</summary>
+public sealed record SyncJobStatus(Guid Id, DateTimeOffset QueuedAt, SyncJobState State = SyncJobState.Queued, string? ErrorMessage = null, DateTimeOffset? CompletedAt = null);
+```
+
+### `SyncJobStatusFactory.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncJobStatus"/>.</summary>
+public static class SyncJobStatusFactory
+{
+    /// <summary>Creates a new <see cref="SyncJobStatus"/> with a generated <see cref="SyncJobStatus.Id"/> and <see cref="SyncJobStatus.QueuedAt"/> timestamp.</summary>
+    public static SyncJobStatus Create() => new(Guid.NewGuid(), DateTimeOffset.UtcNow);
+}
+```
+
+---
+
+## Updated `SyncJob.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>
+/// Represents a single file operation queued by the sync engine.
+/// Created from delta query results and processed in order.
+/// Construct via <see cref="SyncJobFactory"/>.
+/// </summary>
+public sealed record SyncJob(
+    RemoteItemRef Remote,
+    SyncFileTarget Target,
+    SyncFileMetadata Metadata,
+    SyncDirection Direction,
+    SyncJobStatus Status,
+    string? DownloadUrl = null,
+    string? UploadedRemoteItemId = null);
+```
+
+**15 parameters → 7.** `Direction`, `DownloadUrl`, and `UploadedRemoteItemId` remain flat; their nullable smell is addressed separately in `syncjob-refactor.md`.
+
+---
+
+## Updated `SyncJobFactory.cs`
+
+`SyncJobFactory.Create` takes the new record objects directly. Call sites **must** construct each argument via the relevant factory `Create` method — no primitive threading through `SyncJobFactory`.
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Creates <see cref="SyncJob"/> instances.</summary>
+public static class SyncJobFactory
+{
+    /// <summary>Creates a new <see cref="SyncJob"/> from pre-constructed domain objects.</summary>
+    public static SyncJob Create(RemoteItemRef remote, SyncFileTarget target, SyncFileMetadata metadata, SyncDirection direction, SyncJobStatus status, string? downloadUrl = null, string? uploadedRemoteItemId = null)
+        => new(remote, target, metadata, direction, status, downloadUrl, uploadedRemoteItemId);
+}
+```
+
+### Call-site pattern
+
+Every call site must build each argument via its own factory:
+
+```csharp
+SyncJobFactory.Create(
+    RemoteItemRefFactory.Create(account.Id.Id, string.Empty, item.Id),
+    SyncFileTargetFactory.Create(localPath, item.RelativePath ?? item.Name),
+    SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue),
+    SyncDirection.Download,
+    SyncJobStatusFactory.Create(),
+    downloadUrl: item.DownloadUrl);
+```
+
+---
+
+## Consumer Migration Guide
+
+### Property access chains
+
+| Before | After |
+|--------|-------|
+| `job.AccountId` | `job.Remote.AccountId` |
+| `job.FolderId` | `job.Remote.FolderId` |
+| `job.RemoteItemId` | `job.Remote.RemoteItemId` |
+| `job.LocalPath` | `job.Target.LocalPath` |
+| `job.RelativePath` | `job.Target.RelativePath` |
+| `job.FileSize` | `job.Metadata.FileSize` |
+| `job.RemoteModified` | `job.Metadata.RemoteModified` |
+| `job.Id` | `job.Status.Id` |
+| `job.QueuedAt` | `job.Status.QueuedAt` |
+| `job.State` | `job.Status.State` |
+| `job.ErrorMessage` | `job.Status.ErrorMessage` |
+| `job.CompletedAt` | `job.Status.CompletedAt` |
+| `job.Direction` | `job.Direction` *(unchanged)* |
+| `job.DownloadUrl` | `job.DownloadUrl` *(unchanged)* |
+| `job.UploadedRemoteItemId` | `job.UploadedRemoteItemId` *(unchanged)* |
+
+### `with` expression migration
+
+Single-field update — no change in form:
+```csharp
+// before
+job with { UploadedRemoteItemId = uploadedId }
+
+// after — unchanged (field is still on SyncJob)
+job with { UploadedRemoteItemId = uploadedId }
+```
+
+Status updates — nest into `Status`:
+```csharp
+// before
+job with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow }
+
+// after
+job with { Status = job.Status with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow } }
+```
+
+### Files requiring changes
+
+All files affected are internal to the desktop client project.
+
+| File | Change required |
+|------|-----------------|
+| `Domain/SyncJob.cs` | Replace with grouped record |
+| `Domain/SyncJobFactory.cs` | New signature — accepts record objects, not primitives |
+| `Infrastructure/Sync/LocalChangeDetector.cs` | `SyncJobFactory.Create(accountId, ...)` → build args via sub-factories |
+| `Infrastructure/Sync/RemoteFolderEnumerator.cs` | `SyncJobFactory.Create(account.Id.Id, ...)` × 4 calls → build args via sub-factories |
+| `Data/Repositories/SyncRepository.cs` | `j.AccountId` → `j.Remote.AccountId` etc. (entity mapping block) |
+| `Data/Entities/SyncedItemEntityFactory.cs` | `job.RemoteItemId` → `job.Remote.RemoteItemId`; `job.LocalPath` → `job.Target.LocalPath`; `job.RemoteModified` → `job.Metadata.RemoteModified` |
+| `Infrastructure/Sync/DownloadWorker.cs` | `job.LocalPath` → `job.Target.LocalPath`; `job.RelativePath` → `job.Target.RelativePath`; `job.RemoteModified` → `job.Metadata.RemoteModified`; `job.FolderId` → `job.Remote.FolderId`; `job.Id` → `job.Status.Id` |
+| `Activity/ActivityItemViewModel.cs` | `job.AccountId` → `job.Remote.AccountId`; `job.RelativePath` → `job.Target.RelativePath`; `job.FileSize` → `job.Metadata.FileSize`; `job.CompletedAt` → `job.Status.CompletedAt`; `job.ErrorMessage` → `job.Status.ErrorMessage` |
+| `Infrastructure/Sync/ParallelDownloadPipeline.cs` | `with { State = ..., CompletedAt = ... }` → nested `Status with { ... }` |
+| `Infrastructure/Sync/SyncJobExecutor.cs` | `args.Job.State` → `args.Job.Status.State` |
+| Test files (4 files) | `MakeJob` / `BuildSyncJob` / `MinimalJob` helpers — update both call sites and property access chains |
+
+---
+
+## Implementation Order
+
+1. Add new record and factory files (`RemoteItemRef`, `SyncFileTarget`, `SyncFileMetadata`, `SyncJobStatus` and their factories) — compiles immediately alongside old `SyncJob`.
+2. Replace `SyncJob.cs` with the 7-parameter version and update `SyncJobFactory.cs` with new record-object signature — project fails to build.
+3. Fix `LocalChangeDetector` — replace flat `SyncJobFactory.Create` call with sub-factory arguments.
+4. Fix `RemoteFolderEnumerator` — replace 4 flat `SyncJobFactory.Create` calls with sub-factory arguments.
+5. Fix `SyncRepository.EnqueueJobsAsync` mapping block.
+6. Fix `DownloadWorker` property accesses.
+7. Fix `SyncJobExecutor` and `ParallelDownloadPipeline` `with` expressions.
+8. Fix `ActivityItemViewModel.FromJob`.
+9. Fix `SyncedItemEntityFactory`.
+10. Fix test helper methods (`MakeJob`, `BuildSyncJob`, `MinimalJob`, `CreateMinimalJob`) — update both call sites and property access chains.
+11. `dotnet build` — zero errors, zero warnings.
+12. `dotnet test` — all existing tests pass.

--- a/docs/astar-dev-onedrive-sync-client/syncjob-refactor.md
+++ b/docs/astar-dev-onedrive-sync-client/syncjob-refactor.md
@@ -1,0 +1,232 @@
+# SyncJob Discriminated Union Refactor
+
+## Motivation
+
+`SyncJob` carries two nullable properties — `DownloadUrl` and `UploadedRemoteItemId` — that only apply to specific operation types. This primitive-obsession smell manifests as runtime `switch (job.Direction)` branches in `DownloadWorker`, `ActivityItemViewModel`, and `SyncJobExecutor`. It is possible to construct a `DownloadSyncJob` with no `DownloadUrl`, or an `UploadSyncJob` with no `UploadedRemoteItemId`, and the compiler accepts it.
+
+Replacing the `SyncDirection` enum with a discriminated union of three `SyncJob`-derived records:
+
+- makes impossible states unrepresentable
+- moves direction-specific data to where it belongs
+- replaces runtime enum-switch with compile-time type dispatch (pattern matching)
+- aligns with the established `AuthError` DU pattern already in this codebase
+
+---
+
+## Proposed Type Hierarchy
+
+### Abstract base — `SyncJob.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>
+/// Base type for all sync file operations queued by the sync engine.
+/// Construct via <see cref="SyncJobFactory"/> — never use derived constructors directly.
+/// </summary>
+public abstract record SyncJob(
+    string AccountId,
+    string FolderId,
+    string RemoteItemId,
+    string RelativePath,
+    string LocalPath,
+    long FileSize,
+    DateTimeOffset RemoteModified,
+    Guid Id,
+    DateTimeOffset QueuedAt,
+    SyncJobState State = SyncJobState.Queued,
+    string? ErrorMessage = null,
+    DateTimeOffset? CompletedAt = null);
+
+/// <summary>Download a remote file to the local path.</summary>
+public sealed record DownloadSyncJob(
+    string AccountId,
+    string FolderId,
+    string RemoteItemId,
+    string RelativePath,
+    string LocalPath,
+    long FileSize,
+    DateTimeOffset RemoteModified,
+    Guid Id,
+    DateTimeOffset QueuedAt,
+    string DownloadUrl,
+    SyncJobState State = SyncJobState.Queued,
+    string? ErrorMessage = null,
+    DateTimeOffset? CompletedAt = null)
+    : SyncJob(AccountId, FolderId, RemoteItemId, RelativePath, LocalPath, FileSize, RemoteModified, Id, QueuedAt, State, ErrorMessage, CompletedAt);
+
+/// <summary>Upload a local file to OneDrive.</summary>
+public sealed record UploadSyncJob(
+    string AccountId,
+    string FolderId,
+    string RemoteItemId,
+    string RelativePath,
+    string LocalPath,
+    long FileSize,
+    DateTimeOffset RemoteModified,
+    Guid Id,
+    DateTimeOffset QueuedAt,
+    SyncJobState State = SyncJobState.Queued,
+    string? ErrorMessage = null,
+    DateTimeOffset? CompletedAt = null,
+    string? UploadedRemoteItemId = null)
+    : SyncJob(AccountId, FolderId, RemoteItemId, RelativePath, LocalPath, FileSize, RemoteModified, Id, QueuedAt, State, ErrorMessage, CompletedAt);
+
+/// <summary>Delete a local file that no longer exists on OneDrive.</summary>
+public sealed record DeleteSyncJob(
+    string AccountId,
+    string FolderId,
+    string RemoteItemId,
+    string RelativePath,
+    string LocalPath,
+    long FileSize,
+    DateTimeOffset RemoteModified,
+    Guid Id,
+    DateTimeOffset QueuedAt,
+    SyncJobState State = SyncJobState.Queued,
+    string? ErrorMessage = null,
+    DateTimeOffset? CompletedAt = null)
+    : SyncJob(AccountId, FolderId, RemoteItemId, RelativePath, LocalPath, FileSize, RemoteModified, Id, QueuedAt, State, ErrorMessage, CompletedAt);
+```
+
+Key changes from current `SyncJob`:
+- `Direction` property removed — the type itself is the direction
+- `DownloadUrl` lifted from nullable on base to **required** on `DownloadSyncJob`
+- `UploadedRemoteItemId` lifted from nullable on base to optional on `UploadSyncJob` only
+- `DeleteSyncJob` carries no extra fields — clean
+
+### Factory — `SyncJobFactory.cs`
+
+```csharp
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Creates typed <see cref="SyncJob"/> instances with auto-generated identity fields.</summary>
+public static class SyncJobFactory
+{
+    /// <inheritdoc cref="DownloadSyncJob"/>
+    public static DownloadSyncJob CreateDownload(string accountId, string folderId, string remoteItemId, string relativePath, string localPath, long fileSize, DateTimeOffset remoteModified, string downloadUrl)
+        => new(accountId, folderId, remoteItemId, relativePath, localPath, fileSize, remoteModified, Guid.NewGuid(), DateTimeOffset.UtcNow, downloadUrl);
+
+    /// <inheritdoc cref="UploadSyncJob"/>
+    public static UploadSyncJob CreateUpload(string accountId, string folderId, string remoteItemId, string relativePath, string localPath, long fileSize, DateTimeOffset remoteModified)
+        => new(accountId, folderId, remoteItemId, relativePath, localPath, fileSize, remoteModified, Guid.NewGuid(), DateTimeOffset.UtcNow);
+
+    /// <inheritdoc cref="DeleteSyncJob"/>
+    public static DeleteSyncJob CreateDelete(string accountId, string folderId, string remoteItemId, string relativePath, string localPath, long fileSize, DateTimeOffset remoteModified)
+        => new(accountId, folderId, remoteItemId, relativePath, localPath, fileSize, remoteModified, Guid.NewGuid(), DateTimeOffset.UtcNow);
+}
+```
+
+`DownloadUrl` becomes a required parameter on `CreateDownload` — callers that currently pass `null` will fail to compile, surfacing all incomplete constructions.
+
+---
+
+## SyncJobState Advisory — Keep as Enum
+
+**Recommendation: do not convert `SyncJobState` to a discriminated union.**
+
+| Criterion | SyncDirection | SyncJobState |
+|-----------|--------------|-------------|
+| Cases carry different data? | Yes — `DownloadUrl`, `UploadedRemoteItemId` | No — all states have identical data |
+| Drives polymorphic behaviour? | Yes — different code paths per direction | No — state is observed, not dispatched on |
+| EF Core query pressure? | Low (one index, mapping only) | High — `WHERE State = X` is the primary queue query |
+| State transitions? | N/A (immutable at creation) | Linear: Queued → InProgress → Completed/Failed/Skipped |
+| Gain from DU? | High — nullables eliminated, type-safe | None — adds record-reconstruction overhead on every state update |
+
+`SyncJobState` is lifecycle data: the same job changes state over time. Encoding that as derived records would require replacing the entire `SyncJob` instance on each `UpdateJobStateAsync` call, propagating the new instance back through active pipeline stages. The enum keeps state updates cheap and EF Core queries simple.
+
+---
+
+## Impact Assessment
+
+All production classes that consume `SyncJob`, `SyncDirection`, or `SyncJobState`.
+
+| File | Impact | Change Required |
+|------|--------|-----------------|
+| `Domain/SyncJob.cs` | **High** | Complete replacement — abstract base + 3 sealed records |
+| `Domain/SyncJobFactory.cs` | **High** | Redesign — `Create` → `CreateDownload` / `CreateUpload` / `CreateDelete` |
+| `Infrastructure/Sync/DownloadWorker.cs` | **High** | `switch (job.Direction)` → `switch (job) { case DownloadSyncJob d: ... }` |
+| `Data/Repositories/SyncRepository.cs` | **High** | Entity mapping must derive direction from job type; extract `DownloadUrl` / `UploadedRemoteItemId` by type |
+| `Infrastructure/Sync/SyncJobExecutor.cs` | **Medium** | Direction equality check → `is DownloadSyncJob` / `is UploadSyncJob` |
+| `Activity/ActivityItemViewModel.cs` | **Medium** | Direction switch expression → type switch |
+| `Infrastructure/Sync/RemoteFolderEnumerator.cs` | **Medium** | `SyncJobFactory.Create(..., SyncDirection.Download, ...)` → `SyncJobFactory.CreateDownload(...)` |
+| `Infrastructure/Sync/LocalChangeDetector.cs` | **Medium** | Factory call → `SyncJobFactory.CreateUpload(...)` |
+| `Data/Entities/SyncJobEntity.cs` | **Medium** | `Direction` property still needed for persistence; source now derived via mapping, not copied directly |
+| `Infrastructure/Sync/ParallelDownloadPipeline.cs` | **Medium** | `job with { State = ..., CompletedAt = ... }` — derived type preserved via `with`; verify no base-type `with` expression loses subtype |
+| `Infrastructure/Sync/RemoteEnumerationResult.cs` | **Low** | Holds `IReadOnlyList<SyncJob>` — base type unchanged |
+| `Infrastructure/Sync/ILocalChangeDetector.cs` | **Low** | Returns `IReadOnlyList<SyncJob>` — unchanged |
+| `Infrastructure/Sync/ISyncJobExecutor.cs` | **Low** | Accepts `IReadOnlyList<SyncJob>` — unchanged |
+| `Infrastructure/Sync/IParallelDownloadPipeline.cs` | **Low** | Accepts `IEnumerable<SyncJob>` — unchanged |
+| `Infrastructure/Sync/JobCompletedEventArgs.cs` | **Low** | Holds `SyncJob Job` — unchanged |
+| `Data/ModelBuilderExtensions.cs` | **Low** | Enum-to-int conversion for `SyncDirection` moves to mapping helper; `SyncJobState` unchanged |
+| `Data/Entities/SyncedItemEntityFactory.cs` | **Low** | `CreateFromDownloadJob` / `CreateFromUploadJob` already named by direction; parameter types may narrow to `DownloadSyncJob` / `UploadSyncJob` |
+
+---
+
+## Migration Notes
+
+### EF Core / Database
+
+`SyncJobEntity.Direction` column stores `SyncDirection` as an integer today. The column must remain to avoid a migration. Two options:
+
+**Option A (recommended):** Move `SyncDirection` enum to `Data/` namespace, mark `internal`. The entity still maps to int. The repository derives direction during mapping:
+
+```csharp
+Direction = job switch
+{
+    DownloadSyncJob => SyncDirection.Download,
+    UploadSyncJob   => SyncDirection.Upload,
+    DeleteSyncJob   => SyncDirection.Delete,
+    _               => throw new UnreachableException()
+}
+```
+
+**Option B:** Delete `SyncDirection` from Domain, store a discriminator string (`"Download"` / `"Upload"` / `"Delete"`) — requires a new migration and data backfill.
+
+Option A is zero-migration and keeps the int index intact.
+
+### `with` Expressions and Derived Types
+
+C# `with` on a positional record returns the **same concrete type**. `DownloadSyncJob` stays `DownloadSyncJob` after:
+
+```csharp
+job with { State = SyncJobState.Completed, CompletedAt = DateTimeOffset.UtcNow }
+```
+
+This is safe as long as `job` is the concrete type (not upcast to `SyncJob`). If `ParallelDownloadPipeline` holds the job as `SyncJob`, a cast is required before applying `with`. Audit all `with` usages.
+
+### Pattern Matching Replacement
+
+Before:
+```csharp
+switch (job.Direction)
+{
+    case SyncDirection.Download: ...
+    case SyncDirection.Upload:   ...
+    case SyncDirection.Delete:   ...
+}
+```
+
+After:
+```csharp
+switch (job)
+{
+    case DownloadSyncJob d: ... // d.DownloadUrl available without null-check
+    case UploadSyncJob u:   ... // u.UploadedRemoteItemId available without null-check
+    case DeleteSyncJob:     ...
+}
+```
+
+The compiler enforces exhaustiveness when `SyncJob` is abstract and all derived types are sealed in the same assembly.
+
+---
+
+## Suggested Implementation Order
+
+1. **Domain** — replace `SyncJob.cs` (abstract + 3 sealed records), update `SyncJobFactory.cs`. Commit failing build as TDD red.
+2. **Factory call sites** — `RemoteFolderEnumerator`, `LocalChangeDetector`. Restore compile.
+3. **Pipeline** — `DownloadWorker` switch, `ParallelDownloadPipeline` `with` expressions, `SyncJobExecutor` direction checks.
+4. **Data layer** — `SyncRepository` mapping, `SyncJobEntity` direction derivation, `ModelBuilderExtensions`.
+5. **UI** — `ActivityItemViewModel` type switch.
+6. **Cleanup** — relocate `SyncDirection` enum to `Data/` as `internal`; update `SyncedItemEntityFactory` parameter types if narrowing is worthwhile.
+7. **Tests** — update all test builders and factory calls; add tests for each derived type.


### PR DESCRIPTION
refactor(apps/desktop/AStar.Dev.OneDrive.Sync.Client): extract SyncJob data clumps into domain records

SyncJob's 7 flat primitive parameters grouped into 4 named records:
RemoteItemRef (AccountId/FolderId/RemoteItemId), SyncFileTarget,
SyncFileMetadata, and SyncJobStatus — each with a companion factory.

SyncJobExtensions adds Complete() and Fail() to replace nested
`with` expressions at call sites. All consumers updated to construct
sub-objects explicitly before calling SyncJobFactory.Create.

Strong IDs (AccountId, OneDriveFolderId, OneDriveItemId) replace raw
strings throughout; callers access values via .Id.

closes #249 