### PR TITLE
feat(apps/desktop): extract AccountProfile data-clump

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountCardViewModelTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountCardViewModelTests.cs
@@ -162,7 +162,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_refresh_from_model_called_then_display_name_property_changed_is_raised()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-12"), DisplayName = "Alice" };
+        var model = new OneDriveAccount { Id = new AccountId("account-12"), Profile = AccountProfileFactory.Create("Alice", string.Empty) };
         var sut = new AccountCardViewModel(model);
         var propertyChangedRaised = false;
 
@@ -180,7 +180,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_refresh_from_model_called_then_email_property_changed_is_raised()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-13"), Email = "alice@outlook.com" };
+        var model = new OneDriveAccount { Id = new AccountId("account-13"), Profile = AccountProfileFactory.Create(string.Empty, "alice@outlook.com") };
         var sut = new AccountCardViewModel(model);
         var propertyChangedRaised = false;
 
@@ -198,7 +198,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_refresh_from_model_called_then_initials_property_changed_is_raised()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-14"), DisplayName = "Bob Smith" };
+        var model = new OneDriveAccount { Id = new AccountId("account-14"), Profile = AccountProfileFactory.Create("Bob Smith", string.Empty) };
         var sut = new AccountCardViewModel(model);
         var propertyChangedRaised = false;
 
@@ -288,7 +288,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_has_two_parts_then_initials_are_first_letter_of_each()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-19"), DisplayName = "Alice Smith" };
+        var model = new OneDriveAccount { Id = new AccountId("account-19"), Profile = AccountProfileFactory.Create("Alice Smith", string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 
@@ -298,7 +298,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_is_single_word_then_initials_are_first_letter()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-20"), DisplayName = "Alice" };
+        var model = new OneDriveAccount { Id = new AccountId("account-20"), Profile = AccountProfileFactory.Create("Alice", string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 
@@ -308,7 +308,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_is_empty_and_email_provided_then_initials_are_first_letter_of_email()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-21"), DisplayName = "", Email = "bob@outlook.com" };
+        var model = new OneDriveAccount { Id = new AccountId("account-21"), Profile = AccountProfileFactory.Create(string.Empty, "bob@outlook.com") };
 
         var sut = new AccountCardViewModel(model);
 
@@ -318,7 +318,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_and_email_are_empty_then_initials_are_question_mark()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-22"), DisplayName = "", Email = "" };
+        var model = new OneDriveAccount { Id = new AccountId("account-22"), Profile = AccountProfileFactory.Create(string.Empty, string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 
@@ -328,7 +328,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_has_multiple_words_then_initials_use_first_and_last()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-23"), DisplayName = "John Michael Smith" };
+        var model = new OneDriveAccount { Id = new AccountId("account-23"), Profile = AccountProfileFactory.Create("John Michael Smith", string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 
@@ -338,7 +338,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_initials_are_derived_from_display_name_then_they_are_uppercase()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-24"), DisplayName = "alice smith" };
+        var model = new OneDriveAccount { Id = new AccountId("account-24"), Profile = AccountProfileFactory.Create("alice smith", string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 
@@ -348,7 +348,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_initials_are_derived_from_email_then_they_are_uppercase()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-25"), DisplayName = "", Email = "alice@outlook.com" };
+        var model = new OneDriveAccount { Id = new AccountId("account-25"), Profile = AccountProfileFactory.Create(string.Empty, "alice@outlook.com") };
 
         var sut = new AccountCardViewModel(model);
 
@@ -474,7 +474,7 @@ public sealed class GivenAnAccountCardViewModel
     [Fact]
     public void when_display_name_contains_extra_whitespace_then_initials_ignore_empty_parts()
     {
-        var model = new OneDriveAccount { Id = new AccountId("account-36"), DisplayName = "Alice    Smith" };
+        var model = new OneDriveAccount { Id = new AccountId("account-36"), Profile = AccountProfileFactory.Create("Alice    Smith", string.Empty) };
 
         var sut = new AccountCardViewModel(model);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountFilesViewModelTests.cs
@@ -190,7 +190,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         var repository   = Substitute.For<IAccountRepository>();
 
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, "Test User", "test@test.com"));
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
         graphService.GetDriveIdAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns(DriveId);
@@ -215,8 +215,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         => new()
         {
             Id             = new AccountId(AccountIdString),
-            DisplayName    = "Test User",
-            Email          = "test@test.com",
+            Profile        = AccountProfileFactory.Create("Test User", "test@test.com"),
             LocalSyncPath  = string.IsNullOrEmpty(localSyncPath) ? null : LocalSyncPath.Restore(localSyncPath),
             ConflictPolicy = conflictPolicy
         };
@@ -225,8 +224,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         => new()
         {
             Id             = new AccountId(AccountIdString),
-            DisplayName    = "Test User",
-            Email          = "test@test.com",
+            Profile        = AccountProfileFactory.Create("Test User", "test@test.com"),
             LocalSyncPath  = LocalSyncPath.Restore(localSyncPath),
             ConflictPolicy = conflictPolicy
         };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -13,9 +13,8 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
 
     private static OneDriveAccount BuildAccount() => new()
     {
-        Id          = new AccountId(AccountIdString),
-        DisplayName = "Test User",
-        Email       = "test@test.com"
+        Id      = new AccountId(AccountIdString),
+        Profile = AccountProfileFactory.Create("Test User", "test@test.com")
     };
 
     private static AccountFilesViewModel BuildSut(IAuthService authService)
@@ -109,7 +108,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var authService  = Substitute.For<IAuthService>();
         var graphService = Substitute.For<IGraphService>();
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", AccountIdString, "Test User", "test@test.com"));
+            .Returns(AuthResultFactory.Success("token", AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
         graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("drive-1");
         graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
@@ -16,8 +16,7 @@ public sealed class GivenAnAccountSyncSettingsViewModel
     private static OneDriveAccount BuildAccount(string? localSyncPath = null, ConflictPolicy conflictPolicy = ConflictPolicy.Ignore, int accentIndex = 0) => new()
     {
         Id = new AccountId(AccountIdValue),
-        DisplayName = DisplayNameValue,
-        Email = EmailValue,
+        Profile = AccountProfileFactory.Create(DisplayNameValue, EmailValue),
         AccentIndex = accentIndex,
         LocalSyncPath = localSyncPath is null ? null : LocalSyncPath.Restore(localSyncPath),
         ConflictPolicy = conflictPolicy
@@ -26,8 +25,7 @@ public sealed class GivenAnAccountSyncSettingsViewModel
     private static AccountEntity BuildEntity(string localSyncPath = "") => new()
     {
         Id = new AccountId(AccountIdValue),
-        DisplayName = DisplayNameValue,
-        Email = EmailValue
+        Profile = AccountProfileFactory.Create(DisplayNameValue, EmailValue)
     };
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -99,7 +99,7 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
 
         authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, DisplayName, Email));
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, AccountProfileFactory.Create(DisplayName, Email)));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(FolderId1, FolderName1), new DriveFolder(FolderId2, FolderName2)]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/OneDriveAccountTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/OneDriveAccountTests.cs
@@ -10,8 +10,8 @@ public sealed class OneDriveAccountTests
     {
         var account = new OneDriveAccount();
 
-        account.DisplayName.ShouldBe(string.Empty);
-        account.Email.ShouldBe(string.Empty);
+        account.Profile.DisplayName.ShouldBe(string.Empty);
+        account.Profile.Email.ShouldBe(string.Empty);
         account.AccentIndex.ShouldBe(0);
         account.SelectedFolderIds.ShouldBeEmpty();
         account.LastSyncedAt.ShouldBeNull();
@@ -39,9 +39,9 @@ public sealed class OneDriveAccountTests
         var account = new OneDriveAccount();
         string displayName = "Jason Smith";
 
-        account.DisplayName = displayName;
+        account.Profile = AccountProfileFactory.Create(displayName, string.Empty);
 
-        account.DisplayName.ShouldBe(displayName);
+        account.Profile.DisplayName.ShouldBe(displayName);
     }
 
     [Fact]
@@ -50,9 +50,9 @@ public sealed class OneDriveAccountTests
         var account = new OneDriveAccount();
         string email = "jason@outlook.com";
 
-        account.Email = email;
+        account.Profile = AccountProfileFactory.Create(string.Empty, email);
 
-        account.Email.ShouldBe(email);
+        account.Profile.Email.ShouldBe(email);
     }
 
     [Fact]
@@ -181,15 +181,14 @@ public sealed class OneDriveAccountTests
         long quotaTotal = 1_099_511_627_776L;
         long quotaUsed = 549_755_813_888L;
 
-        account.DisplayName = displayName;
-        account.Email = email;
+        account.Profile = AccountProfileFactory.Create(displayName, email);
         account.AccentIndex = accentIndex;
         account.QuotaTotal = quotaTotal;
         account.QuotaUsed = quotaUsed;
         account.IsActive = true;
 
-        account.DisplayName.ShouldBe(displayName);
-        account.Email.ShouldBe(email);
+        account.Profile.DisplayName.ShouldBe(displayName);
+        account.Profile.Email.ShouldBe(email);
         account.AccentIndex.ShouldBe(accentIndex);
         account.QuotaTotal.ShouldBe(quotaTotal);
         account.QuotaUsed.ShouldBe(quotaUsed);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
@@ -3,17 +3,44 @@ using AStar.Dev.OneDrive.Sync.Client.Data;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
 
-public sealed class GivenAnAccountRepository
+public sealed class GivenAnAccountRepository : IDisposable
 {
+    private readonly SqliteConnection _connection;
+    private readonly AppDbContext _seedingContext;
+    private readonly IDbContextFactory<AppDbContext> _factory;
+
+    public GivenAnAccountRepository()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _seedingContext = new AppDbContext(options);
+        _ = _seedingContext.Database.EnsureCreated();
+
+        _factory = Substitute.For<IDbContextFactory<AppDbContext>>();
+        _factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(new AppDbContext(options)));
+    }
+
+    public void Dispose()
+    {
+        _seedingContext.Dispose();
+        _connection.Dispose();
+    }
+
     [Fact]
     public async Task when_getting_all_with_no_accounts_then_empty_list_is_returned()
     {
-        var (_, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
+        var repository = new AccountRepository(_factory);
 
         var result = await repository.GetAllAsync(TestContext.Current.CancellationToken);
 
@@ -23,11 +50,10 @@ public sealed class GivenAnAccountRepository
     [Fact]
     public async Task when_getting_all_with_single_account_then_account_is_returned()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        var account = new AccountEntity { Id = new AccountId("user-1"), Email = "user@outlook.com", DisplayName = "User" };
-        _ = db.Accounts.Add(account);
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com") };
+        _ = _seedingContext.Accounts.Add(account);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await repository.GetAllAsync(TestContext.Current.CancellationToken);
 
@@ -38,43 +64,40 @@ public sealed class GivenAnAccountRepository
     [Fact]
     public async Task when_getting_all_then_accounts_are_ordered_by_email()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        db.Accounts.AddRange(
-            new AccountEntity { Id = new AccountId("user-3"), Email = "zebra@outlook.com", DisplayName = "Z User" },
-            new AccountEntity { Id = new AccountId("user-1"), Email = "alice@outlook.com", DisplayName = "A User" },
-            new AccountEntity { Id = new AccountId("user-2"), Email = "bob@outlook.com", DisplayName = "B User" }
+        var repository = new AccountRepository(_factory);
+        _seedingContext.Accounts.AddRange(
+            new AccountEntity { Id = new AccountId("user-3"), Profile = AccountProfileFactory.Create("Z User", "zebra@outlook.com") },
+            new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("A User", "alice@outlook.com") },
+            new AccountEntity { Id = new AccountId("user-2"), Profile = AccountProfileFactory.Create("B User", "bob@outlook.com") }
         );
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await repository.GetAllAsync(TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(3);
-        result[0].Email.ShouldBe("alice@outlook.com");
-        result[1].Email.ShouldBe("bob@outlook.com");
-        result[2].Email.ShouldBe("zebra@outlook.com");
+        result[0].Profile.Email.ShouldBe("alice@outlook.com");
+        result[1].Profile.Email.ShouldBe("bob@outlook.com");
+        result[2].Profile.Email.ShouldBe("zebra@outlook.com");
     }
 
     [Fact]
     public async Task when_getting_by_id_with_existing_id_then_some_is_returned()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        var account = new AccountEntity { Id = new AccountId("user-1"), Email = "user@outlook.com", DisplayName = "User" };
-        _ = db.Accounts.Add(account);
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com") };
+        _ = _seedingContext.Accounts.Add(account);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var result = await repository.GetByIdAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result.IsSome().ShouldBeTrue();
-        result.Match(entity => entity.Email, () => string.Empty).ShouldBe("user@outlook.com");
+        result.Match(entity => entity.Profile.Email, () => string.Empty).ShouldBe("user@outlook.com");
     }
 
     [Fact]
     public async Task when_getting_by_id_with_non_existing_id_then_none_is_returned()
     {
-        var (_, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
+        var repository = new AccountRepository(_factory);
 
         var result = await repository.GetByIdAsync(new AccountId("non-existent"), TestContext.Current.CancellationToken);
 
@@ -84,81 +107,61 @@ public sealed class GivenAnAccountRepository
     [Fact]
     public async Task when_upserting_new_account_then_account_is_inserted()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        var account = new AccountEntity { Id = new AccountId("user-1"), Email = "user@outlook.com", DisplayName = "User" };
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com") };
 
         await repository.UpsertAsync(account, TestContext.Current.CancellationToken);
 
-        var retrieved = await db.Accounts.FindAsync([new AccountId("user-1")], cancellationToken: TestContext.Current.CancellationToken);
+        var retrieved = await _seedingContext.Accounts.FindAsync([new AccountId("user-1")], cancellationToken: TestContext.Current.CancellationToken);
         _ = retrieved.ShouldNotBeNull();
-        retrieved.Email.ShouldBe("user@outlook.com");
+        retrieved.Profile.Email.ShouldBe("user@outlook.com");
     }
 
     [Fact]
     public async Task when_upserting_existing_account_then_account_is_updated()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        var account = new AccountEntity { Id = new AccountId("user-1"), Email = "user@outlook.com", DisplayName = "User" };
-        _ = db.Accounts.Add(account);
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com") };
+        _ = _seedingContext.Accounts.Add(account);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        account.DisplayName = "Updated User";
+        account.Profile = account.Profile with { DisplayName = "Updated User" };
         await repository.UpsertAsync(account, TestContext.Current.CancellationToken);
 
-        var retrieved = await db.Accounts.FindAsync([new AccountId("user-1"), TestContext.Current.CancellationToken], TestContext.Current.CancellationToken);
-        retrieved!.DisplayName.ShouldBe("Updated User");
+        await _seedingContext.Entry(account).ReloadAsync(TestContext.Current.CancellationToken);
+        account.Profile.DisplayName.ShouldBe("Updated User");
     }
 
     [Fact]
     public async Task when_deleting_account_then_account_is_removed()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        var account = new AccountEntity { Id = new AccountId("user-1"), Email = "user@outlook.com", DisplayName = "User" };
-        _ = db.Accounts.Add(account);
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com") };
+        _ = _seedingContext.Accounts.Add(account);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        try
-        {
-            await repository.DeleteAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
-        }
-        catch(InvalidOperationException)
-        {
-        }
+        await repository.DeleteAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+
+        _seedingContext.ChangeTracker.Clear();
+        var retrieved = await _seedingContext.Accounts.FindAsync([new AccountId("user-1")], cancellationToken: TestContext.Current.CancellationToken);
+        retrieved.ShouldBeNull();
     }
 
     [Fact]
     public async Task when_setting_active_account_then_one_account_is_active()
     {
-        var (db, factory) = CreateInMemoryFactory();
-        var repository = new AccountRepository(factory);
-        db.Accounts.AddRange(
-            new AccountEntity { Id = new AccountId("user-1"), Email = "user1@outlook.com", DisplayName = "User 1", IsActive = true },
-            new AccountEntity { Id = new AccountId("user-2"), Email = "user2@outlook.com", DisplayName = "User 2", IsActive = false }
+        var repository = new AccountRepository(_factory);
+        _seedingContext.Accounts.AddRange(
+            new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User 1", "user1@outlook.com"), IsActive = true },
+            new AccountEntity { Id = new AccountId("user-2"), Profile = AccountProfileFactory.Create("User 2", "user2@outlook.com"), IsActive = false }
         );
-        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        try
-        {
-            await repository.SetActiveAccountAsync(new AccountId("user-2"), TestContext.Current.CancellationToken);
-        }
-        catch(InvalidOperationException)
-        {
-        }
-    }
+        await repository.SetActiveAccountAsync(new AccountId("user-2"), TestContext.Current.CancellationToken);
 
-    private static (AppDbContext seedingContext, IDbContextFactory<AppDbContext> factory) CreateInMemoryFactory()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        var seedingContext = new AppDbContext(options);
-        _ = seedingContext.Database.EnsureCreated();
-        var factory = Substitute.For<IDbContextFactory<AppDbContext>>();
-        factory.CreateDbContextAsync(Arg.Any<CancellationToken>()).Returns(callInfo => Task.FromResult(new AppDbContext(options)));
-
-        return (seedingContext, factory);
+        await _seedingContext.Entry(_seedingContext.Accounts.Local.First(a => a.Id == new AccountId("user-1"))).ReloadAsync(TestContext.Current.CancellationToken);
+        await _seedingContext.Entry(_seedingContext.Accounts.Local.First(a => a.Id == new AccountId("user-2"))).ReloadAsync(TestContext.Current.CancellationToken);
+        _seedingContext.Accounts.Local.First(a => a.Id == new AccountId("user-1")).IsActive.ShouldBeFalse();
+        _seedingContext.Accounts.Local.First(a => a.Id == new AccountId("user-2")).IsActive.ShouldBeTrue();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRuleRepositoryTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/SyncRuleRepositoryTests.cs
@@ -204,7 +204,7 @@ public sealed class GivenASyncRuleRepository : IDisposable
         if(await _seedingContext.Accounts.AnyAsync(a => a.Id == new AccountId(accountId), TestContext.Current.CancellationToken))
             return;
 
-        _seedingContext.Accounts.Add(new AccountEntity { Id = new AccountId(accountId), Email = $"{accountId}@test.com", DisplayName = accountId });
+        _seedingContext.Accounts.Add(new AccountEntity { Id = new AccountId(accountId), Profile = AccountProfileFactory.Create(accountId, $"{accountId}@test.com") });
         await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAnAccountProfile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAnAccountProfile.cs
@@ -1,0 +1,61 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAnAccountProfile
+{
+    private const string DisplayName = "Jason Smith";
+    private const string Email = "jason@outlook.com";
+
+    [Fact]
+    public void when_created_then_display_name_is_set_correctly()
+    {
+        var profile = AccountProfileFactory.Create(DisplayName, Email);
+
+        profile.DisplayName.ShouldBe(DisplayName);
+    }
+
+    [Fact]
+    public void when_created_then_email_is_set_correctly()
+    {
+        var profile = AccountProfileFactory.Create(DisplayName, Email);
+
+        profile.Email.ShouldBe(Email);
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_values_then_they_are_equal()
+    {
+        var first = AccountProfileFactory.Create(DisplayName, Email);
+        var second = AccountProfileFactory.Create(DisplayName, Email);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_display_names_then_they_are_not_equal()
+    {
+        var first = AccountProfileFactory.Create(DisplayName, Email);
+        var second = AccountProfileFactory.Create("Other Name", Email);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_emails_then_they_are_not_equal()
+    {
+        var first = AccountProfileFactory.Create(DisplayName, Email);
+        var second = AccountProfileFactory.Create(DisplayName, "other@outlook.com");
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_empty_is_requested_then_both_fields_are_empty_strings()
+    {
+        var empty = AccountProfileFactory.Empty;
+
+        empty.DisplayName.ShouldBe(string.Empty);
+        empty.Email.ShouldBe(string.Empty);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -103,7 +103,7 @@ public sealed class GivenAMainWindowViewModel
     {
         const string accountIdStr = "active-account-123";
         var accountsVm = CreateAccountsViewModel();
-        accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), DisplayName = "Test User", Email = "test@example.com" });
+        accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test User", "test@example.com") });
         var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
 
         await sut.SyncNowCommand.ExecuteAsync(null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -16,7 +17,7 @@ public sealed class GivenAStatusBarViewModel
 
     private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _syncEventAggregator);
 
-    private static AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Email = email, DisplayName = displayName });
+    private static AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) });
 
     [Fact]
     public void when_active_account_is_null_then_has_account_is_false()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/AuthResultTests.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;
@@ -11,15 +12,17 @@ public sealed class GivenAnAuthResultFactory
     private const string Email = "jason@outlook.com";
     private const string ErrorMessage = "Authentication failed: Invalid credentials";
 
+    private static AccountProfile Profile => AccountProfileFactory.Create(DisplayName, Email);
+
     [Fact]
     public void when_success_is_called_then_result_is_ok() =>
-        AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email)
+        AuthResultFactory.Success(AccessToken, AccountId, Profile)
             .ShouldBeOfType<Result<AuthResult, AuthError>.Ok>();
 
     [Fact]
     public void when_success_is_called_then_ok_value_has_correct_access_token()
     {
-        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, Profile);
 
         result.Value.AccessToken.ShouldBe(AccessToken);
     }
@@ -27,7 +30,7 @@ public sealed class GivenAnAuthResultFactory
     [Fact]
     public void when_success_is_called_then_ok_value_has_correct_account_id()
     {
-        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, Profile);
 
         result.Value.AccountId.ShouldBe(AccountId);
     }
@@ -35,17 +38,17 @@ public sealed class GivenAnAuthResultFactory
     [Fact]
     public void when_success_is_called_then_ok_value_has_correct_display_name()
     {
-        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, Profile);
 
-        result.Value.DisplayName.ShouldBe(DisplayName);
+        result.Value.Profile.DisplayName.ShouldBe(DisplayName);
     }
 
     [Fact]
     public void when_success_is_called_then_ok_value_has_correct_email()
     {
-        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(AccessToken, AccountId, Profile);
 
-        result.Value.Email.ShouldBe(Email);
+        result.Value.Profile.Email.ShouldBe(Email);
     }
 
     [Fact]
@@ -89,12 +92,12 @@ public sealed class GivenAnAuthResultFactory
     [InlineData("token-3", "account-3", "User Three", "user3@outlook.com")]
     public void when_success_is_called_then_all_token_and_account_data_are_preserved(string accessToken, string accountId, string displayName, string email)
     {
-        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(accessToken, accountId, displayName, email);
+        var result = (Result<AuthResult, AuthError>.Ok)AuthResultFactory.Success(accessToken, accountId, AccountProfileFactory.Create(displayName, email));
 
         result.Value.AccessToken.ShouldBe(accessToken);
         result.Value.AccountId.ShouldBe(accountId);
-        result.Value.DisplayName.ShouldBe(displayName);
-        result.Value.Email.ShouldBe(email);
+        result.Value.Profile.DisplayName.ShouldBe(displayName);
+        result.Value.Profile.Email.ShouldBe(email);
     }
 
     [Theory]
@@ -112,7 +115,7 @@ public sealed class GivenAnAuthResultFactory
     [Fact]
     public void when_success_and_failure_results_are_compared_then_they_are_different_subtypes()
     {
-        var successResult = AuthResultFactory.Success(AccessToken, AccountId, DisplayName, Email);
+        var successResult = AuthResultFactory.Success(AccessToken, AccountId, Profile);
         var failureResult = AuthResultFactory.Failure(ErrorMessage);
 
         successResult.ShouldBeOfType<Result<AuthResult, AuthError>.Ok>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -46,7 +46,7 @@ public sealed class GivenAnApplicationInitializer
         => new(_startupService, accounts, files, dashboard, activity, settings);
 
     private static OneDriveAccount BuildAccount(string id = "acc-1", string email = "user@test.com", bool isActive = false)
-        => new() { Id = new AccountId(id), DisplayName = "Test User", Email = email, IsActive = isActive, SelectedFolderIds = [] };
+        => new() { Id = new AccountId(id), Profile = AccountProfileFactory.Create("Test User", email), IsActive = isActive, SelectedFolderIds = [] };
 
     [Fact]
     public async Task when_initialized_then_accounts_are_restored_from_startup_service()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -29,7 +29,7 @@ public sealed class GivenARemoteFolderEnumerator
     private static OneDriveAccount CreateAccount() => new()
     {
         Id             = new AccountId("user-1"),
-        Email          = "user@outlook.com",
+        Profile        = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
         LocalSyncPath  = LocalSyncPath.Restore(BasePath),
         SelectedFolderIds = []
     };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -17,7 +17,7 @@ public sealed class GivenASyncJobExecutor
     private readonly OneDriveAccount _account = new()
     {
         Id    = new AccountId("user-1"),
-        Email = "user@outlook.com"
+        Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com")
     };
 
     private SyncJobExecutor CreateSut(MockFileSystem mockFs) => new(_syncRepository, _syncedItemRepository, _pipeline, mockFs);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
@@ -32,7 +32,7 @@ public sealed class GivenASyncPassOrchestrator
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {
         Id = new AccountId("user-1"),
-        Email = "user@outlook.com",
+        Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
         LocalSyncPath = LocalSyncPath.Restore(localSyncPath),
         SelectedFolderIds = []
     };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -93,7 +93,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Email = "test@example.com", DisplayName = "test" }]);
+        _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Profile = AccountProfileFactory.Create("test", "test@example.com") }]);
 
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
@@ -107,7 +107,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Email = "test@example.com", DisplayName = "test" }]);
+        _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Profile = AccountProfileFactory.Create("test", "test@example.com") }]);
 
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
@@ -229,8 +229,7 @@ public sealed class GivenASyncScheduler
         var account = new OneDriveAccount
         {
             Id = new AccountId("account-123"),
-            Email = "test@outlook.com",
-            DisplayName = "Test User"
+            Profile = AccountProfileFactory.Create("Test User", "test@outlook.com")
         };
 
         await scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
@@ -248,10 +247,9 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id = new AccountId(accountIdStr),
-            DisplayName = "Test User",
-            Email = "test@outlook.com",
-            LocalSyncPath = LocalSyncPath.Restore("/some/path"),
+            Id             = new AccountId(accountIdStr),
+            Profile        = AccountProfileFactory.Create("Test User", "test@outlook.com"),
+            LocalSyncPath  = LocalSyncPath.Restore("/some/path"),
             ConflictPolicy = ConflictPolicy.Ignore,
         }));
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
@@ -283,7 +281,7 @@ public sealed class GivenASyncScheduler
         const string accountIdStr = "account-789";
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), DisplayName = "Test", Email = "test@test.com" }));
+        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test", "test@test.com") }));
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
         string? raisedId = null;
         scheduler.SyncStarted += (_, id) => raisedId = id;
@@ -299,7 +297,7 @@ public sealed class GivenASyncScheduler
         const string accountIdStr = "account-789";
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), DisplayName = "Test", Email = "test@test.com" }));
+        _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test", "test@test.com") }));
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
         string? raisedId = null;
         scheduler.SyncCompleted += (_, id) => raisedId = id;
@@ -319,8 +317,7 @@ public sealed class GivenASyncScheduler
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
             Id            = new AccountId(accountIdStr),
-            DisplayName   = "Map Test User",
-            Email         = "maptest@outlook.com",
+            Profile       = AccountProfileFactory.Create("Map Test User", "maptest@outlook.com"),
             AccentIndex   = 3,
             IsActive      = true,
             LastSyncedAt  = lastSyncedAt,
@@ -334,8 +331,8 @@ public sealed class GivenASyncScheduler
         await mockSyncService.Received(1).SyncAccountAsync(
             Arg.Is<OneDriveAccount>(a =>
                 a.Id == new AccountId(accountIdStr) &&
-                a.DisplayName == "Map Test User" &&
-                a.Email == "maptest@outlook.com" &&
+                a.Profile.DisplayName == "Map Test User" &&
+                a.Profile.Email == "maptest@outlook.com" &&
                 a.AccentIndex == 3 &&
                 a.IsActive == true &&
                 a.LastSyncedAt == lastSyncedAt &&
@@ -353,8 +350,7 @@ public sealed class GivenASyncScheduler
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
             Id            = new AccountId(accountIdStr),
-            DisplayName   = "No Path User",
-            Email         = "nopath@outlook.com",
+            Profile       = AccountProfileFactory.Create("No Path User", "nopath@outlook.com"),
             LocalSyncPath = LocalSyncPath.Restore(string.Empty),
         }));
         var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
@@ -374,9 +370,8 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id          = new AccountId(accountIdStr),
-            DisplayName = "Rules User",
-            Email       = "rules@outlook.com",
+            Id      = new AccountId(accountIdStr),
+            Profile = AccountProfileFactory.Create("Rules User", "rules@outlook.com"),
         }));
         var rulesRepo = Substitute.For<ISyncRuleRepository>();
         rulesRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
@@ -405,8 +400,7 @@ public sealed class GivenASyncScheduler
         _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new AccountEntity
         {
             Id          = new AccountId(accountIdStr),
-            DisplayName = "Accent User",
-            Email       = "accent@outlook.com",
+            Profile     = AccountProfileFactory.Create("Accent User", "accent@outlook.com"),
             AccentIndex = 5,
             IsActive    = true,
         }]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -50,7 +50,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     public async Task when_auth_succeeds_then_sync_repository_resolve_is_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
         var sut = CreateSut();
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -40,7 +40,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {
         Id            = new AccountId("user-1"),
-        Email         = "user@outlook.com",
+        Profile       = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
         LocalSyncPath = LocalSyncPath.Restore(localSyncPath),
         SelectedFolderIds = []
     };
@@ -50,7 +50,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
 
     private void SetupAuthSuccess() =>
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private void SetupDeepSyncPrerequisites()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/SyncServiceTests.cs
@@ -52,7 +52,7 @@ public sealed class SyncServiceTests
     public async Task when_sync_called_with_valid_account_then_auth_service_is_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
@@ -64,7 +64,7 @@ public sealed class SyncServiceTests
         var account = new OneDriveAccount
         {
             Id            = new AccountId("user-1"),
-            Email         = "user@outlook.com",
+            Profile       = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
             LocalSyncPath = LocalSyncPath.Restore("/home/user/OneDrive")
         };
 
@@ -80,7 +80,7 @@ public sealed class SyncServiceTests
             .Returns(AuthResultFactory.Failure("Authentication failed"));
 
         var service = BuildSut();
-        var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
+        var account = new OneDriveAccount { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com") };
         bool errorRaised = false;
         service.SyncProgressChanged += (_, args) =>
         {
@@ -97,10 +97,10 @@ public sealed class SyncServiceTests
     public async Task when_local_sync_path_is_null_then_no_local_sync_path_progress_is_raised()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
         var service = BuildSut();
-        var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com", LocalSyncPath = null };
+        var account = new OneDriveAccount { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com"), LocalSyncPath = null };
         bool noSyncPathRaised = false;
         service.SyncProgressChanged += (_, args) =>
         {
@@ -120,7 +120,7 @@ public sealed class SyncServiceTests
             .Returns(AuthResultFactory.Failure("fail"));
 
         var service = BuildSut();
-        var account = new OneDriveAccount { Id = new AccountId("user-1"), Email = "user@outlook.com" };
+        var account = new OneDriveAccount { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com") };
         bool eventRaised = false;
         service.SyncProgressChanged += (_, _) => eventRaised = true;
 
@@ -133,7 +133,7 @@ public sealed class SyncServiceTests
     public async Task when_resolve_conflict_called_with_valid_policy_then_sync_repository_resolve_is_called()
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
         var service = BuildSut();
         var conflict = new SyncConflict
@@ -172,7 +172,7 @@ public sealed class SyncServiceTests
     public async Task when_resolve_conflict_called_with_various_policies_then_policy_is_recorded(ConflictPolicy policy)
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "user-1", "User", "user@outlook.com"));
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), AccountId = "user-1" };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -16,7 +16,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     private async Task SignInAsync(AddAccountWizardViewModel sut)
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("fake-token", "account-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("fake-token", "account-1", AccountProfileFactory.Create("Test User", "test@example.com")));
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
     }
@@ -271,7 +271,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     public async Task when_sign_in_succeeds_then_is_signed_in_is_true()
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("Test User", "test@example.com")));
         var sut = CreateSut();
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
@@ -283,7 +283,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     public async Task when_sign_in_succeeds_then_sign_in_status_text_contains_email()
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("Test User", "test@example.com")));
         var sut = CreateSut();
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
@@ -295,7 +295,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     public async Task when_sign_in_succeeds_then_sign_in_has_error_is_false()
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("Test User", "test@example.com")));
         var sut = CreateSut();
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
@@ -307,7 +307,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     public async Task when_sign_in_succeeds_then_confirmed_display_name_is_set()
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("Test User", "test@example.com")));
         var sut = CreateSut();
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
@@ -319,7 +319,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     public async Task when_sign_in_succeeds_then_confirmed_email_is_set()
     {
         _authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
-            .Returns(AuthResultFactory.Success("token", "acc-1", "Test User", "test@example.com"));
+            .Returns(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("Test User", "test@example.com")));
         var sut = CreateSut();
 
         await sut.OpenBrowserCommand.ExecuteAsync(null);
@@ -409,7 +409,7 @@ public sealed class GivenAnAddAccountWizardViewModel
 
         var firstCall = sut.OpenBrowserCommand.ExecuteAsync(null);
         await sut.OpenBrowserCommand.ExecuteAsync(null);
-        tcs.SetResult(AuthResultFactory.Success("token", "acc-1", "User", "user@example.com"));
+        tcs.SetResult(AuthResultFactory.Success("token", "acc-1", AccountProfileFactory.Create("User", "user@example.com")));
         await firstCall;
 
         await _authService.Received(1).SignInInteractiveAsync(Arg.Any<CancellationToken>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
@@ -40,8 +40,7 @@ public sealed class GivenASettingsViewModel
     private static OneDriveAccount BuildAccount(string accountId) => new()
     {
         Id = new AccountId(accountId),
-        DisplayName = "Test User",
-        Email = "test@example.com"
+        Profile = AccountProfileFactory.Create("Test User", "test@example.com")
     };
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountCardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountCardViewModel.cs
@@ -25,8 +25,8 @@ public sealed partial class AccountCardViewModel : ObservableObject
 
     /// <summary>Raw string account ID — unwrapped at the display boundary.</summary>
     public string Id => _model.Id.Id;
-    public string DisplayName => _model.DisplayName;
-    public string Email => _model.Email;
+    public string DisplayName => _model.Profile.DisplayName;
+    public string Email => _model.Profile.Email;
     public Color AccentColor => Color.Parse(PaletteHex(_model.AccentIndex));
 
     /// <summary>
@@ -37,15 +37,15 @@ public sealed partial class AccountCardViewModel : ObservableObject
     {
         get
         {
-            string[] parts = _model.DisplayName
+            string[] parts = _model.Profile.DisplayName
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
             return parts.Length >= 2
                 ? $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant()
-                : _model.DisplayName.Length > 0
-                    ? _model.DisplayName[0].ToString().ToUpperInvariant()
-                    : _model.Email.Length > 0
-                        ? _model.Email[0].ToString().ToUpperInvariant()
+                : _model.Profile.DisplayName.Length > 0
+                    ? _model.Profile.DisplayName[0].ToString().ToUpperInvariant()
+                    : _model.Profile.Email.Length > 0
+                        ? _model.Profile.Email[0].ToString().ToUpperInvariant()
                         : "?";
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -26,12 +26,12 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     /// <summary>The unique identifier for the account.</summary>
     public string AccountId => _account.Id.Id;
-    public string DisplayName => _account.DisplayName;
-    public string Email => _account.Email;
+    public string DisplayName => _account.Profile.DisplayName;
+    public string Email => _account.Profile.Email;
 
-    public string TabLabel => _account.DisplayName.Length > 0
-                                 ? _account.DisplayName
-                                 : _account.Email;
+    public string TabLabel => _account.Profile.DisplayName.Length > 0
+                                 ? _account.Profile.DisplayName
+                                 : _account.Profile.Email;
 
     public int AccentIndex => _account.AccentIndex;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountSyncSettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountSyncSettingsViewModel.cs
@@ -12,8 +12,8 @@ public sealed partial class AccountSyncSettingsViewModel(OneDriveAccount account
 {
     /// <summary>Raw string account ID — unwrapped at the display boundary.</summary>
     public string AccountId => account.Id.Id;
-    public string Email => account.Email;
-    public string DisplayName => account.DisplayName;
+    public string Email => account.Profile.Email;
+    public string DisplayName => account.Profile.DisplayName;
     public string AccentHex => AccountCardViewModel.PaletteHex(account.AccentIndex);
 
     [ObservableProperty]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -99,7 +99,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
                     account.IsActive = Accounts.Count == 0;
                     if(account.LocalSyncPath is null)
                     {
-                        var defaultPath = ApplicationMetadata.ApplicationNameLowered.UserDirectory().CombinePath(account.Email);
+                        var defaultPath = ApplicationMetadata.ApplicationNameLowered.UserDirectory().CombinePath(account.Profile.Email);
                         account.LocalSyncPath = LocalSyncPathFactory.Create(defaultPath).Match<LocalSyncPath?>(p => p, _ => null);
                     }
 
@@ -211,8 +211,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
         => new()
         {
             Id            = a.Id,
-            DisplayName   = a.DisplayName,
-            Email         = a.Email,
+            Profile       = a.Profile,
             AccentIndex   = a.AccentIndex,
             IsActive      = a.IsActive,
             LastSyncedAt  = a.LastSyncedAt,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccount.cs
@@ -7,11 +7,8 @@ public sealed class OneDriveAccount
     /// <summary>Stable identifier — the Microsoft account object ID from MSAL.</summary>
     public AccountId Id { get; init; }
 
-    /// <summary>Display name from the Microsoft profile (e.g. "Jason Smith").</summary>
-    public string DisplayName { get; set; } = string.Empty;
-
-    /// <summary>Email / UPN (e.g. jason@outlook.com).</summary>
-    public string Email { get; set; } = string.Empty;
+    /// <summary>Display name and email from the Microsoft profile.</summary>
+    public AccountProfile Profile { get; set; } = AccountProfileFactory.Empty;
 
     /// <summary>
     /// Index into the fixed accent colour palette (0–5).

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -18,8 +18,8 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
 
     /// <summary>Raw string account ID — unwrapped at the display boundary.</summary>
     public string AccountId => _account.Id.Id;
-    public string DisplayName => _account.DisplayName;
-    public string Email => _account.Email;
+    public string DisplayName => _account.Profile.DisplayName;
+    public string Email => _account.Profile.Email;
     public string AccentHex => Accounts.AccountCardViewModel.PaletteHex(_account.AccentIndex);
     public Avalonia.Media.Color AccentColor => Avalonia.Media.Color.Parse(AccentHex);
 
@@ -96,12 +96,11 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
             {
                 var fullAccount = new OneDriveAccount
                 {
-                    Id                = entity.Id,
-                    DisplayName       = entity.DisplayName,
-                    Email             = entity.Email,
-                    LocalSyncPath     = entity.LocalSyncPath.Value.Length > 0 ? entity.LocalSyncPath : null,
-                    ConflictPolicy    = entity.ConflictPolicy,
-                    LastSyncedAt      = entity.LastSyncedAt
+                    Id            = entity.Id,
+                    Profile       = entity.Profile,
+                    LocalSyncPath = entity.LocalSyncPath.Value.Length > 0 ? entity.LocalSyncPath : null,
+                    ConflictPolicy = entity.ConflictPolicy,
+                    LastSyncedAt  = entity.LastSyncedAt
                 };
                 await _scheduler.TriggerAccountAsync(fullAccount);
             });

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/AccountEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/AccountEntityConfiguration.cs
@@ -12,6 +12,11 @@ public class AccountEntityConfiguration : IEntityTypeConfiguration<AccountEntity
         _ = builder.HasKey(e => e.Id);
         _ = builder.Property(e => e.Id)
                    .HasConversion(id => id.Id, str => new AccountId(str));
+        _ = builder.ComplexProperty(e => e.Profile, p =>
+        {
+            _ = p.Property(prof => prof.DisplayName).HasColumnName("DisplayName");
+            _ = p.Property(prof => prof.Email).HasColumnName("Email");
+        });
         _ = builder.Property(e => e.LocalSyncPath)
                    .HasConversion(path => path.Value, str => LocalSyncPath.Restore(str));
         _ = builder.HasMany<SyncConflictEntity>()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/AccountEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/AccountEntity.cs
@@ -1,13 +1,11 @@
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 
-
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 
 public sealed class AccountEntity
 {
     public AccountId Id { get; set; } = new AccountId("Unknown");
-    public string DisplayName { get; set; } = string.Empty;
-    public string Email { get; set; } = string.Empty;
+    public AccountProfile Profile { get; set; } = AccountProfileFactory.Empty;
     public int AccentIndex { get; set; }
     public bool IsActive { get; set; }
     public DateTimeOffset? LastSyncedAt { get; set; }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
@@ -17,7 +17,7 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         return await db.Accounts
-          .OrderBy(a => a.Email)
+          .OrderBy(a => a.Profile.Email)
           .ToListAsync(cancellationToken);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/AccountProfile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/AccountProfile.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>The Microsoft account display fields captured during authentication.</summary>
+public sealed record AccountProfile(string DisplayName, string Email);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/AccountProfileFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/AccountProfileFactory.cs
@@ -1,0 +1,11 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="AccountProfile"/>.</summary>
+public static class AccountProfileFactory
+{
+    /// <summary>Creates an <see cref="AccountProfile"/> from the given Microsoft account display fields.</summary>
+    public static AccountProfile Create(string displayName, string email) => new(displayName, email);
+
+    /// <summary>An empty profile with no display fields set.</summary>
+    public static AccountProfile Empty => new(string.Empty, string.Empty);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
@@ -165,7 +165,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
                     settings.AddAccount(account);
                     ActiveSection = NavSection.Files;
                     await files.ActivateAccountAsync(account.Id.Id);
-                    await activity.SetActiveAccountAsync(account.Id.Id, account.Email);
+                    await activity.SetActiveAccountAsync(account.Id.Id, account.Profile.Email);
                     return Unit.Default;
                 })
                 .TapErrorAsync(e => Serilog.Log.Error(e, "[MainWindowViewModel.OnAccountAddedAsync] Error: {Error}", e));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResult.cs
@@ -1,7 +1,9 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 /// <summary>
 /// The success payload returned when authentication succeeds.
 /// Use <see cref="AuthResultFactory"/> to obtain a <see cref="AStar.Dev.Functional.Extensions.Result{TSuccess,TError}"/> wrapping this value.
 /// </summary>
-public sealed record AuthResult(string AccessToken, string AccountId, string DisplayName, string Email);
+public sealed record AuthResult(string AccessToken, string AccountId, AccountProfile Profile);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthResultFactory.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
@@ -12,6 +13,6 @@ public static class AuthResultFactory
     public static Result<AuthResult, AuthError> Failure(string message) => new Result<AuthResult, AuthError>.Error(new AuthFailedError(message));
 
     /// <summary>Returns a successful authentication result containing the token and account details.</summary>
-    public static Result<AuthResult, AuthError> Success(string accessToken, string accountId, string displayName, string email)
-         => new Result<AuthResult, AuthError>.Ok(new AuthResult(accessToken, accountId, displayName, email));
+    public static Result<AuthResult, AuthError> Success(string accessToken, string accountId, AccountProfile profile)
+         => new Result<AuthResult, AuthError>.Ok(new AuthResult(accessToken, accountId, profile));
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
@@ -146,6 +147,6 @@ public sealed class AuthService(ITokenCacheService cacheService, IOptions<EntraI
                 email = emailClaim;
         }
 
-        return AuthResultFactory.Success(accessToken: result.AccessToken, accountId: result.Account.HomeAccountId.Identifier, displayName: displayName ?? result.Account.Username, email: email ?? result.Account.Username);
+        return AuthResultFactory.Success(accessToken: result.AccessToken, accountId: result.Account.HomeAccountId.Identifier, profile: AccountProfileFactory.Create(displayName ?? result.Account.Username, email ?? result.Account.Username));
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
@@ -35,7 +35,7 @@ public sealed class ApplicationInitializer(IStartupService startupService, Accou
             if(activeAccount is not null)
             {
                 await files.ActivateAccountAsync(activeAccount.Id.Id).ConfigureAwait(false);
-                await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Email).ConfigureAwait(false);
+                await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Profile.Email).ConfigureAwait(false);
             }
         }
         catch(Exception ex)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -19,7 +19,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
         if(rules.Count == 0)
         {
-            Serilog.Log.Information("[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync", account.Email);
+            Serilog.Log.Information("[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync", account.Profile.Email);
 
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: true);
         }
@@ -48,7 +48,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 continue;
             }
 
-            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Email);
+            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Profile.Email);
             var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct).ConfigureAwait(false);
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -107,8 +107,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     private static OneDriveAccount MapEntityToAccount(AccountEntity entity, IReadOnlyList<SyncRuleEntity> rules) => new()
     {
         Id                = entity.Id,
-        DisplayName       = entity.DisplayName,
-        Email             = entity.Email,
+        Profile           = entity.Profile,
         AccentIndex       = entity.AccentIndex,
         IsActive          = entity.IsActive,
         LastSyncedAt      = entity.LastSyncedAt,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -26,7 +26,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     /// <inheritdoc />
     public async Task SyncAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
-        Serilog.Log.Information("[SyncService] SyncAccountAsync for {Email}", account.Email);
+        Serilog.Log.Information("[SyncService] SyncAccountAsync for {Email}", account.Profile.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
         var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
@@ -64,7 +64,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 RaiseProgress(account.Id.Id, 0, 0, "No folders selected", SyncState.Idle);
             else
             {
-                Serilog.Log.Information("[SyncService] Sync complete for {Email}", account.Email);
+                Serilog.Log.Information("[SyncService] Sync complete for {Email}", account.Profile.Email);
                 RaiseProgress(account.Id.Id, 0, 0, "Sync complete", SyncState.Idle);
             }
         }
@@ -74,7 +74,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[SyncService] Unhandled error syncing {Email}: {Error}", account.Email, ex.Message);
+            Serilog.Log.Error(ex, "[SyncService] Unhandled error syncing {Email}: {Error}", account.Profile.Email, ex.Message);
             RaiseProgress(account.Id.Id, 0, 0, ex.Message, SyncState.Error);
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -1,9 +1,9 @@
 using System.Collections.ObjectModel;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
-using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -156,8 +156,8 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
     {
         _accountId = successfulLoginResult.Value.AccountId;
         _accessToken = successfulLoginResult.Value.AccessToken;
-        ConfirmedDisplayName = successfulLoginResult.Value.DisplayName;
-        ConfirmedEmail = successfulLoginResult.Value.Email;
+        ConfirmedDisplayName = successfulLoginResult.Value.Profile.DisplayName;
+        ConfirmedEmail = successfulLoginResult.Value.Profile.Email;
         IsSignedIn = true;
         SignInStatusText = $"Signed in as {ConfirmedEmail}";
         SignInHasError = false;
@@ -230,8 +230,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
         var account = new OneDriveAccount
         {
             Id = new AccountId(_accountId),
-            DisplayName = ConfirmedDisplayName,
-            Email = ConfirmedEmail,
+            Profile = AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
             SelectedFolderIds = [.. Folders.Where(f => f.IsSelected).Select(f => new OneDriveFolderId(f.Id))],
             FolderNames = Folders
                 .Where(f => f.IsSelected)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
@@ -26,8 +26,7 @@ public sealed class StartupService(IAccountRepository repository, ISyncRuleRepos
             accounts.Add(new OneDriveAccount
             {
                 Id                = entity.Id,
-                DisplayName       = entity.DisplayName,
-                Email             = entity.Email,
+                Profile           = entity.Profile,
                 AccentIndex       = entity.AccentIndex,
                 IsActive          = entity.IsActive,
                 LastSyncedAt      = entity.LastSyncedAt,

--- a/docs/astar-dev-onedrive-sync-client/dataclump-analysis.md
+++ b/docs/astar-dev-onedrive-sync-client/dataclump-analysis.md
@@ -1,0 +1,285 @@
+# Data-Clump Analysis — AStar.Dev.OneDrive.Sync.Client
+
+> Generated 2026-05-06. Scope: all `.cs` files in `apps/desktop/AStar.Dev.OneDrive.Sync.Client/`.
+> The SyncJob data-clumps (`RemoteItemRef`, `SyncFileTarget`, `SyncFileMetadata`, `SyncJobStatus`) were already extracted per `syncjob-dataclump-refactor.md` and are not re-listed here.
+
+---
+
+## Summary
+
+| # | Clump | Fields | Consumers | Status |
+|---|-------|--------|-----------|--------|
+| 1 | Account Profile | `DisplayName` · `Email` · `AccentIndex` | 5 | Not extracted |
+| 2 | Account Sync Config | `ConflictPolicy` · `LocalSyncPath` | 4 | Not extracted |
+| 3 | Storage Quota | `QuotaTotal` · `QuotaUsed` | 3 | Not extracted |
+| 4 | Remote File Identity in SyncConflict | `AccountId` · `FolderId` · `RemoteItemId` | 2 | `RemoteItemRef` exists — not applied |
+| 5 | Local File Location in SyncConflict | `LocalPath` · `RelativePath` | 2 | `SyncFileTarget` exists — not applied |
+| 6 | Conflict Snapshot | `LocalModified` · `LocalSize` · `RemoteModified` · `RemoteSize` | 2 | Not extracted |
+| 7 | Version Tags in SyncedItemEntity | `ETag` · `CTag` | 2 | `VersionInfo` exists — not applied |
+
+---
+
+## Clump 1 — Account Profile (5 consumers)
+
+**Fields:** `DisplayName` (string), `Email` (string), `AccentIndex` (int)
+
+**Question answered:** *Who is this Microsoft account and how should it be presented?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `OneDriveAccount` | `Accounts/OneDriveAccount.cs:11-20` | All three |
+| `AccountEntity` | `Data/Entities/AccountEntity.cs:9-11` | All three |
+| `AuthResult` | `Infrastructure/Authentication/AuthResult.cs:7` | `DisplayName` + `Email` |
+| `AccountCardViewModel` | `Accounts/AccountCardViewModel.cs:29-57` | Reads all three from `_model` |
+| `DashboardAccountViewModel` | `Dashboard/DashboardAccountViewModel.cs:21-23` | Reads all three from `_account` |
+
+**Pattern:** Every site that holds or displays account identity reads the same three fields together. `AccentIndex` always accompanies `DisplayName` + `Email` because all rendering sites need it to pick an avatar colour.
+
+**Proposed extraction:**
+
+```csharp
+// Domain/AccountProfile.cs
+public sealed record AccountProfile(string DisplayName, string Email, int AccentIndex);
+
+// Domain/AccountProfileFactory.cs
+public static class AccountProfileFactory
+{
+    public static AccountProfile Create(string displayName, string email, int accentIndex)
+        => new(displayName, email, accentIndex);
+}
+```
+
+**Migration impact:**
+- `OneDriveAccount` — replace three flat properties with `AccountProfile Profile { get; set; }`
+- `AccountEntity` — same; or use EF Core Owned Entity Type `[Owned]`
+- `AuthResult` — drop `DisplayName` + `Email` constructor params; pass `AccountProfile` instead
+- `AccountCardViewModel` — `_model.Profile.DisplayName`, `_model.Profile.Email`, `_model.Profile.AccentIndex`
+- `DashboardAccountViewModel` — same access pattern
+
+---
+
+## Clump 2 — Account Sync Config (4 consumers)
+
+**Fields:** `ConflictPolicy` (enum), `LocalSyncPath` (`LocalSyncPath` / string)
+
+**Question answered:** *How should this account's sync behave locally?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `OneDriveAccount` | `Accounts/OneDriveAccount.cs:44-49` | Both |
+| `AccountEntity` | `Data/Entities/AccountEntity.cs:16-17` | Both |
+| `AccountSettings` | `Accounts/AccountSettings.cs:12-18` | Both (LocalSyncPath as `string`) |
+| `DashboardAccountViewModel.SyncNowAsync` | `Dashboard/DashboardAccountViewModel.cs:100-104` | Both (inline construction) |
+
+**Pattern:** Every time an account is loaded, saved, or used to trigger a sync, these two fields move together. `AccountSettings` is a DTO that duplicates both, and `SyncNowAsync` inline-constructs an `OneDriveAccount` by copying only these two fields plus identity fields.
+
+**Note:** `AccountSettings.LocalSyncPath` is still a raw `string` — it should use `LocalSyncPath` (the validated value object) for consistency.
+
+**Proposed extraction:**
+
+```csharp
+// Domain/AccountSyncConfig.cs
+public sealed record AccountSyncConfig(ConflictPolicy ConflictPolicy, LocalSyncPath LocalSyncPath);
+
+// Domain/AccountSyncConfigFactory.cs
+public static class AccountSyncConfigFactory
+{
+    public static AccountSyncConfig Create(ConflictPolicy policy, LocalSyncPath path)
+        => new(policy, path);
+}
+```
+
+**Migration impact:**
+- `OneDriveAccount` — replace two flat properties with `AccountSyncConfig SyncConfig { get; set; }`
+- `AccountEntity` — same; EF Core Owned Entity Type for `AccountSyncConfig`
+- `AccountSettings` — replace with `AccountSyncConfig` directly; delete `AccountSettings`
+- `DashboardAccountViewModel.SyncNowAsync` — pass `entity.SyncConfig` rather than copying fields
+- All callers of `account.ConflictPolicy` → `account.SyncConfig.ConflictPolicy`
+- All callers of `account.LocalSyncPath` → `account.SyncConfig.LocalSyncPath`
+
+---
+
+## Clump 3 — Storage Quota (3 consumers)
+
+**Fields:** `QuotaTotal` (long, bytes), `QuotaUsed` (long, bytes)
+
+**Question answered:** *How much OneDrive storage does this account have and use?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `OneDriveAccount` | `Accounts/OneDriveAccount.cs:32-35` | Both |
+| `AccountEntity` | `Data/Entities/AccountEntity.cs:13-14` | Both |
+| `DashboardAccountViewModel` | `Dashboard/DashboardAccountViewModel.cs:26-33` | Both; derives `StorageFraction` + `StorageText` |
+
+**Pattern:** `QuotaTotal` and `QuotaUsed` always appear and change together (refreshed from Graph API as a pair). `DashboardAccountViewModel` re-derives formatted display from both simultaneously.
+
+**Proposed extraction:**
+
+```csharp
+// Domain/StorageQuota.cs
+public sealed record StorageQuota(long TotalBytes, long UsedBytes)
+{
+    public double Fraction => TotalBytes > 0 ? Math.Clamp((double)UsedBytes / TotalBytes, 0, 1) : 0;
+}
+
+// Domain/StorageQuotaFactory.cs
+public static class StorageQuotaFactory
+{
+    public static StorageQuota Create(long totalBytes, long usedBytes) => new(totalBytes, usedBytes);
+    public static StorageQuota Unknown => new(0, 0);
+}
+```
+
+**Migration impact:**
+- `OneDriveAccount` — `QuotaTotal` + `QuotaUsed` → `StorageQuota Quota { get; set; }`
+- `AccountEntity` — same; EF Core Owned Entity Type
+- `DashboardAccountViewModel` — `StorageFraction` and `StorageText` delegate to `_account.Quota.Fraction`; remove inline calculation
+
+---
+
+## Clump 4 — Remote File Identity in SyncConflict (2 consumers)
+
+**Fields:** `AccountId` (string), `FolderId` (string), `RemoteItemId` (string)
+
+**Question answered:** *Which remote item is involved in this conflict?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `SyncConflict` | `Domain/SyncConflict.cs:12-14` | All three — as raw strings |
+| `RemoteItemRef` | `Domain/RemoteItemRef.cs` | Extracted record — used by `SyncJob` |
+
+**Pattern:** `SyncConflict` uses the same three-field identity group as `SyncJob.Remote`, but stores raw strings instead of the already-extracted `RemoteItemRef`. This inconsistency means conflict resolution code handles the same concept twice with different shapes.
+
+**Note:** `SyncConflict.AccountId` / `FolderId` / `RemoteItemId` use `string` not the strong-typed IDs (`AccountId`, `OneDriveFolderId`, `OneDriveItemId`). The fix should use the strong IDs and the existing record.
+
+**Proposed change:** Replace the three string fields with `RemoteItemRef Remote { get; init; }`.
+
+**Migration impact:**
+- `Domain/SyncConflict.cs:12-14` — remove `AccountId`, `FolderId`, `RemoteItemId`; add `RemoteItemRef Remote`
+- `Data/Repositories/SyncRepository.cs` — conflict entity mapping
+- `ConflictItemViewModel` — `conflict.AccountId` → `conflict.Remote.AccountId.Id`
+- `Infrastructure/Sync/RemoteFolderEnumerator.cs` — conflict construction site
+
+---
+
+## Clump 5 — Local File Location in SyncConflict (2 consumers)
+
+**Fields:** `LocalPath` (string), `RelativePath` (string)
+
+**Question answered:** *Where does the conflicting file live on disk?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `SyncConflict` | `Domain/SyncConflict.cs:15-16` | Both — as raw strings |
+| `SyncFileTarget` | `Domain/SyncFileTarget.cs` | Extracted record — used by `SyncJob` |
+
+**Pattern:** Identical to Clump 4. `SyncConflict` carries the same local-path pair as `SyncJob.Target` but as raw strings, creating an inconsistency between the two domain objects that represent the same operation from different perspectives.
+
+**Proposed change:** Replace `LocalPath` + `RelativePath` with `SyncFileTarget Target { get; init; }`.
+
+**Migration impact:**
+- `Domain/SyncConflict.cs:15-16` — remove `LocalPath`, `RelativePath`; add `SyncFileTarget Target`
+- `ConflictItemViewModel` — `conflict.RelativePath` → `conflict.Target.RelativePath`, `conflict.LocalPath` → `conflict.Target.LocalPath`
+- `Data/Repositories/SyncRepository.cs` — conflict entity mapping
+
+---
+
+## Clump 6 — Conflict Snapshot (2 consumers)
+
+**Fields:** `LocalModified` (DateTimeOffset), `LocalSize` (long), `RemoteModified` (DateTimeOffset), `RemoteSize` (long)
+
+**Question answered:** *What were the local and remote file states when the conflict was detected?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `SyncConflict` | `Domain/SyncConflict.cs:18-21` | All four |
+| `ConflictItemViewModel` | `Conflicts/ConflictItemViewModel.cs:18-21` | Re-exposes all four; derives four formatted text properties |
+
+**Pattern:** These four values are detected, persisted, and displayed as a unit. `ConflictResolver` reads `LocalModified` and `RemoteModified` together to apply `LastWriteWins` policy. `ConflictItemViewModel` projects all four into display text simultaneously.
+
+**Proposed extraction:**
+
+```csharp
+// Domain/ConflictSnapshot.cs
+public sealed record ConflictSnapshot(DateTimeOffset LocalModified, long LocalSize, DateTimeOffset RemoteModified, long RemoteSize);
+
+// Domain/ConflictSnapshotFactory.cs
+public static class ConflictSnapshotFactory
+{
+    public static ConflictSnapshot Create(DateTimeOffset localModified, long localSize, DateTimeOffset remoteModified, long remoteSize)
+        => new(localModified, localSize, remoteModified, remoteSize);
+}
+```
+
+**Migration impact:**
+- `Domain/SyncConflict.cs` — replace four flat fields with `ConflictSnapshot Snapshot { get; init; }`
+- `Conflicts/ConflictResolver.cs` — `conflict.LocalModified` → `conflict.Snapshot.LocalModified` etc.
+- `ConflictItemViewModel` — all four properties delegate to `conflict.Snapshot.*`
+
+---
+
+## Clump 7 — Version Tags in SyncedItemEntity (2 consumers)
+
+**Fields:** `ETag` (string?), `CTag` (string?)
+
+**Question answered:** *What Graph API change-detection tags identify this version of the item?*
+
+| Consumer | File | Fields present |
+|----------|------|----------------|
+| `SyncedItemEntity` | `Data/Entities/SyncedItemEntity.cs:16-17` | Both — flat nullable strings |
+| `VersionInfo` | `Domain/VersionInfo.cs` | Extracted record — used by `DeltaItem` |
+
+**Pattern:** `DeltaItem` already uses `VersionInfo` for ETag/CTag. `SyncedItemEntity` persists the same data as flat columns instead of using an owned type. When ETag/CTag are read from the entity and compared against a `DeltaItem.VersionInfo`, the mismatch forces manual field mapping at every comparison site.
+
+**Proposed change:** Apply EF Core Owned Entity Type so `SyncedItemEntity` holds a `VersionInfo Tags` property backed by the same columns.
+
+```csharp
+// SyncedItemEntity.cs — replace ETag + CTag with:
+public VersionInfo Tags { get; set; } = new(null, null);
+
+// AppDbContext / entity configuration:
+entity.OwnsOne(e => e.Tags, b =>
+{
+    b.Property(v => v.ETag).HasColumnName("ETag");
+    b.Property(v => v.CTag).HasColumnName("CTag");
+});
+```
+
+**Migration impact:**
+- `Data/Entities/SyncedItemEntity.cs:16-17` — remove `ETag`, `CTag`; add `VersionInfo Tags`
+- `Data/Repositories/SyncedItemRepository.cs` — any `entity.ETag` → `entity.Tags.ETag`
+- `Infrastructure/Sync/RemoteFolderEnumerator.cs` — ETag comparison sites
+- A new EF Core migration is required
+
+---
+
+## Cross-Cutting Note — SyncConflict
+
+`SyncConflict` is the primary clump aggregator. It contains **four** separate data-clumps (Clumps 4, 5, 6, and the implicit identity/state fields). After applying all four extractions, it becomes:
+
+```csharp
+public sealed class SyncConflict
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public RemoteItemRef Remote { get; init; }
+    public SyncFileTarget Target { get; init; }
+    public ConflictSnapshot Snapshot { get; init; }
+    public ConflictState State { get; set; } = ConflictState.Pending;
+    public ConflictPolicy? Resolution { get; set; }
+    public DateTimeOffset DetectedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? ResolvedAt { get; set; }
+}
+```
+
+Field count: **16 → 8**. Every consumer site gains named access (`conflict.Remote.AccountId`, `conflict.Snapshot.LocalModified`) matching the pattern already established by `SyncJob`.
+
+---
+
+## Recommended Implementation Order
+
+1. **Clump 6** — `ConflictSnapshot` — no existing record, new domain type, touches only `SyncConflict` and `ConflictItemViewModel`
+2. **Clumps 4 + 5** — apply `RemoteItemRef` and `SyncFileTarget` to `SyncConflict` — types already exist, alignment refactor only
+3. **Clump 7** — EF Core Owned Type for `VersionInfo` — requires migration; isolate in a single PR
+4. **Clump 3** — `StorageQuota` — small record, touches two entities and one ViewModel
+5. **Clump 2** — `AccountSyncConfig` — medium impact; `AccountSettings` can be deleted afterward
+6. **Clump 1** — `AccountProfile` — highest consumer count; save for last as it touches all account-facing layers


### PR DESCRIPTION
## Summary

- Extracts the `DisplayName + Email` data-clump that always travelled together across `OneDriveAccount`, `AccountEntity`, `AuthResult`, and ~20 consumer sites into a new `AccountProfile` record + `AccountProfileFactory`
- EF Core ownership mapped via `ComplexProperty` (EF 8+) — preserves existing `DisplayName`/`Email` column names, no migration required
- `AuthResultFactory.Success` signature collapsed from 4 params to 3 (`accessToken`, `accountId`, `AccountProfile profile`)
- `AccentIndex` intentionally kept flat — it is a UI-assigned palette index, not sourced from Microsoft profile
- Repository tests migrated from EF in-memory provider to SQLite in-memory (EF in-memory does not support `ComplexProperty` query translation)

## Test plan

- [x] `dotnet build` — zero errors, zero warnings (two pre-existing Avalonia AXAML warnings unrelated to this change)
- [x] `dotnet test` — 787 total, 787 passed, 0 failed
- [x] All 14 affected test files updated to use `AccountProfileFactory.Create(...)` / `Profile = ...`
- [x] `GivenAnAccountRepository` migrated to SQLite in-memory + `IDisposable` pattern matching `GivenASyncRuleRepository`

Closes #261 