### PR TITLE
feat(apps/desktop): extract StorageQuota data-clump (#263)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccount.cs
@@ -15,8 +15,8 @@ public sealed class GivenAnOneDriveAccount
         account.AccentIndex.ShouldBe(0);
         account.SelectedFolderIds.ShouldBeEmpty();
         account.LastSyncedAt.ShouldBeNull();
-        account.QuotaTotal.ShouldBe(0L);
-        account.QuotaUsed.ShouldBe(0L);
+        account.Quota.TotalBytes.ShouldBe(0L);
+        account.Quota.UsedBytes.ShouldBe(0L);
         account.IsActive.ShouldBeFalse();
         account.FolderNames.ShouldBeEmpty();
         account.SyncConfig.ShouldBeNull();
@@ -88,25 +88,25 @@ public sealed class GivenAnOneDriveAccount
     }
 
     [Fact]
-    public void when_quota_total_is_set_then_it_is_preserved()
+    public void when_quota_is_set_then_total_bytes_is_preserved()
     {
         var account = new OneDriveAccount();
-        long quotaTotal = 1_099_511_627_776L;
+        long totalBytes = 1_099_511_627_776L;
 
-        account.QuotaTotal = quotaTotal;
+        account.Quota = StorageQuotaFactory.Create(totalBytes, 0L);
 
-        account.QuotaTotal.ShouldBe(quotaTotal);
+        account.Quota.TotalBytes.ShouldBe(totalBytes);
     }
 
     [Fact]
-    public void when_quota_used_is_set_then_it_is_preserved()
+    public void when_quota_is_set_then_used_bytes_is_preserved()
     {
         var account = new OneDriveAccount();
-        long quotaUsed = 549_755_813_888L;
+        long usedBytes = 549_755_813_888L;
 
-        account.QuotaUsed = quotaUsed;
+        account.Quota = StorageQuotaFactory.Create(1_099_511_627_776L, usedBytes);
 
-        account.QuotaUsed.ShouldBe(quotaUsed);
+        account.Quota.UsedBytes.ShouldBe(usedBytes);
     }
 
     [Fact]
@@ -185,15 +185,14 @@ public sealed class GivenAnOneDriveAccount
 
         account.Profile = AccountProfileFactory.Create(displayName, email);
         account.AccentIndex = accentIndex;
-        account.QuotaTotal = quotaTotal;
-        account.QuotaUsed = quotaUsed;
+        account.Quota = StorageQuotaFactory.Create(quotaTotal, quotaUsed);
         account.IsActive = true;
 
         account.Profile.DisplayName.ShouldBe(displayName);
         account.Profile.Email.ShouldBe(email);
         account.AccentIndex.ShouldBe(accentIndex);
-        account.QuotaTotal.ShouldBe(quotaTotal);
-        account.QuotaUsed.ShouldBe(quotaUsed);
+        account.Quota.TotalBytes.ShouldBe(quotaTotal);
+        account.Quota.UsedBytes.ShouldBe(quotaUsed);
         account.IsActive.ShouldBeTrue();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAStorageQuota.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAStorageQuota.cs
@@ -1,0 +1,85 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAStorageQuota
+{
+    private const long TotalBytes = 1_099_511_627_776L;
+    private const long UsedBytes = 549_755_813_888L;
+
+    [Fact]
+    public void when_created_then_total_bytes_is_set_correctly()
+    {
+        var quota = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+
+        quota.TotalBytes.ShouldBe(TotalBytes);
+    }
+
+    [Fact]
+    public void when_created_then_used_bytes_is_set_correctly()
+    {
+        var quota = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+
+        quota.UsedBytes.ShouldBe(UsedBytes);
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_values_then_they_are_equal()
+    {
+        var first = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+        var second = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_total_bytes_then_they_are_not_equal()
+    {
+        var first = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+        var second = StorageQuotaFactory.Create(TotalBytes + 1, UsedBytes);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_used_bytes_then_they_are_not_equal()
+    {
+        var first = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+        var second = StorageQuotaFactory.Create(TotalBytes, UsedBytes + 1);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void when_unknown_is_requested_then_both_fields_are_zero()
+    {
+        var unknown = StorageQuotaFactory.Unknown;
+
+        unknown.TotalBytes.ShouldBe(0L);
+        unknown.UsedBytes.ShouldBe(0L);
+    }
+
+    [Fact]
+    public void when_fraction_is_calculated_with_nonzero_total_then_result_is_used_divided_by_total()
+    {
+        var quota = StorageQuotaFactory.Create(TotalBytes, UsedBytes);
+
+        quota.Fraction().ShouldBe((double)UsedBytes / TotalBytes, tolerance: 1e-10);
+    }
+
+    [Fact]
+    public void when_fraction_is_calculated_with_zero_total_then_result_is_zero()
+    {
+        var quota = StorageQuotaFactory.Unknown;
+
+        quota.Fraction().ShouldBe(0.0);
+    }
+
+    [Fact]
+    public void when_used_exceeds_total_then_fraction_is_clamped_to_one()
+    {
+        var quota = StorageQuotaFactory.Create(100L, 200L);
+
+        quota.Fraction().ShouldBe(1.0);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -217,8 +217,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
             AccentIndex  = a.AccentIndex,
             IsActive     = a.IsActive,
             LastSyncedAt = a.LastSyncedAt,
-            QuotaTotal   = a.QuotaTotal,
-            QuotaUsed    = a.QuotaUsed,
+            Quota        = a.Quota,
             SyncConfig   = a.SyncConfig ?? AccountSyncConfigFactory.Default
         };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccount.cs
@@ -25,11 +25,8 @@ public sealed class OneDriveAccount
     /// <summary>UTC timestamp of the last successful delta sync.</summary>
     public DateTimeOffset? LastSyncedAt { get; set; }
 
-    /// <summary>Total OneDrive quota in bytes (refreshed periodically).</summary>
-    public long QuotaTotal { get; set; }
-
-    /// <summary>Used OneDrive quota in bytes.</summary>
-    public long QuotaUsed { get; set; }
+    /// <summary>OneDrive storage quota refreshed periodically from the Graph API.</summary>
+    public StorageQuota Quota { get; set; } = StorageQuotaFactory.Unknown;
 
     /// <summary>Whether this account is currently active / selected in the UI.</summary>
     public bool IsActive { get; set; }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -24,14 +24,11 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public string AccentHex => Accounts.AccountCardViewModel.PaletteHex(_account.AccentIndex);
     public Avalonia.Media.Color AccentColor => Avalonia.Media.Color.Parse(AccentHex);
 
-    public long QuotaTotal => _account.QuotaTotal;
-    public long QuotaUsed => _account.QuotaUsed;
-    public double StorageFraction => QuotaTotal > 0
-        ? Math.Clamp((double)QuotaUsed / QuotaTotal, 0, 1)
-        : 0;
-
-    public string StorageText => QuotaTotal > 0
-        ? $"{QuotaUsed.FileSizeToText()} / {QuotaTotal.FileSizeToText()}"
+    public long QuotaTotal => _account.Quota.TotalBytes;
+    public long QuotaUsed => _account.Quota.UsedBytes;
+    public double StorageFraction => _account.Quota.Fraction();
+    public string StorageText => _account.Quota.TotalBytes > 0
+        ? $"{_account.Quota.UsedBytes.FileSizeToText()} / {_account.Quota.TotalBytes.FileSizeToText()}"
         : "Unknown";
 
     [ObservableProperty]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/AccountEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/AccountEntityConfiguration.cs
@@ -17,6 +17,11 @@ public class AccountEntityConfiguration : IEntityTypeConfiguration<AccountEntity
             _ = p.Property(prof => prof.DisplayName).HasColumnName("DisplayName");
             _ = p.Property(prof => prof.Email).HasColumnName("Email");
         });
+        _ = builder.ComplexProperty(e => e.Quota, q =>
+        {
+            _ = q.Property(s => s.TotalBytes).HasColumnName("QuotaTotal");
+            _ = q.Property(s => s.UsedBytes).HasColumnName("QuotaUsed");
+        });
         _ = builder.ComplexProperty(e => e.SyncConfig, s =>
         {
             _ = s.Property(cfg => cfg.ConflictPolicy).HasColumnName("ConflictPolicy");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/AccountEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/AccountEntity.cs
@@ -9,7 +9,6 @@ public sealed class AccountEntity
     public int AccentIndex { get; set; }
     public bool IsActive { get; set; }
     public DateTimeOffset? LastSyncedAt { get; set; }
-    public long QuotaTotal { get; set; }
-    public long QuotaUsed { get; set; }
+    public StorageQuota Quota { get; set; } = StorageQuotaFactory.Unknown;
     public AccountSyncConfig SyncConfig { get; set; } = AccountSyncConfigFactory.Default;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuota.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuota.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Groups the OneDrive storage quota fields refreshed as a pair from the Graph API.</summary>
+public sealed record StorageQuota(long TotalBytes, long UsedBytes);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuotaExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuotaExtensions.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Extension methods for <see cref="StorageQuota"/>.</summary>
+public static class StorageQuotaExtensions
+{
+    /// <summary>Returns the fraction of storage used, clamped to [0, 1]. Returns 0 when <see cref="StorageQuota.TotalBytes"/> is 0.</summary>
+    public static double Fraction(this StorageQuota quota) => quota.TotalBytes > 0 ? Math.Clamp((double)quota.UsedBytes / quota.TotalBytes, 0, 1) : 0;
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuotaFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/StorageQuotaFactory.cs
@@ -1,0 +1,11 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="StorageQuota"/>.</summary>
+public static class StorageQuotaFactory
+{
+    /// <summary>Creates a <see cref="StorageQuota"/> from the given byte counts.</summary>
+    public static StorageQuota Create(long totalBytes, long usedBytes) => new(totalBytes, usedBytes);
+
+    /// <summary>Quota with no data — used before the first Graph API refresh.</summary>
+    public static StorageQuota Unknown => new(0, 0);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
@@ -30,8 +30,7 @@ public sealed class StartupService(IAccountRepository repository, ISyncRuleRepos
                 AccentIndex       = entity.AccentIndex,
                 IsActive          = entity.IsActive,
                 LastSyncedAt      = entity.LastSyncedAt,
-                QuotaTotal        = entity.QuotaTotal,
-                QuotaUsed         = entity.QuotaUsed,
+                Quota             = entity.Quota,
                 SelectedFolderIds = [.. rules.Where(r => r.RuleType == RuleType.Include && r.RemoteItemId is not null).Select(r => new OneDriveFolderId(r.RemoteItemId!))],
                 SyncConfig        = entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? entity.SyncConfig : null
             });


### PR DESCRIPTION
## Summary

- Extracts `QuotaTotal` + `QuotaUsed` data-clump from `OneDriveAccount`, `AccountEntity`, and `DashboardAccountViewModel` into a `StorageQuota` record
- `StorageQuota(TotalBytes, UsedBytes)` lives in `Domain/`; factory and extension method follow repo conventions
- `Fraction()` computed via extension method rather than record property, per code-style rules
- EF Core `ComplexProperty` maps `TotalBytes`/`UsedBytes` to existing columns `QuotaTotal`/`QuotaUsed` — no migration required

## Test plan

- [x] `GivenAStorageQuota` — 9 new tests covering create, equality, `Unknown`, `Fraction()` including clamp edge case
- [x] `GivenAnOneDriveAccount` — updated quota tests to use `Quota.TotalBytes` / `Quota.UsedBytes`
- [x] All 803 tests pass, 0 failures

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)