### PR TITLE
fix(apps/desktop): replace obsolete Avalonia UI properties (#274)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
@@ -192,7 +192,7 @@
                                             <TextBox Grid.Column="0"
                                                      Text="{Binding LocalSyncPath}"
                                                      FontSize="{StaticResource FontSizeSm}"
-                                                     Watermark="e.g. /home/user/OneDrive/personal"
+                                                     PlaceholderText="e.g. /home/user/OneDrive/personal"
                                                      CornerRadius="{StaticResource RadiusMd}"/>
                                             <Button Grid.Column="2"
                                                     Content="Browse ..."

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml
@@ -6,7 +6,7 @@
         Width="400" Height="260"
         CanResize="False"
         ShowInTaskbar="False"
-        SystemDecorations="None"
+        WindowDecorations="None"
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource BackgroundPrimaryBrush}">
 


### PR DESCRIPTION
## Summary

- Replace `TextBox.Watermark` with `PlaceholderText` in `SettingsView.axaml`
- Replace `Window.SystemDecorations` with `WindowDecorations` in `SplashWindow.axaml`

Closes #274

## Test plan

- [x] Build passes with zero errors and zero warnings
- [x] Splash window renders without decoration (borderless)
- [x] TextBox placeholder text displays correctly in Settings view

🤖 Generated with [Claude Code](https://claude.com/claude-code)