### PR TITLE
feat(apps/desktop): extract ConflictSnapshot data-clump (#266)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAConflictSnapshot.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAConflictSnapshot.cs
@@ -1,0 +1,61 @@
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAConflictSnapshot
+{
+    private static readonly DateTimeOffset LocalModified = new(2025, 1, 1, 10, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset RemoteModified = new(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+    private const long LocalSize = 1024L;
+    private const long RemoteSize = 2048L;
+
+    [Fact]
+    public void when_created_then_local_modified_is_preserved()
+    {
+        var snapshot = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+
+        snapshot.LocalModified.ShouldBe(LocalModified);
+    }
+
+    [Fact]
+    public void when_created_then_local_size_is_preserved()
+    {
+        var snapshot = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+
+        snapshot.LocalSize.ShouldBe(LocalSize);
+    }
+
+    [Fact]
+    public void when_created_then_remote_modified_is_preserved()
+    {
+        var snapshot = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+
+        snapshot.RemoteModified.ShouldBe(RemoteModified);
+    }
+
+    [Fact]
+    public void when_created_then_remote_size_is_preserved()
+    {
+        var snapshot = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+
+        snapshot.RemoteSize.ShouldBe(RemoteSize);
+    }
+
+    [Fact]
+    public void when_two_snapshots_have_same_values_then_they_are_equal()
+    {
+        var first = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+        var second = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_snapshots_differ_by_local_size_then_they_are_not_equal()
+    {
+        var first = ConflictSnapshotFactory.Create(LocalModified, LocalSize, RemoteModified, RemoteSize);
+        var second = ConflictSnapshotFactory.Create(LocalModified, LocalSize + 1, RemoteModified, RemoteSize);
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncConflict.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncConflict.cs
@@ -62,10 +62,7 @@ public sealed class GivenASyncConflict
             Id = id,
             Remote = remote,
             Target = SyncFileTargetFactory.Create(localPath, relativePath),
-            LocalModified = now.AddHours(-1),
-            RemoteModified = now,
-            LocalSize = 1024,
-            RemoteSize = 2048,
+            Snapshot = ConflictSnapshotFactory.Create(now.AddHours(-1), 1024, now, 2048),
             DetectedAt = now
         };
 
@@ -75,8 +72,8 @@ public sealed class GivenASyncConflict
         conflict.Remote.RemoteItemId.Id.ShouldBe("item-789");
         conflict.Target.RelativePath.ShouldBe(relativePath);
         conflict.Target.LocalPath.ShouldBe(localPath);
-        conflict.LocalSize.ShouldBe(1024);
-        conflict.RemoteSize.ShouldBe(2048);
+        conflict.Snapshot.LocalSize.ShouldBe(1024);
+        conflict.Snapshot.RemoteSize.ShouldBe(2048);
     }
 
     [Fact]
@@ -130,9 +127,9 @@ public sealed class GivenASyncConflict
     {
         long largeSize = 1_073_741_824L;
 
-        var conflict = new SyncConflict { LocalSize = largeSize };
+        var conflict = new SyncConflict { Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.MinValue, largeSize, DateTimeOffset.MinValue, 0L) };
 
-        conflict.LocalSize.ShouldBe(largeSize);
+        conflict.Snapshot.LocalSize.ShouldBe(largeSize);
     }
 
     [Fact]
@@ -142,14 +139,11 @@ public sealed class GivenASyncConflict
 
         var conflict = new SyncConflict
         {
-            LocalModified = now.AddHours(-2),
-            RemoteModified = now,
-            LocalSize = 1024,
-            RemoteSize = 2048
+            Snapshot = ConflictSnapshotFactory.Create(now.AddHours(-2), 1024, now, 2048)
         };
 
-        conflict.LocalModified.ShouldBeLessThan(conflict.RemoteModified);
-        conflict.LocalSize.ShouldNotBe(conflict.RemoteSize);
+        conflict.Snapshot.LocalModified.ShouldBeLessThan(conflict.Snapshot.RemoteModified);
+        conflict.Snapshot.LocalSize.ShouldNotBe(conflict.Snapshot.RemoteSize);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -138,11 +138,10 @@ public sealed class GivenASyncService
         var service = BuildSut();
         var conflict = new SyncConflict
         {
-            Id             = Guid.NewGuid(),
-            Remote         = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
-            LocalModified  = DateTimeOffset.UtcNow,
-            RemoteModified = DateTimeOffset.UtcNow.AddMinutes(-5),
-            State          = ConflictState.Pending
+            Id       = Guid.NewGuid(),
+            Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
+            Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow.AddMinutes(-5), 0L),
+            State    = ConflictState.Pending
         };
 
         await service.ResolveConflictAsync(conflict, ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -39,11 +39,10 @@ public sealed class GivenASyncServiceResolvingConflicts
 
     private static SyncConflict CreateConflict() => new()
     {
-        Id             = Guid.NewGuid(),
-        Remote         = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
-        LocalModified  = DateTimeOffset.UtcNow,
-        RemoteModified = DateTimeOffset.UtcNow.AddMinutes(-5),
-        State          = ConflictState.Pending
+        Id       = Guid.NewGuid(),
+        Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
+        Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow.AddMinutes(-5), 0L),
+        State    = ConflictState.Pending
     };
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
@@ -88,14 +88,11 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
     private static SyncConflict MapConflictEntityToViewModel(SyncConflictEntity entity)
         => new()
         {
-            Id             = entity.Id,
-            Remote         = RemoteItemRefFactory.Create(entity.AccountId, entity.FolderId, entity.RemoteItemId),
-            Target         = SyncFileTargetFactory.Create(entity.LocalPath, entity.RelativePath),
-            LocalModified  = entity.LocalModified,
-            RemoteModified = entity.RemoteModified,
-            LocalSize      = entity.LocalSize,
-            RemoteSize     = entity.RemoteSize,
-            DetectedAt     = entity.DetectedAt
+            Id         = entity.Id,
+            Remote     = RemoteItemRefFactory.Create(entity.AccountId, entity.FolderId, entity.RemoteItemId),
+            Target     = SyncFileTargetFactory.Create(entity.LocalPath, entity.RelativePath),
+            Snapshot   = ConflictSnapshotFactory.Create(entity.LocalModified, entity.LocalSize, entity.RemoteModified, entity.RemoteSize),
+            DetectedAt = entity.DetectedAt
         };
 
     /// <summary>Called when a sync job completes.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Conflicts/ConflictItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Conflicts/ConflictItemViewModel.cs
@@ -15,16 +15,16 @@ public sealed partial class ConflictItemViewModel(
     public string AccountId => conflict.Remote.AccountId.Id;
     public string FileName => Path.GetFileName(conflict.Target.RelativePath);
     public string RelativePath => conflict.Target.RelativePath;
-    public DateTimeOffset LocalModified => conflict.LocalModified;
-    public DateTimeOffset RemoteModified => conflict.RemoteModified;
-    public long LocalSize => conflict.LocalSize;
-    public long RemoteSize => conflict.RemoteSize;
+    public DateTimeOffset LocalModified => conflict.Snapshot.LocalModified;
+    public DateTimeOffset RemoteModified => conflict.Snapshot.RemoteModified;
+    public long LocalSize => conflict.Snapshot.LocalSize;
+    public long RemoteSize => conflict.Snapshot.RemoteSize;
     public DateTimeOffset DetectedAt => conflict.DetectedAt;
 
-    public string LocalModifiedText => FormatDateTime(conflict.LocalModified);
-    public string RemoteModifiedText => FormatDateTime(conflict.RemoteModified);
-    public string LocalSizeText => conflict.LocalSize.FileSizeToText();
-    public string RemoteSizeText => conflict.RemoteSize.FileSizeToText();
+    public string LocalModifiedText => FormatDateTime(conflict.Snapshot.LocalModified);
+    public string RemoteModifiedText => FormatDateTime(conflict.Snapshot.RemoteModified);
+    public string LocalSizeText => conflict.Snapshot.LocalSize.FileSizeToText();
+    public string RemoteSizeText => conflict.Snapshot.RemoteSize.FileSizeToText();
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsPanelOpen))]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
@@ -93,10 +93,10 @@ public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : 
             RemoteItemId   = conflict.Remote.RemoteItemId,
             RelativePath   = conflict.Target.RelativePath,
             LocalPath      = conflict.Target.LocalPath,
-            LocalModified  = conflict.LocalModified,
-            RemoteModified = conflict.RemoteModified,
-            LocalSize      = conflict.LocalSize,
-            RemoteSize     = conflict.RemoteSize,
+            LocalModified  = conflict.Snapshot.LocalModified,
+            RemoteModified = conflict.Snapshot.RemoteModified,
+            LocalSize      = conflict.Snapshot.LocalSize,
+            RemoteSize     = conflict.Snapshot.RemoteSize,
             State          = conflict.State,
             DetectedAt     = conflict.DetectedAt
         });

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ConflictSnapshot.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ConflictSnapshot.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Captures the local and remote file state at the moment a sync conflict was detected.</summary>
+public sealed record ConflictSnapshot(DateTimeOffset LocalModified, long LocalSize, DateTimeOffset RemoteModified, long RemoteSize);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ConflictSnapshotFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ConflictSnapshotFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="ConflictSnapshot"/>.</summary>
+public static class ConflictSnapshotFactory
+{
+    /// <summary>Creates a <see cref="ConflictSnapshot"/> from the local and remote file state.</summary>
+    public static ConflictSnapshot Create(DateTimeOffset localModified, long localSize, DateTimeOffset remoteModified, long remoteSize) => new(localModified, localSize, remoteModified, remoteSize);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncConflict.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncConflict.cs
@@ -11,11 +11,7 @@ public sealed class SyncConflict
     public Guid Id { get; init; } = Guid.NewGuid();
     public RemoteItemRef Remote { get; init; } = RemoteItemRefFactory.Create(new AccountId(string.Empty), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty));
     public SyncFileTarget Target { get; init; } = SyncFileTargetFactory.Create(string.Empty, string.Empty);
-
-    public DateTimeOffset LocalModified { get; init; }
-    public DateTimeOffset RemoteModified { get; init; }
-    public long LocalSize { get; init; }
-    public long RemoteSize { get; init; }
+    public ConflictSnapshot Snapshot { get; init; } = ConflictSnapshotFactory.Create(DateTimeOffset.MinValue, 0L, DateTimeOffset.MinValue, 0L);
 
     public ConflictState State { get; set; } = ConflictState.Pending;
     public ConflictPolicy? Resolution { get; set; }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -188,12 +188,9 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
     private SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
         => new()
         {
-            Remote         = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
-            Target         = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
-            LocalModified  = localModified,
-            RemoteModified = item.LastModified ?? DateTimeOffset.MinValue,
-            LocalSize      = fileSystem.FileInfo.New(localPath).Length,
-            RemoteSize     = item.Size
+            Remote   = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
+            Target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
+            Snapshot = ConflictSnapshotFactory.Create(localModified, fileSystem.FileInfo.New(localPath).Length, item.LastModified ?? DateTimeOffset.MinValue, item.Size)
         };
 
     private static string BuildLocalPath(string localBasePath, string relativePath)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -87,7 +87,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         if (authResult is not Result<AuthResult, AuthError>.Ok authOk)
             return;
 
-        var outcome = ConflictResolver.Resolve(policy, conflict.LocalModified, conflict.RemoteModified);
+        var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
 
         await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, authOk.Value.AccessToken, ct).ConfigureAwait(false);
         await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
@@ -101,11 +101,11 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 string downloadUrl = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false)
                     ?? throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.Target.RelativePath}' (itemId={conflict.Remote.RemoteItemId.Id}).");
 
-                await httpDownloader.DownloadAsync(downloadUrl, conflict.Target.LocalPath, conflict.RemoteModified, ct: ct).ConfigureAwait(false);
+                await httpDownloader.DownloadAsync(downloadUrl, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
                 break;
 
             case ConflictOutcome.KeepBoth:
-                string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.LocalModified, fileSystem);
+                string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
                 if (fileSystem.File.Exists(conflict.Target.LocalPath))
                     fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
                 break;


### PR DESCRIPTION
## Summary

- Extract `ConflictSnapshot` record (`LocalModified`, `LocalSize`, `RemoteModified`, `RemoteSize`) from `SyncConflict`
- Add `ConflictSnapshotFactory` with static `Create` method following repo record-design conventions
- Replace four flat properties on `SyncConflict` with `ConflictSnapshot Snapshot { get; init; }`
- Update all consumers (`ConflictItemViewModel`, `SyncService`, `RemoteFolderEnumerator`, `SyncRepository`, `ActivityViewModel`) to read from `conflict.Snapshot.*`
- Add `GivenAConflictSnapshot` test class (6 tests); update existing `GivenASyncConflict` tests

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test` — 809 passed, 1 pre-existing failure (`GivenAnIconRailButton`, unrelated Avalonia UI test)
- [x] `GivenAConflictSnapshot` — all 6 new tests pass
- [x] `GivenASyncConflict` — all existing tests updated and passing

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)