### PR TITLE
feat(apps/desktop): extract VersionInfo owned entity from SyncedItemEntity (#267)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -1,0 +1,50 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
+
+public sealed class GivenASyncedItemEntityFactory
+{
+    private static DeltaItem CreateDeltaItem(string? etag, string? ctag)
+        => DeltaItemFactory.Create(new OneDriveItemId("item-1"), "drive-1", null, ItemPathFactory.Create("file.txt", "/file.txt"), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, ctag));
+
+    [Fact]
+    public void when_creating_from_delta_item_then_tags_etag_is_populated()
+    {
+        var item = CreateDeltaItem("etag-abc", null);
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
+
+        entity.Tags.ETag.ShouldBe("etag-abc");
+    }
+
+    [Fact]
+    public void when_creating_from_delta_item_then_tags_ctag_is_populated()
+    {
+        var item = CreateDeltaItem(null, "ctag-xyz");
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
+
+        entity.Tags.CTag.ShouldBe("ctag-xyz");
+    }
+
+    [Fact]
+    public void when_creating_from_delta_item_with_null_etag_then_tags_etag_is_null()
+    {
+        var item = CreateDeltaItem(null, "ctag-xyz");
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
+
+        entity.Tags.ETag.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_creating_from_delta_item_with_null_ctag_then_tags_ctag_is_null()
+    {
+        var item = CreateDeltaItem("etag-abc", null);
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
+
+        entity.Tags.CTag.ShouldBeNull();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -162,11 +162,11 @@ public sealed class GivenARemoteFolderEnumerator
 
         var knownItem = new SyncedItemEntity
         {
-            AccountId      = new AccountId("user-1"),
-            RemoteItemId   = new OneDriveItemId("item-a"),
-            RemotePath     = "/Documents/a.txt",
-            LocalPath      = localFile,
-            ETag           = "etag-123",
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            Tags             = VersionInfoFactory.Create("etag-123", null),
             RemoteModifiedAt = DateTimeOffset.UtcNow.AddDays(-1)
         };
         _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemEntityConfiguration.cs
@@ -16,6 +16,11 @@ public class SyncedItemEntityConfiguration : IEntityTypeConfiguration<SyncedItem
                    .HasConversion(id => id.Id, str => new OneDriveItemId(str));
         _ = builder.HasIndex(e => new { e.AccountId, e.RemoteItemId }).IsUnique();
         _ = builder.HasIndex(e => new { e.AccountId, e.LocalPath });
+        _ = builder.OwnsOne(e => e.Tags, b =>
+        {
+            _ = b.Property(v => v.ETag).HasColumnName("ETag");
+            _ = b.Property(v => v.CTag).HasColumnName("CTag");
+        });
         _ = builder.HasOne(e => e.Account)
                    .WithMany()
                    .HasForeignKey(e => e.AccountId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntity.cs
@@ -13,8 +13,7 @@ public sealed class SyncedItemEntity
     public string LocalPath { get; set; } = string.Empty;
     public bool IsFolder { get; set; }
     public DateTimeOffset RemoteModifiedAt { get; set; }
-    public string? ETag { get; set; }
-    public string? CTag { get; set; }
+    public VersionInfo Tags { get; set; } = new(null, null);
 
     [ForeignKey(nameof(AccountId))]
     public AccountEntity? Account { get; set; }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -20,8 +20,7 @@ public static class SyncedItemEntityFactory
             LocalPath        = localPath,
             IsFolder         = item.IsFolder,
             RemoteModifiedAt = item.LastModified ?? DateTimeOffset.MinValue,
-            ETag             = item.VersionInfo.ETag,
-            CTag             = item.VersionInfo.CTag
+            Tags             = item.VersionInfo
         };
 
     /// <summary>Creates a tracking entity for a successfully completed download job.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260506162553_UseVersionInfoOwnedTypeForSyncedItemTags.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260506162553_UseVersionInfoOwnedTypeForSyncedItemTags.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506162553_UseVersionInfoOwnedTypeForSyncedItemTags")]
+    partial class UseVersionInfoOwnedTypeForSyncedItemTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260506162553_UseVersionInfoOwnedTypeForSyncedItemTags.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260506162553_UseVersionInfoOwnedTypeForSyncedItemTags.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UseVersionInfoOwnedTypeForSyncedItemTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -35,8 +35,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
             existing.LocalPath        = item.LocalPath;
             existing.IsFolder         = item.IsFolder;
             existing.RemoteModifiedAt = item.RemoteModifiedAt;
-            existing.ETag             = item.ETag;
-            existing.CTag             = item.CTag;
+            existing.Tags             = item.Tags;
         }
 
         _ = await db.SaveChangesAsync(cancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -98,7 +98,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
         syncedItems.TryGetValue(item.Id.Id, out var knownItem);
 
-        if(knownItem?.ETag is not null && knownItem.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
+        if(knownItem?.Tags.ETag is not null && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
         {
             Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.Path.RelativePath);
             return;


### PR DESCRIPTION
## Summary

- Replaces flat `ETag`/`CTag` nullable string columns on `SyncedItemEntity` with `VersionInfo Tags` EF Core owned entity
- `DeltaItem` already uses `VersionInfo`; entity now uses the same type, eliminating manual field mapping at every comparison site
- Migration is intentionally empty — `HasColumnName("ETag"/"CTag")` preserves existing column names so no data migration needed

## Changes

| File | Change |
|------|--------|
| `SyncedItemEntity.cs` | `ETag`/`CTag` → `VersionInfo Tags { get; set; }` |
| `SyncedItemEntityConfiguration.cs` | Added `OwnsOne(Tags)` mapping columns `ETag`/`CTag` |
| `SyncedItemEntityFactory.cs` | `ETag = ..., CTag = ...` → `Tags = item.VersionInfo` |
| `SyncedItemRepository.cs` | `existing.ETag/CTag` → `existing.Tags = item.Tags` |
| `RemoteFolderEnumerator.cs` | `knownItem?.ETag` → `knownItem?.Tags.ETag` |
| `GivenARemoteFolderEnumerator.cs` | Updated test to use `Tags = VersionInfoFactory.Create(...)` |
| Migration | Empty (schema unchanged — same column names) |
| `GivenASyncedItemEntityFactory.cs` | New tests covering `Tags.ETag`/`Tags.CTag` population |

## Test plan

- [x] RED commit: 4 new tests targeting `entity.Tags.ETag`/`entity.Tags.CTag` failed before production code
- [x] GREEN: All 814 tests pass after implementation
- [x] `dotnet build` — 0 errors, 0 new warnings

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)