### PR TITLE
feat(apps/desktop): replace TestableIO with Testably.Abstractions (#279)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -182,8 +182,8 @@
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.1" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
+    <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
+    <PackageVersion Include="Testably.Abstractions.Testing" Version="6.2.0" />
     <PackageVersion Include="Testcontainers" Version="3.11.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="WireMock.Net" Version="2.2.0" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
@@ -13,7 +13,8 @@
     <Using Include="Xunit" />
     <Using Include="Shouldly" />
     <Using Include="NSubstitute" />
-    <Using Include="System.IO.Abstractions.TestingHelpers" />
+    <Using Include="Testably.Abstractions.Testing" />
+    <Using Include="Testably.Abstractions.Testing.Initializer" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,7 +29,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly"/>
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
+    <PackageReference Include="Testably.Abstractions.Testing" />
     <PackageReference Include="WireMock.Net" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using Microsoft.Identity.Client;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;
 
@@ -10,7 +11,7 @@ public sealed class GivenATokenCacheService
     {
         _ = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         _ = service.ShouldNotBeNull();
         service.CacheDirectory.ShouldNotBeNullOrEmpty();
@@ -19,7 +20,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_constructed_then_cache_directory_property_is_not_null()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         _ = service.CacheDirectory.ShouldNotBeNull();
     }
@@ -27,7 +28,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_is_not_empty()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         service.CacheDirectory.Length.ShouldBeGreaterThan(0);
     }
@@ -35,7 +36,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_contains_app_name()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         service.CacheDirectory.ShouldContain("astar-dev-onedrive-sync");
     }
@@ -46,7 +47,7 @@ public sealed class GivenATokenCacheService
         var mockApp = Substitute.For<IPublicClientApplication>();
         var mockCache = Substitute.For<ITokenCache>();
         _ = mockApp.UserTokenCache.Returns(mockCache);
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
         try
         {
             await service.RegisterAsync(mockApp);
@@ -63,7 +64,7 @@ public sealed class GivenATokenCacheService
         var mockApp = Substitute.For<IPublicClientApplication>();
         var mockCache = Substitute.For<ITokenCache>();
         _ = mockApp.UserTokenCache.Returns(mockCache);
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         try
         {
@@ -80,8 +81,8 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_two_instances_are_created_then_they_share_the_same_cache_directory()
     {
-        var service1 = new TokenCacheService();
-        var service2 = new TokenCacheService();
+        var service1 = new TokenCacheService(new MockFileSystem());
+        var service2 = new TokenCacheService(new MockFileSystem());
 
         _ = service1.ShouldNotBeNull();
         _ = service2.ShouldNotBeNull();
@@ -94,7 +95,7 @@ public sealed class GivenATokenCacheService
     [InlineData("different/path")]
     public void when_cache_directory_is_read_then_it_is_platform_specific(string _)
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         string cacheDir = service.CacheDirectory;
         cacheDir.ShouldNotBeNullOrEmpty();
@@ -104,7 +105,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_twice_then_same_value_is_returned()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
         string cachedDir = service.CacheDirectory;
         service.CacheDirectory.ShouldBe(cachedDir);
     }
@@ -112,7 +113,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_is_an_absolute_path()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         bool isAbsolute = Path.IsPathRooted(service.CacheDirectory);
         isAbsolute.ShouldBeTrue();
@@ -121,7 +122,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_property_is_inspected_then_it_has_no_setter()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         _ = service.CacheDirectory;
         var property = typeof(TokenCacheService).GetProperty("CacheDirectory");
@@ -132,7 +133,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public async Task when_register_async_called_with_null_then_null_reference_exception_is_thrown()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
         try
         {
             await service.RegisterAsync(null!);
@@ -154,7 +155,7 @@ public sealed class GivenATokenCacheService
         {
             var task = Task.Run(() =>
             {
-                var service = new TokenCacheService();
+                var service = new TokenCacheService(new MockFileSystem());
                 lock (lockObj)
                 {
                     services.Add(service);
@@ -176,7 +177,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_path_is_rooted()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
 
         service.CacheDirectory.ShouldNotBeNullOrEmpty();
         Path.IsPathRooted(service.CacheDirectory).ShouldBeTrue();
@@ -185,7 +186,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_matches_platform_convention()
     {
-        var service = new TokenCacheService();
+        var service = new TokenCacheService(new MockFileSystem());
         string cacheDir = service.CacheDirectory;
         if (OperatingSystem.IsWindows())
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 
@@ -7,22 +8,22 @@ public sealed class GivenASettingsService
 {
     private const string SettingsPath = "/app/settings.json";
 
-    private static MockFileSystem CreateMockFs()
+    private static MockFileSystem CreateMockFileSystem()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory("/app");
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory("/app");
 
-        return mockFs;
+        return mockFileSystem;
     }
 
     [Fact]
     public void when_constructed_then_service_implements_isettings_service() =>
-        new SettingsService(CreateMockFs(), SettingsPath).ShouldBeAssignableTo<ISettingsService>();
+        new SettingsService(CreateMockFileSystem(), SettingsPath).ShouldBeAssignableTo<ISettingsService>();
 
     [Fact]
     public async Task when_load_async_is_called_then_service_still_implements_isettings_service()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         await service.LoadAsync();
 
@@ -32,7 +33,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_save_async_is_called_without_subscribers_then_no_exception_is_thrown()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         await Should.NotThrowAsync(() => service.SaveAsync());
     }
@@ -40,7 +41,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_save_async_is_called_multiple_times_then_settings_changed_is_raised_each_time()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
         var raiseCount = 0;
         service.SettingsChanged += (_, _) => raiseCount++;
 
@@ -53,7 +54,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_settings_changed_event_is_raised_then_sender_is_the_service_instance()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
         object? capturedSender = null;
         service.SettingsChanged += (sender, _) => capturedSender = sender;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 
@@ -9,27 +10,27 @@ public sealed class GivenASettingsServiceLoadAsync
     private const string SettingsPath = "/app/settings.json";
     private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-    private static MockFileSystem CreateMockFsWithSettings(AppSettings settings)
+    private static MockFileSystem CreateMockFileSystemWithSettings(AppSettings settings)
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory("/app");
-        mockFs.AddFile(SettingsPath, new MockFileData(JsonSerializer.Serialize(settings, JsonOpts)));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory("/app");
+        mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent(JsonSerializer.Serialize(settings, JsonOpts)));
 
-        return mockFs;
+        return mockFileSystem;
     }
 
-    private static MockFileSystem CreateEmptyMockFs()
+    private static MockFileSystem CreateEmptyMockileSystem()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory("/app");
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory("/app");
 
-        return mockFs;
+        return mockFileSystem;
     }
 
     [Fact]
     public async Task when_settings_file_does_not_exist_then_current_uses_defaults_after_load()
     {
-        var sut = new SettingsService(CreateEmptyMockFs(), SettingsPath);
+        var sut = new SettingsService(CreateEmptyMockileSystem(), SettingsPath);
 
         await sut.LoadAsync();
 
@@ -41,7 +42,7 @@ public sealed class GivenASettingsServiceLoadAsync
     public async Task when_valid_json_file_exists_then_current_is_populated_after_load()
     {
         var expected = new AppSettings { Theme = AppTheme.Dark, SyncIntervalMinutes = 15, Locale = "fr-FR" };
-        var sut = new SettingsService(CreateMockFsWithSettings(expected), SettingsPath);
+        var sut = new SettingsService(CreateMockFileSystemWithSettings(expected), SettingsPath);
 
         await sut.LoadAsync();
 
@@ -53,9 +54,9 @@ public sealed class GivenASettingsServiceLoadAsync
     [Fact]
     public async Task when_json_file_is_malformed_then_current_uses_defaults_after_load()
     {
-        var mockFs = CreateEmptyMockFs();
-        mockFs.AddFile(SettingsPath, new MockFileData("{ this is not valid json }}}"));
-        var sut = new SettingsService(mockFs, SettingsPath);
+        var mockFileSystem = CreateEmptyMockileSystem();
+        mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("{ this is not valid json }}}"));
+        var sut = new SettingsService(mockFileSystem, SettingsPath);
 
         await sut.LoadAsync();
 
@@ -66,9 +67,9 @@ public sealed class GivenASettingsServiceLoadAsync
     [Fact]
     public async Task when_json_file_is_malformed_then_no_exception_is_thrown()
     {
-        var mockFs = CreateEmptyMockFs();
-        mockFs.AddFile(SettingsPath, new MockFileData("not json at all"));
-        var sut = new SettingsService(mockFs, SettingsPath);
+        var mockFileSystem = CreateEmptyMockileSystem();
+        mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("not json at all"));
+        var sut = new SettingsService(mockFileSystem, SettingsPath);
 
         await Should.NotThrowAsync(() => sut.LoadAsync());
     }
@@ -76,9 +77,9 @@ public sealed class GivenASettingsServiceLoadAsync
     [Fact]
     public async Task when_json_file_deserializes_to_null_then_current_uses_defaults()
     {
-        var mockFs = CreateEmptyMockFs();
-        mockFs.AddFile(SettingsPath, new MockFileData("null"));
-        var sut = new SettingsService(mockFs, SettingsPath);
+        var mockFileSystem = CreateEmptyMockileSystem();
+        mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("null"));
+        var sut = new SettingsService(mockFileSystem, SettingsPath);
 
         await sut.LoadAsync();
 
@@ -88,12 +89,12 @@ public sealed class GivenASettingsServiceLoadAsync
     [Fact]
     public async Task when_load_async_is_called_multiple_times_then_current_reflects_latest_file_content()
     {
-        var mockFs = CreateMockFsWithSettings(new AppSettings { Theme = AppTheme.Light });
-        var sut = new SettingsService(mockFs, SettingsPath);
+        var mockFileSystem = CreateMockFileSystemWithSettings(new AppSettings { Theme = AppTheme.Light });
+        var sut = new SettingsService(mockFileSystem, SettingsPath);
         await sut.LoadAsync();
         sut.Current.Theme.ShouldBe(AppTheme.Light);
 
-        mockFs.File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new AppSettings { Theme = AppTheme.Dark }, JsonOpts));
+        mockFileSystem.File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new AppSettings { Theme = AppTheme.Dark }, JsonOpts));
         await sut.LoadAsync();
 
         sut.Current.Theme.ShouldBe(AppTheme.Dark);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 
@@ -9,18 +10,18 @@ public sealed class GivenASettingsServiceWithDefaults
 {
     private const string SettingsPath = "/app/settings.json";
 
-    private static MockFileSystem CreateMockFs()
+    private static MockFileSystem CreateMockFileSystem()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory("/app");
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory("/app");
 
-        return mockFs;
+        return mockFileSystem;
     }
 
     [Fact]
     public void when_constructed_then_settings_have_default_values()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         _ = service.Current.ShouldNotBeNull();
         service.Current.Theme.ShouldBe(AppTheme.System);
@@ -32,7 +33,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_current_is_read_then_it_is_app_settings()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         var settings = service.Current;
 
@@ -43,7 +44,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_theme_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.Theme = AppTheme.Dark;
 
@@ -53,7 +54,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_locale_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.Locale = "fr-FR";
 
@@ -63,7 +64,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_default_conflict_policy_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.DefaultConflictPolicy = ConflictPolicy.LastWriteWins;
 
@@ -73,7 +74,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_sync_interval_minutes_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.SyncIntervalMinutes = 30;
 
@@ -81,9 +82,9 @@ public sealed class GivenASettingsServiceWithDefaults
     }
 
     [Fact]
-    public async Task when_save_async_called_then_settings_changed_event_is_raised()
+    public async Task when_save_async_called_then_settingschanged_event_is_raised()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
         bool eventRaised = false;
         AppSettings? changedSettings = null;
         service.SettingsChanged += (s, settings) =>
@@ -103,7 +104,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_save_async_called_then_settings_are_persisted()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
         service.Current.Locale = "de-DE";
         service.Current.SyncIntervalMinutes = 45;
 
@@ -116,7 +117,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_load_async_called_then_no_exception_is_thrown()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         await Should.NotThrowAsync(() => service.LoadAsync());
     }
@@ -124,7 +125,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_load_async_called_then_current_settings_is_not_null()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         await service.LoadAsync();
 
@@ -137,7 +138,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(AppTheme.Dark)]
     public void when_any_theme_is_set_then_it_is_preserved(AppTheme theme)
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.Theme = theme;
 
@@ -151,7 +152,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData("es-ES")]
     public void when_any_locale_is_set_then_it_is_preserved(string locale)
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.Locale = locale;
 
@@ -165,7 +166,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(ConflictPolicy.LocalWins)]
     public void when_any_conflict_policy_is_set_then_it_is_preserved(ConflictPolicy policy)
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.DefaultConflictPolicy = policy;
 
@@ -179,7 +180,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(120)]
     public void when_any_sync_interval_is_set_then_it_is_preserved(int minutes)
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.SyncIntervalMinutes = minutes;
 
@@ -189,7 +190,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_multiple_settings_are_changed_then_all_are_maintained()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
 
         service.Current.Theme = AppTheme.Dark;
         service.Current.Locale = "fr-FR";
@@ -205,7 +206,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_save_async_called_after_multiple_changes_then_event_includes_all_changes()
     {
-        var service = new SettingsService(CreateMockFs(), SettingsPath);
+        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
         bool eventRaised = false;
         AppSettings? changedSettings = null;
         service.SettingsChanged += (s, settings) =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Testably.Abstractions.Testing;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -19,9 +20,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_no_rules_are_provided_then_returns_empty_list()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory(BasePath);
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory(BasePath);
+        var sut = CreateSut(mockFileSystem);
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, [], EmptyLookup());
 
@@ -31,10 +32,10 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_only_exclude_rules_are_provided_then_returns_empty_list()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory($"{BasePath}/Documents");
-        mockFs.AddFile($"{BasePath}/Documents/file.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory($"{BasePath}/Documents");
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/file.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Exclude) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -45,9 +46,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_include_rule_maps_to_non_existent_directory_then_returns_empty_list()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory(BasePath);
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory(BasePath);
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/NonExistentFolder", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -58,9 +59,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_include_rule_directory_exists_but_is_empty_then_returns_empty_list()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory($"{BasePath}/Documents");
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory($"{BasePath}/Documents");
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -71,9 +72,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_upload_job_is_created()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -84,9 +85,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_job_has_correct_account_id()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -98,9 +99,9 @@ public sealed class GivenALocalChangeDetector
     public void when_new_file_is_not_in_lookup_then_job_has_correct_local_path()
     {
         const string filePath = $"{BasePath}/Documents/report.txt";
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(filePath, new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -111,9 +112,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_job_has_correct_relative_path()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -124,9 +125,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_job_is_upload_sync_job()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -137,9 +138,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_job_relative_path_is_used_for_upload_target()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -150,9 +151,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_new_file_is_not_in_lookup_then_job_folder_id_is_empty()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -165,15 +166,15 @@ public sealed class GivenALocalChangeDetector
     {
         const string filePath = $"{BasePath}/Documents/unchanged.txt";
         var lastWrite = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
-        var fileData = new MockFileData("data") { LastWriteTime = lastWrite };
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(filePath, fileData);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTime(filePath, lastWrite);
         var remoteModified = new DateTimeOffset(lastWrite, TimeSpan.Zero);
         var lookup = new Dictionary<string, SyncedItemEntity>
         {
             [filePath] = new() { RemoteModifiedAt = remoteModified, RemoteItemId = new OneDriveItemId("remote-id-1") }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
@@ -186,15 +187,15 @@ public sealed class GivenALocalChangeDetector
     {
         const string filePath = $"{BasePath}/Documents/modified.txt";
         var lastWrite = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
-        var fileData = new MockFileData("data") { LastWriteTime = lastWrite };
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(filePath, fileData);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTime(filePath, lastWrite);
         var staleRemoteModified = new DateTimeOffset(lastWrite, TimeSpan.Zero).AddSeconds(-10);
         var lookup = new Dictionary<string, SyncedItemEntity>
         {
             [filePath] = new() { RemoteModifiedAt = staleRemoteModified, RemoteItemId = new OneDriveItemId("remote-id-2") }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
@@ -208,15 +209,15 @@ public sealed class GivenALocalChangeDetector
         const string knownRemoteItemId = "remote-id-known";
         const string filePath = $"{BasePath}/Documents/modified.txt";
         var lastWrite = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
-        var fileData = new MockFileData("data") { LastWriteTime = lastWrite };
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(filePath, fileData);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTime(filePath, lastWrite);
         var staleRemoteModified = new DateTimeOffset(lastWrite, TimeSpan.Zero).AddSeconds(-10);
         var lookup = new Dictionary<string, SyncedItemEntity>
         {
             [filePath] = new() { RemoteModifiedAt = staleRemoteModified, RemoteItemId = new OneDriveItemId(knownRemoteItemId) }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
@@ -227,9 +228,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_file_name_starts_with_dot_then_file_is_skipped()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/.hidden-dotfile", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/.hidden-dotfile").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -240,9 +241,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_file_has_tmp_extension_then_file_is_skipped()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/download.tmp", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/download.tmp").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -253,9 +254,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_file_has_temp_extension_then_file_is_skipped()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/download.temp", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/download.temp").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -266,9 +267,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_file_has_partial_extension_then_file_is_skipped()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/download.partial", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/download.partial").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -279,9 +280,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_subdirectory_name_starts_with_dot_then_files_inside_are_not_scanned()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/.hidden-sub/secret.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/.hidden-sub/secret.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -292,9 +293,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_subdirectory_matches_include_rule_then_files_inside_are_scanned()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/Reports/q1.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/Reports/q1.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -305,9 +306,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_subdirectory_matches_include_rule_then_job_relative_path_reflects_subdirectory()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/Reports/q1.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/Reports/q1.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -318,9 +319,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_subdirectory_is_not_matched_by_any_rule_then_files_inside_are_not_scanned()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/Private/confidential.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/Private/confidential.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[]
         {
             Rule("/Documents", RuleType.Include),
@@ -335,9 +336,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_file_remote_path_does_not_match_any_sync_rule_then_file_is_skipped()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Photos", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -348,9 +349,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_include_rule_has_multi_level_remote_path_then_local_path_starts_with_base_path()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/2024/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/2024/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents/2024", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
@@ -362,9 +363,9 @@ public sealed class GivenALocalChangeDetector
     [Fact]
     public void when_include_rule_has_multi_level_remote_path_then_local_path_contains_full_relative_structure()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile($"{BasePath}/Documents/2024/report.txt", new MockFileData("data"));
-        var sut = CreateSut(mockFs);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/2024/report.txt").Which(m => m.HasStringContent("data"));
+        var sut = CreateSut(mockFileSystem);
         var rules = new[] { Rule("/Documents/2024", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
@@ -2,6 +2,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -21,13 +22,13 @@ public sealed class GivenALocalDeletionDetector
     [Fact]
     public async Task when_local_file_still_exists_then_graph_delete_is_not_called()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFile).Which(m => m.HasStringContent("data"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = LocalFile, IsFolder = false }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
 
@@ -37,12 +38,12 @@ public sealed class GivenALocalDeletionDetector
     [Fact]
     public async Task when_local_file_is_missing_then_graph_delete_is_called()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = $"{BaseDir}/deleted.txt", IsFolder = false }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
 
@@ -52,12 +53,12 @@ public sealed class GivenALocalDeletionDetector
     [Fact]
     public async Task when_local_file_is_missing_then_synced_item_repository_delete_is_called()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = $"{BaseDir}/deleted.txt", IsFolder = false }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
 
@@ -67,12 +68,12 @@ public sealed class GivenALocalDeletionDetector
     [Fact]
     public async Task when_synced_item_is_a_folder_then_it_is_skipped()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["folder-1"] = new() { RemoteItemId = new OneDriveItemId("folder-1"), RemotePath = "/SubDir", LocalPath = $"{BaseDir}/SubDir", IsFolder = true }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
 
@@ -82,7 +83,7 @@ public sealed class GivenALocalDeletionDetector
     [Fact]
     public async Task when_graph_delete_throws_then_exception_is_caught_and_remaining_items_are_processed()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>())
             .Returns(Task.FromException(new HttpRequestException("network error")));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
@@ -90,7 +91,7 @@ public sealed class GivenALocalDeletionDetector
             ["item-fail"] = new() { RemoteItemId = new OneDriveItemId("item-fail"), RemotePath = "/fail.txt", LocalPath = $"{BaseDir}/fail.txt", IsFolder = false },
             ["item-ok"]   = new() { RemoteItemId = new OneDriveItemId("item-ok"),   RemotePath = "/ok.txt",   LocalPath = $"{BaseDir}/ok.txt",   IsFolder = false }
         };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -22,47 +23,47 @@ public sealed class GivenARemoteDeletionDetector
     [Fact]
     public async Task when_remote_id_is_in_seen_set_then_local_file_is_not_deleted()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFile).Which(m => m.HasStringContent("data"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = LocalFile, IsFolder = false }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "item-1" };
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
 
-        mockFs.File.Exists(LocalFile).ShouldBeTrue();
+        mockFileSystem.File.Exists(LocalFile).ShouldBeTrue();
     }
 
     [Fact]
     public async Task when_remote_id_absent_and_local_file_exists_then_file_is_deleted()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFile).Which(m => m.HasStringContent("data"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = LocalFile, IsFolder = false }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
 
-        mockFs.File.Exists(LocalFile).ShouldBeFalse();
+        mockFileSystem.File.Exists(LocalFile).ShouldBeFalse();
     }
 
     [Fact]
     public async Task when_remote_id_absent_and_local_file_does_not_exist_then_no_exception_is_thrown()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/gone.txt", LocalPath = $"{BaseDir}/gone.txt", IsFolder = false }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         var act = async () => await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/gone.txt"), TestContext.Current.CancellationToken);
 
@@ -74,31 +75,31 @@ public sealed class GivenARemoteDeletionDetector
     {
         const string localDir = $"{BaseDir}/subfolder";
         const string childFile = $"{localDir}/child.txt";
-        var mockFs = new MockFileSystem();
-        mockFs.AddDirectory(localDir);
-        mockFs.AddFile(childFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Directory.CreateDirectory(localDir);
+        mockFileSystem.Initialize().WithFile(childFile).Which(m => m.HasStringContent("data"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["folder-1"] = new() { RemoteItemId = new OneDriveItemId("folder-1"), RemotePath = "/subfolder", LocalPath = localDir, IsFolder = true }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/subfolder"), TestContext.Current.CancellationToken);
 
-        mockFs.Directory.Exists(localDir).ShouldBeFalse();
+        mockFileSystem.Directory.Exists(localDir).ShouldBeFalse();
     }
 
     [Fact]
     public async Task when_remote_id_absent_then_synced_item_repository_delete_is_called()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = $"{BaseDir}/file.txt", IsFolder = false }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/file.txt"), TestContext.Current.CancellationToken);
 
@@ -108,18 +109,18 @@ public sealed class GivenARemoteDeletionDetector
     [Fact]
     public async Task when_remote_path_does_not_match_include_rules_then_item_is_not_treated_as_deleted()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFile).Which(m => m.HasStringContent("data"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/Other/other.txt", LocalPath = LocalFile, IsFolder = false }
         };
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/Documents"), TestContext.Current.CancellationToken);
 
-        mockFs.File.Exists(LocalFile).ShouldBeTrue();
+        mockFileSystem  .File.Exists(LocalFile).ShouldBeTrue();
         await _syncedItemRepository.DidNotReceive().DeleteByRemoteIdAsync(Arg.Any<AccountId>(), Arg.Any<OneDriveItemId>(), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -159,8 +160,8 @@ public sealed class GivenARemoteFolderEnumerator
     public async Task when_etag_matches_and_local_file_exists_then_no_download_job_is_created()
     {
         const string localFile = $"{BasePath}/Documents/a.txt";
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(localFile, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("data"));
 
         var knownItem = new SyncedItemEntity
         {
@@ -177,7 +178,7 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
@@ -189,9 +190,9 @@ public sealed class GivenARemoteFolderEnumerator
     {
         const string localFile = $"{BasePath}/Documents/a.txt";
         var localWriteTime = DateTime.UtcNow;
-        var fileData = new MockFileData("modified locally") { LastWriteTime = localWriteTime };
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(localFile, fileData);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
+        mockFileSystem.File.SetLastWriteTime(localFile, localWriteTime);
 
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var knownItem = new SyncedItemEntity
@@ -210,7 +211,7 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([DeltaItemFactory.Create(new OneDriveItemId("item-a"), "drive-1", null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]);
 
         var conflictsDetected = new List<SyncConflict>();
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.EnumerateAsync(CreateAccount(), "token", conflict =>
         {
@@ -240,14 +241,14 @@ public sealed class GivenARemoteFolderEnumerator
     public async Task when_file_exists_locally_without_synced_item_then_phantom_item_is_upserted()
     {
         const string localFile = $"{BasePath}/Documents/phantom.txt";
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(localFile, new MockFileData("phantom"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("phantom"));
 
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]);
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -83,8 +84,8 @@ public sealed class GivenASyncJobExecutor
     [Fact]
     public async Task when_pipeline_completes_upload_job_with_remote_id_then_synced_item_is_upserted_with_uploaded_id()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(UploadFilePath, new MockFileData("data"));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(UploadFilePath).Which(m => m.HasStringContent("data"));
 
         var job = (UploadSyncJob)MakeJob("item-1", SyncDirection.Upload, UploadFilePath);
         var jobs = new List<SyncJob> { job };
@@ -96,7 +97,7 @@ public sealed class GivenASyncJobExecutor
                 onJobCompleted(new JobCompletedEventArgs(((UploadSyncJob)job.Complete()) with { UploadedRemoteItemId = "uploaded-remote-id" }));
             });
 
-        var sut = CreateSut(mockFs);
+        var sut = CreateSut(mockFileSystem);
 
         await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
@@ -9,6 +9,7 @@ using WireMock.Types;
 using WireMockBodyType = WireMock.Types.BodyType;
 using WireMockRequest = WireMock.RequestBuilders.Request;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -56,12 +57,12 @@ public sealed class GivenAnUploadService
     [Fact]
     public async Task when_upload_async_is_called_with_pre_cancelled_token_then_operation_is_cancelled()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFilePath, new MockFileData(new byte[64]));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), mockFs);
+        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), mockFileSystem);
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
             sut.UploadAsync(BuildAnonymousGraphClient(), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: cts.Token));
@@ -70,8 +71,8 @@ public sealed class GivenAnUploadService
     [Fact]
     public async Task when_chunk_returns_201_created_with_item_id_then_item_id_is_returned()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFilePath, new MockFileData(new byte[64]));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
         using var server = WireMockServer.Start();
 
         server.Given(WireMockRequest.Create().UsingPost())
@@ -80,7 +81,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithCallback(_ => Created201Response()));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFs);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
         string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -90,8 +91,8 @@ public sealed class GivenAnUploadService
     [Fact]
     public async Task when_chunk_returns_200_ok_with_item_id_then_item_id_is_returned()
     {
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFilePath, new MockFileData(new byte[64]));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
         using var server = WireMockServer.Start();
 
         server.Given(WireMockRequest.Create().UsingPost())
@@ -100,7 +101,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithCallback(_ => Ok200Response()));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFs);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
         string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -112,8 +113,8 @@ public sealed class GivenAnUploadService
     {
         int chunkSizeBytes = 10 * 1024 * 1024;
         byte[] fileBytes = new byte[chunkSizeBytes + 64];
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFilePath, new MockFileData(fileBytes));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(fileBytes));
         using var server = WireMockServer.Start();
 
         server.Given(WireMockRequest.Create().UsingPost())
@@ -128,7 +129,7 @@ public sealed class GivenAnUploadService
                       return callIndex == 0 ? Accepted202Response() : Created201Response();
                   }));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFs);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
         string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -140,8 +141,8 @@ public sealed class GivenAnUploadService
     public async Task when_upload_reports_progress_then_progress_is_reported_with_byte_count()
     {
         const int FileSize = 64;
-        var mockFs = new MockFileSystem();
-        mockFs.AddFile(LocalFilePath, new MockFileData(new byte[FileSize]));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[FileSize]));
         using var server = WireMockServer.Start();
 
         server.Given(WireMockRequest.Create().UsingPost())
@@ -152,7 +153,7 @@ public sealed class GivenAnUploadService
 
         var reportedValues = new List<long>();
         var progress = new Progress<long>(reportedValues.Add);
-        var sut = new UploadService(CreateChunkClientFactory(), mockFs);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
         await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, progress, TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/TestHelpers/TemporaryDirectory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/TestHelpers/TemporaryDirectory.cs
@@ -1,13 +1,18 @@
+using AStar.Dev.Utilities;
+using Testably.Abstractions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.TestHelpers;
 
 internal sealed class TemporaryDirectory : IDisposable
 {
-    public string Path { get; } = Directory.CreateTempSubdirectory("settings-test-").FullName;
-    public string SettingsFilePath => System.IO.Path.Combine(Path, "settings.json");
+    private static readonly RealFileSystem FileSystem = new();
+
+    public string Path { get; } = FileSystem.Directory.CreateTempSubdirectory("settings-test-").FullName;
+    public string SettingsFilePath => Path.CombinePath("settings.json");
 
     public void Dispose()
     {
-        if (Directory.Exists(Path))
-            Directory.Delete(Path, recursive: true);
+        if (FileSystem.Directory.Exists(Path))
+            FileSystem.Directory.Delete(Path, recursive: true);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Graph" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
 
-    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
+    <PackageReference Include="Testably.Abstractions" />
 
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
+using Testably.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 
 namespace AStar.Dev.OneDrive.Sync.Client;
@@ -57,7 +58,8 @@ public class App : Application, IDisposable
     private static ServiceProvider BuildServiceProvider()
     {
         var inMemoryLogSink = new InMemoryLogSink();
-        ConfigureSerilog(inMemoryLogSink);
+        var fileSystem = new RealFileSystem();
+        ConfigureSerilog(inMemoryLogSink, fileSystem);
 
         var services = new ServiceCollection();
 
@@ -79,11 +81,11 @@ public class App : Application, IDisposable
         return services.BuildServiceProvider();
     }
 
-    private static void ConfigureSerilog(InMemoryLogSink inMemoryLogSink)
+    private static void ConfigureSerilog(InMemoryLogSink inMemoryLogSink, RealFileSystem fileSystem)
     {
         string logDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData).CombinePath(ApplicationMetadata.ApplicationName, "logs");
 
-        _ = Directory.CreateDirectory(logDirectory);
+        _ = fileSystem.Directory.CreateDirectory(logDirectory);
 
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
@@ -21,8 +21,6 @@ public sealed class TokenCacheService(IFileSystem fileSystem) : ITokenCacheServi
 {
     private const int KeyringTimeoutSeconds = 5;
 
-    public TokenCacheService() : this(new FileSystem()) { }
-
     public string CacheDirectory { get; } = InitialiseCacheDirectory(fileSystem);
 
     /// <summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.LogViewer;
 using Microsoft.Extensions.DependencyInjection;
+using Testably.Abstractions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Startup;
 
@@ -23,7 +24,7 @@ internal static class ShellServiceExtensions
 
         _ = services.AddSingleton(inMemoryLogSink);
         _ = services.AddSingleton<ILogEntryProvider>(inMemoryLogSink);
-        _ = services.AddSingleton<IFileSystem, FileSystem>();
+        _ = services.AddSingleton<IFileSystem, RealFileSystem>();
         _ = services.AddSingleton<ITokenCacheService, TokenCacheService>();
         _ = services.AddSingleton<IAuthService, AuthService>();
         _ = services.AddSingleton<IGraphClientFactory, GraphClientFactory>();


### PR DESCRIPTION
## Summary

- Replaces `TestableIO.System.IO.Abstractions.Wrappers` v22.1.1 with `Testably.Abstractions` v10.2.0 in production
- Replaces `TestableIO.System.IO.Abstractions.TestingHelpers` v22.0.16 with `Testably.Abstractions.Testing` v6.2.0 in tests
- Removes the `TokenCacheService` default constructor that instantiated `new RealFileSystem()` internally — file system is now always injected
- All `MockFileSystem` test usages migrated from old `AddFile`/`MockFileData` API to the new `Initialize().WithFile().Which(m => m.HasStringContent(...))` API

## Test plan

- [x] `dotnet build` — zero errors (2 pre-existing Avalonia deprecation warnings, unrelated)
- [x] `dotnet test` — 814/814 pass

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)