### PR TITLE
feat(apps/desktop): introduce DriveId strong value type (#277)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
@@ -15,7 +16,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
     private const string AccountIdString  = "account-1";
     private const string LocalSyncPathString = "/configured/sync/path";
     private const string AccessToken      = "token-abc";
-    private const string DriveId          = "drive-1";
+    private const string DriveIdValue      = "drive-1";
     private const string FolderId         = "folder-1";
     private const string FolderName       = "Photos";
     private const string ChildFolderId    = "folder-1-child";
@@ -194,7 +195,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
         graphService.GetDriveIdAsync(AccessToken, Arg.Any<CancellationToken>())
-            .Returns(DriveId);
+            .Returns(new DriveId(DriveIdValue));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(FolderId, FolderName)]);
@@ -206,7 +207,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
     {
         var (authService, graphService, repository) = BuildMocks();
 
-        graphService.GetChildFoldersAsync(AccessToken, DriveId, FolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdValue), FolderId, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(ChildFolderId, ChildFolderName, FolderId)]);
 
         return (authService, graphService, repository);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
@@ -110,7 +111,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var graphService = Substitute.For<IGraphService>();
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
-        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns("drive-1");
+        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new DriveId("drive-1"));
         graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -8,7 +9,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
 public sealed class GivenASyncedItemEntityFactory
 {
     private static DeltaItem CreateDeltaItem(string? etag, string? ctag)
-        => DeltaItemFactory.Create(new OneDriveItemId("item-1"), "drive-1", null, ItemPathFactory.Create("file.txt", "/file.txt"), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, ctag));
+        => DeltaItemFactory.Create(new OneDriveItemId("item-1"), new DriveId("drive-1"), null, ItemPathFactory.Create("file.txt", "/file.txt"), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, ctag));
 
     [Fact]
     public void when_creating_from_delta_item_then_tags_etag_is_populated()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
@@ -10,7 +11,7 @@ public sealed class GivenADeltaItem
     public void when_created_with_all_properties_then_they_are_preserved()
     {
         string id = "file-123";
-        string driveId = "drive-456";
+        var driveId = new DriveId("drive-456");
         string name = "document.docx";
         string parentId = "folder-789";
         bool isFolder = false;
@@ -49,7 +50,7 @@ public sealed class GivenADeltaItem
     {
         var item = DeltaItemFactory.Create(
             new OneDriveItemId("file-123"),
-            "drive-456",
+            new DriveId("drive-456"),
             new OneDriveFolderId("folder-789"),
             ItemPathFactory.Create("document.docx"),
             false,
@@ -65,7 +66,7 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_created_as_deleted_then_is_deleted_is_true()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", null, ItemPathFactory.Create("name"), false, true, 0, null, null, VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("name"), false, true, 0, null, null, VersionInfoFactory.Create(null, null));
 
         item.IsDeleted.ShouldBeTrue();
     }
@@ -73,7 +74,7 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_created_as_folder_then_is_folder_is_true()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("Documents"), true, false, 0, null, null, VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("Documents"), true, false, 0, null, null, VersionInfoFactory.Create(null, null));
 
         item.IsFolder.ShouldBeTrue();
     }
@@ -81,7 +82,7 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_created_as_file_then_is_folder_is_false()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("file.txt"), false, false, 1024, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("file.txt"), false, false, 1024, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.IsFolder.ShouldBeFalse();
     }
@@ -89,7 +90,7 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_size_is_zero_then_it_is_preserved()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("empty.txt"), false, false, 0, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("empty.txt"), false, false, 0, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.Size.ShouldBe(0);
     }
@@ -99,7 +100,7 @@ public sealed class GivenADeltaItem
     {
         long largeSize = 1_099_511_627_776L;
 
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("large.iso"), false, false, largeSize, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("large.iso"), false, false, largeSize, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.Size.ShouldBe(largeSize);
     }
@@ -107,7 +108,7 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_last_modified_is_null_then_it_is_null()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 0, null, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 0, null, "url", VersionInfoFactory.Create(null, null));
 
         item.LastModified.ShouldBeNull();
     }
@@ -115,8 +116,8 @@ public sealed class GivenADeltaItem
     [Fact]
     public void when_two_instances_have_same_values_then_they_are_equal()
     {
-        var item1 = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
-        var item2 = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, item1.LastModified, "url", VersionInfoFactory.Create(null, null));
+        var item1 = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item2 = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, item1.LastModified, "url", VersionInfoFactory.Create(null, null));
 
         item1.ShouldBe(item2);
     }
@@ -125,8 +126,8 @@ public sealed class GivenADeltaItem
     public void when_deleted_flag_differs_then_instances_are_not_equal()
     {
         var timestamp = DateTimeOffset.UtcNow;
-        var active = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
-        var deleted = DeltaItemFactory.Create(new OneDriveItemId("id"), "drive", new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, true, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
+        var active = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
+        var deleted = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, true, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
 
         active.ShouldNotBe(deleted);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenADriveId.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenADriveId.cs
@@ -1,0 +1,32 @@
+using AStar.Dev.OneDrive.Sync.Client.Home;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
+
+public sealed class GivenADriveId
+{
+    [Fact]
+    public void when_constructed_with_value_then_value_is_stored()
+    {
+        var sut = new DriveId("drive-abc");
+
+        sut.Value.ShouldBe("drive-abc");
+    }
+
+    [Fact]
+    public void when_two_instances_have_same_value_then_they_are_equal()
+    {
+        var first  = new DriveId("drive-abc");
+        var second = new DriveId("drive-abc");
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void when_two_instances_have_different_values_then_they_are_not_equal()
+    {
+        var first  = new DriveId("drive-abc");
+        var second = new DriveId("drive-xyz");
+
+        first.ShouldNotBe(second);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenADriveIdFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenADriveIdFactory.cs
@@ -1,0 +1,45 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
+
+public sealed class GivenADriveIdFactory
+{
+    [Fact]
+    public void when_create_is_called_with_a_value_then_some_is_returned()
+    {
+        var result = DriveIdFactory.Create("drive-abc");
+
+        result.ShouldBeOfType<Option<DriveId>.Some>();
+    }
+
+    [Fact]
+    public void when_create_is_called_with_a_value_then_value_is_wrapped()
+    {
+        var result = DriveIdFactory.Create("drive-abc");
+
+        result.Match(id => id.Value, () => string.Empty).ShouldBe("drive-abc");
+    }
+
+    [Fact]
+    public void when_create_is_called_with_null_then_none_is_returned()
+    {
+        var result = DriveIdFactory.Create(null!);
+
+        result.ShouldBeOfType<Option<DriveId>.None>();
+    }
+
+    [Fact]
+    public void when_create_is_called_with_empty_string_then_none_is_returned()
+    {
+        var result = DriveIdFactory.Create(string.Empty);
+
+        result.ShouldBeOfType<Option<DriveId>.None>();
+    }
+
+    [Fact]
+    public void when_empty_is_accessed_then_none_is_returned()
+    {
+        DriveIdFactory.Empty.ShouldBeOfType<Option<DriveId>.None>();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
@@ -7,7 +7,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
 public sealed class GivenAFolderTreeNodeViewModel
 {
     private const string AccessToken    = "token-abc";
-    private const string DriveId        = "drive-1";
+    private const string DriveIdString   = "drive-1";
     private const string RootFolderId   = "folder-root";
     private const string RootFolderName = "Documents";
     private const string ChildFolderId  = "folder-child";
@@ -111,7 +111,7 @@ public sealed class GivenAFolderTreeNodeViewModel
     {
         var graphService = Substitute.For<IGraphService>();
 
-        graphService.GetChildFoldersAsync(AccessToken, DriveId, RootFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]);
 
         return graphService;
@@ -121,10 +121,10 @@ public sealed class GivenAFolderTreeNodeViewModel
     {
         var graphService = Substitute.For<IGraphService>();
 
-        graphService.GetChildFoldersAsync(AccessToken, DriveId, RootFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]);
 
-        graphService.GetChildFoldersAsync(AccessToken, DriveId, ChildFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), ChildFolderId, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(GrandChildId, GrandChildName, ChildFolderId)]);
 
         return graphService;
@@ -147,6 +147,6 @@ public sealed class GivenAFolderTreeNodeViewModel
             SyncState:   syncState,
             HasChildren: true);
 
-        return new FolderTreeNodeViewModel(node, graphService, AccessToken, DriveId);
+        return new FolderTreeNodeViewModel(node, graphService, AccessToken, new DriveId(DriveIdString));
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using WireMock.RequestBuilders;
@@ -65,7 +66,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetChildFoldersAsync(AnyAccessToken, AnyDriveId, AnyFolderId, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetChildFoldersAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, cts.Token));
     }
 
     [Fact]
@@ -85,7 +86,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, AnyRemotePath, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, cts.Token));
     }
 
     [Fact]
@@ -95,7 +96,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetFolderIdByPathAsync(AnyAccessToken, AnyDriveId, AnyRemotePath, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetFolderIdByPathAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyRemotePath, cts.Token));
     }
 
     [Fact]
@@ -162,7 +163,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { error = new { code = "itemNotFound", message = "The resource could not be found." } }));
 
-        var result = await CreateSut().GetFolderIdByPathAsync(AnyAccessToken, AnyDriveId, AnyRemotePath, TestContext.Current.CancellationToken);
+        var result = await CreateSut().GetFolderIdByPathAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyRemotePath, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -225,7 +226,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(3);
         result.ShouldContain(i => i.Id.Id == "file-root");
@@ -259,7 +260,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, AnyDriveId, AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(2);
         result.ShouldContain(i => i.Id.Id == "subfolder-A");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
@@ -23,7 +24,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<string, SyncedItemEntity>());
         _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns("drive-1");
+            .Returns(new DriveId("drive-1"));
     }
 
     private RemoteFolderEnumerator CreateSut(MockFileSystem mockFs) => new(_graphService, _syncRuleRepository, _syncedItemRepository, mockFs);
@@ -40,10 +41,10 @@ public sealed class GivenARemoteFolderEnumerator
         => new() { RemotePath = remotePath, RuleType = RuleType.Include, RemoteItemId = remoteItemId };
 
     private static DeltaItem FileItem(string id, string name, string? relativePath = null, string? etag = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), "drive-1", null, ItemPathFactory.Create(name, relativePath ?? name), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
 
     private static DeltaItem FolderItem(string id, string name, string? relativePath = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), "drive-1", null, ItemPathFactory.Create(name, relativePath ?? name), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
 
     [Fact]
     public async Task when_no_rules_configured_then_result_has_no_rules_flag_set()
@@ -86,13 +87,13 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents")]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
         var sut = CreateSut(new MockFileSystem());
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -100,9 +101,9 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: null)]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -116,7 +117,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -130,7 +131,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -145,7 +146,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt")]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -176,7 +177,7 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]);
         var sut = CreateSut(mockFileSystem);
 
@@ -207,8 +208,8 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([DeltaItemFactory.Create(new OneDriveItemId("item-a"), "drive-1", null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]);
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([DeltaItemFactory.Create(new OneDriveItemId("item-a"), new DriveId("drive-1"), null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]);
 
         var conflictsDetected = new List<SyncConflict>();
         var sut = CreateSut(mockFileSystem);
@@ -228,7 +229,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FolderItem("subfolder-1", "Sub", "/Documents/Sub")]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -246,7 +247,7 @@ public sealed class GivenARemoteFolderEnumerator
 
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]);
         var sut = CreateSut(mockFileSystem);
 
@@ -260,7 +261,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -275,7 +276,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
         var sut = CreateSut(new MockFileSystem());
 
@@ -290,7 +291,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
         var sut = CreateSut(new MockFileSystem());
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
@@ -8,6 +8,7 @@ using WireMock.Util;
 using WireMock.Types;
 using WireMockBodyType = WireMock.Types.BodyType;
 using WireMockRequest = WireMock.RequestBuilders.Request;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Testably.Abstractions.Testing;
 
@@ -15,7 +16,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenAnUploadService
 {
-    private const string DriveId        = "drive-001";
+    private const string DriveIdValue   = "drive-001";
     private const string ParentFolderId = "folder-001";
     private const string RemotePath     = "test-file.bin";
     private const string ExpectedItemId = "item-abc-123";
@@ -51,7 +52,7 @@ public sealed class GivenAnUploadService
         var sut = new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem());
 
         await Should.ThrowAsync<FileNotFoundException>(() =>
-            sut.UploadAsync(BuildAnonymousGraphClient(), DriveId, ParentFolderId, "/nonexistent/path/file.bin", RemotePath));
+            sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, "/nonexistent/path/file.bin", RemotePath));
     }
 
     [Fact]
@@ -65,7 +66,7 @@ public sealed class GivenAnUploadService
         var sut = new UploadService(Substitute.For<IHttpClientFactory>(), mockFileSystem);
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
-            sut.UploadAsync(BuildAnonymousGraphClient(), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: cts.Token));
+            sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: cts.Token));
     }
 
     [Fact]
@@ -83,7 +84,7 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
         itemId.ShouldBe(ExpectedItemId);
     }
@@ -103,7 +104,7 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
         itemId.ShouldBe(ExpectedItemId);
     }
@@ -131,7 +132,7 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
         itemId.ShouldBe(ExpectedItemId);
         putCallCount.ShouldBe(2);
@@ -155,7 +156,7 @@ public sealed class GivenAnUploadService
         var progress = new Progress<long>(reportedValues.Add);
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        await sut.UploadAsync(BuildGraphClient(server), DriveId, ParentFolderId, LocalFilePath, RemotePath, progress, TestContext.Current.CancellationToken);
+        await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, progress, TestContext.Current.CancellationToken);
 
         await Task.Delay(50, TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -22,7 +22,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     private readonly IAccountRepository _repository = repository;
     private readonly ISyncRuleRepository _syncRuleRepository = syncRuleRepository;
     private string? _accessToken;
-    private string? _driveId;
+    private Option<DriveId> _driveId = DriveIdFactory.Empty;
 
     /// <summary>The unique identifier for the account.</summary>
     public string AccountId => _account.Id.Id;
@@ -79,7 +79,8 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
             }
 
             _accessToken = ok.Value.AccessToken;
-            _driveId = await _graphService.GetDriveIdAsync(_accessToken);
+            var driveId = await _graphService.GetDriveIdAsync(_accessToken);
+            _driveId = new Option<DriveId>.Some(driveId);
 
             var includedPaths = await LoadRulesAsync();
             await BuildRootFoldersAsync(includedPaths);
@@ -118,7 +119,9 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
             var node = new FolderTreeNode(Id: f.Id, Name: f.Name, ParentId: f.ParentId, AccountId: _account.Id.Id, RemotePath: remotePath, SyncState: syncState, HasChildren: true);
 
-            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, _driveId!);
+            var vm = _driveId.Match(
+                id => new FolderTreeNodeViewModel(node, _graphService, _accessToken!, id),
+                () => throw new InvalidOperationException("Drive ID not available."));
 
             vm.IncludeToggled += OnIncludeToggledAsync;
             vm.ViewActivityRequested += OnViewActivityRequested;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItem.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItem.cs
@@ -1,7 +1,8 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
 /// <summary>Represents a single item returned by the Microsoft Graph delta API.</summary>
-public sealed record DeltaItem(OneDriveItemId Id, string DriveId, OneDriveFolderId? ParentId, ItemPath Path, bool IsFolder, bool IsDeleted, long Size, DateTimeOffset? LastModified, string? DownloadUrl, VersionInfo VersionInfo);
+public sealed record DeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path, bool IsFolder, bool IsDeleted, long Size, DateTimeOffset? LastModified, string? DownloadUrl, VersionInfo VersionInfo);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItemFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItemFactory.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -7,5 +8,5 @@ namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 public static class DeltaItemFactory
 {
     /// <summary>Creates a <see cref="DeltaItem"/> representing a remote drive item.</summary>
-    public static DeltaItem Create(OneDriveItemId id, string driveId, OneDriveFolderId? parentId, ItemPath path, bool isFolder, bool isDeleted, long size, DateTimeOffset? lastModified, string? downloadUrl, VersionInfo versionInfo) => new(id, driveId, parentId, path, isFolder, isDeleted, size, lastModified, downloadUrl, versionInfo);
+    public static DeltaItem Create(OneDriveItemId id, DriveId driveId, OneDriveFolderId? parentId, ItemPath path, bool isFolder, bool isDeleted, long size, DateTimeOffset? lastModified, string? downloadUrl, VersionInfo versionInfo) => new(id, driveId, parentId, path, isFolder, isDeleted, size, lastModified, downloadUrl, versionInfo);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveId.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveId.cs
@@ -1,18 +1,5 @@
-using AStar.Dev.Functional.Extensions;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
 /// <summary>Represents a OneDrive drive ID, providing type safety over raw strings.</summary>
 /// <param name="Value">The string value of the drive ID.</param>
 public readonly record struct DriveId(string Value);
-
-/// <summary>Factory for <see cref="DriveId"/>.</summary>
-public static class DriveIdFactory
-{
-    /// <summary>Creates an <see cref="Option{T}"/> of <see cref="DriveId"/> from a string. Returns <see cref="Option{T}.None"/> when the value is null or empty.</summary>
-    public static Option<DriveId> Create(string value)
-        => string.IsNullOrEmpty(value) ? Option<DriveId>.None.Instance : new Option<DriveId>.Some(new DriveId(value));
-
-    /// <summary>An empty <see cref="DriveId"/> option representing the absence of a drive ID.</summary>
-    public static Option<DriveId> Empty => Option<DriveId>.None.Instance;
-}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveId.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveId.cs
@@ -1,0 +1,18 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Home;
+
+/// <summary>Represents a OneDrive drive ID, providing type safety over raw strings.</summary>
+/// <param name="Value">The string value of the drive ID.</param>
+public readonly record struct DriveId(string Value);
+
+/// <summary>Factory for <see cref="DriveId"/>.</summary>
+public static class DriveIdFactory
+{
+    /// <summary>Creates an <see cref="Option{T}"/> of <see cref="DriveId"/> from a string. Returns <see cref="Option{T}.None"/> when the value is null or empty.</summary>
+    public static Option<DriveId> Create(string value)
+        => string.IsNullOrEmpty(value) ? Option<DriveId>.None.Instance : new Option<DriveId>.Some(new DriveId(value));
+
+    /// <summary>An empty <see cref="DriveId"/> option representing the absence of a drive ID.</summary>
+    public static Option<DriveId> Empty => Option<DriveId>.None.Instance;
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveIdFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/DriveIdFactory.cs
@@ -1,0 +1,14 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Home;
+
+/// <summary>Factory for <see cref="DriveId"/>.</summary>
+public static class DriveIdFactory
+{
+    /// <summary>Creates an <see cref="Option{T}"/> of <see cref="DriveId"/> from a string. Returns <see cref="Option{T}.None"/> when the value is null or empty.</summary>
+    public static Option<DriveId> Create(string value)
+        => string.IsNullOrEmpty(value) ? Option<DriveId>.None.Instance : new Option<DriveId>.Some(new DriveId(value));
+
+    /// <summary>An empty <see cref="DriveId"/> option representing the absence of a drive ID.</summary>
+    public static Option<DriveId> Empty => Option<DriveId>.None.Instance;
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -67,7 +67,6 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         SyncState = node.SyncState;
         HasChildren = node.HasChildren;
         _graphService = graphService;
-
         _accessToken = accessToken;
         _driveId = driveId;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -10,7 +10,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
 {
     private readonly IGraphService _graphService;
     private readonly string        _accessToken;
-    private readonly string        _driveId;
+    private readonly DriveId       _driveId;
     private          bool          _childrenLoaded;
 
     public string Id { get; }
@@ -57,7 +57,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     public event EventHandler<FolderTreeNodeViewModel>? OpenInFileManagerRequested;
     public event EventHandler<FolderTreeNodeViewModel>? ViewActivityRequested;
 
-    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, string accessToken, string driveId, int depth = 0)
+    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, string accessToken, DriveId driveId, int depth = 0)
     {
         Id = node.Id;
         Name = node.Name;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.Graph;
@@ -23,7 +24,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     private readonly ConcurrentDictionary<string, DriveContext> _cache = [];
 
     /// <inheritdoc />
-    public async Task<string> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
+    public async Task<DriveId> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
         => (await ResolveClientWithDriveContextAsync(accessToken, ct)).Ctx.DriveId;
 
     /// <inheritdoc />
@@ -31,7 +32,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         (var client, var driveContext) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
-        var response = await client.Drives[driveContext.DriveId].Items[driveContext.RootId].Children
+        var response = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
             .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
 
         List<DriveFolder> folders = [];
@@ -47,7 +48,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             if(page.OdataNextLink is null)
                 break;
 
-            page = await client.Drives[driveContext.DriveId].Items[driveContext.RootId].Children
+            page = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
                 .WithUrl(page.OdataNextLink)
                 .GetAsync(cancellationToken: ct);
         }
@@ -56,11 +57,11 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, string driveId, string parentFolderId, CancellationToken ct = default)
+    public async Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
 
-        var result = await client.Drives[driveId].Items[parentFolderId].Children
+        var result = await client.Drives[driveId.Value].Items[parentFolderId].Children
             .GetAsync(req =>
             {
                 req.QueryParameters.Select = ["id", "name", "folder", "parentReference"];
@@ -80,7 +81,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             if(page.OdataNextLink is null)
                 break;
 
-            page = await client.Drives[driveId].Items[parentFolderId].Children
+            page = await client.Drives[driveId.Value].Items[parentFolderId].Children
                 .WithUrl(page.OdataNextLink)
                 .GetAsync(cancellationToken: ct);
         }
@@ -93,7 +94,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
-        var drive = await client.Drives[ctx.DriveId]
+        var drive = await client.Drives[ctx.DriveId.Value]
             .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
 
         return drive?.Quota is { Total: not null, Used: not null }
@@ -102,7 +103,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, string driveId, string folderId, string remotePath, CancellationToken ct = default)
+    public async Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
         List<DeltaItem> items = [];
@@ -113,13 +114,13 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<string?> GetFolderIdByPathAsync(string accessToken, string driveId, string remotePath, CancellationToken ct = default)
+    public async Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
 
         try
         {
-            var item = await client.Drives[driveId].Items[$"{RootPathMarker}:{remotePath}"]
+            var item = await client.Drives[driveId.Value].Items[$"{RootPathMarker}:{remotePath}"]
                 .GetAsync(req => req.QueryParameters.Select = ["id"], ct);
 
             return item?.Id;
@@ -135,7 +136,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
-        var item = await client.Drives[ctx.DriveId].Items[itemId]
+        var item = await client.Drives[ctx.DriveId.Value].Items[itemId]
             .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
             .ConfigureAwait(false);
 
@@ -159,15 +160,15 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     public async Task DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
-        await client.Drives[ctx.DriveId].Items[itemId].DeleteAsync(cancellationToken: ct);
+        await client.Drives[ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
     }
 
-    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, string driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)
+    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)
     {
         if(!visited.Add(parentId))
             return;
 
-        var page = await client.Drives[driveId].Items[parentId].Children
+        var page = await client.Drives[driveId.Value].Items[parentId].Children
             .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
 
         while(page?.Value is not null)
@@ -178,14 +179,14 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
 
                 items.Add(MapToDeltaItem(item, itemPath));
 
-                if (item.Folder is not null && item.Id is not null)
+                if(item.Folder is not null && item.Id is not null)
                     await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, ct);
             }
 
             if (page.OdataNextLink is null)
                 break;
 
-            page = await client.Drives[driveId].Items[parentId].Children
+            page = await client.Drives[driveId.Value].Items[parentId].Children
                 .WithUrl(page.OdataNextLink)
                 .GetAsync(cancellationToken: ct);
         }
@@ -197,7 +198,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
 
     private static DeltaItem MapToDeltaItem(DriveItem item, string itemPath) => DeltaItemFactory.Create(
         new OneDriveItemId(item.Id!),
-        item.ParentReference?.DriveId ?? string.Empty,
+        new DriveId(item.ParentReference?.DriveId ?? string.Empty),
         item.ParentReference?.Id is string pid ? new OneDriveFolderId(pid) : null,
         ItemPathFactory.Create(item.Name ?? string.Empty, itemPath),
         isFolder: item.Folder is not null,
@@ -221,9 +222,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
 
         var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
 
-        string driveId = drive?.Id ?? throw new InvalidOperationException("Could not retrieve drive ID.");
+        var driveId = new DriveId(drive?.Id ?? throw new InvalidOperationException("Could not retrieve drive ID."));
 
-        var root = await client.Drives[driveId].Root.GetAsync(cancellationToken: ct);
+        var root = await client.Drives[driveId.Value].Root.GetAsync(cancellationToken: ct);
 
         string rootId = root?.Id ?? throw new InvalidOperationException("Could not retrieve root item ID.");
 
@@ -233,5 +234,5 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
         return (client, driveContext);
     }
 
-    private sealed record DriveContext(string DriveId, string RootId);
+    private sealed record DriveContext(DriveId DriveId, string RootId);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -15,7 +15,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     private const string RootPathMarker = "root:";
     private const string DownloadUrlKey = "@microsoft.graph.downloadUrl";
 
-    private static readonly string[] ChildrenSelect =
+    private static readonly string[] _childrenSelect =
     [
         "id", "name", "folder", "file", "size", "lastModifiedDateTime", "parentReference",
         "eTag", "cTag", DownloadUrlKey
@@ -33,7 +33,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
         (var client, var driveContext) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
         var response = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
-            .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
+            .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
 
         List<DriveFolder> folders = [];
 
@@ -169,7 +169,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             return;
 
         var page = await client.Drives[driveId.Value].Items[parentId].Children
-            .GetAsync(req => req.QueryParameters.Select = ChildrenSelect, ct);
+            .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
 
         while(page?.Value is not null)
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -1,26 +1,27 @@
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
 public interface IGraphService
 {
     /// <summary>Returns the ID of the user's default drive (OneDrive for Business or Personal).</summary>
-    Task<string> GetDriveIdAsync(string accessToken, CancellationToken ct = default);
+    Task<DriveId> GetDriveIdAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the root folder.</summary>
     Task<List<DriveFolder>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the given parent folder. Used for lazy-loading the folder tree.</summary>
-    Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, string driveId, string parentFolderId, CancellationToken ct = default);
+    Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default);
 
     /// <summary>Returns the user's OneDrive storage quota.</summary>
     Task<(long Total, long Used)> GetQuotaAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, string driveId, string folderId, string remotePath, CancellationToken ct = default);
+    Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
-    Task<string?> GetFolderIdByPathAsync(string accessToken, string driveId, string remotePath, CancellationToken ct = default);
+    Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);
 
     /// <summary>Fetches the pre-authenticated download URL for a specific drive item.</summary>
     Task<string?> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using Microsoft.Graph;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
@@ -8,5 +9,5 @@ public interface IUploadService
     /// Uploads a local file to OneDrive using a resumable upload session.
     /// Returns the uploaded DriveItem ID on success.
     /// </summary>
-    Task<string> UploadAsync(GraphServiceClient client, string driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default);
+    Task<string> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -27,7 +27,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         }
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
-        DriveId driveId = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
+        var driveId = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
 
         var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -26,7 +27,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         }
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
-        var driveId     = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
+        DriveId driveId = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
 
         var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules
@@ -59,7 +60,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
     }
 
-    private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, string accessToken, string driveId, CancellationToken ct)
+    private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, string accessToken, DriveId driveId, CancellationToken ct)
     {
         var folderId = rule.RemoteItemId
             ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
 using Microsoft.Graph.Models;
@@ -30,7 +31,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
     /// Uploads a local file to OneDrive using a resumable upload session.
     /// Returns the uploaded DriveItem ID on success.
     /// </summary>
-    public async Task<string> UploadAsync(GraphServiceClient client, string driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default)
+    public async Task<string> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default)
     {
         var fileInfo = fileSystem.FileInfo.New(localPath);
         if(!fileInfo.Exists)
@@ -40,7 +41,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         Serilog.Log.Information("[UploadService] Starting upload: {Path} ({Size:F2} MB)", remotePath, fileInfo.Length / (1024.0 * 1024));
 
-        string sessionUrl = await CreateSessionWithRetryAsync(client, driveId, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
+        string sessionUrl = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
 
         string itemId = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
 


### PR DESCRIPTION
## Summary

- Introduce `readonly record struct DriveId(string Value)` in `AStar.Dev.OneDrive.Sync.Client.Home` namespace, replacing all raw `string driveId` usages throughout the desktop app
- Add `DriveIdFactory` with `Create(string) → Option<DriveId>` and `Empty` property for nullable sites
- Update `AccountFilesViewModel` to store `Option<DriveId>` instead of `string?`, using `Match` to unwrap when constructing `FolderTreeNodeViewModel`
- All Microsoft Graph SDK call sites unwrap via `.Value` (e.g. `client.Drives[driveId.Value]`)
- All NSubstitute mock matchers updated from `Arg.Any<string>()` to `Arg.Any<DriveId>()` for drive ID positions
- Add `GivenADriveId` and `GivenADriveIdFactory` unit tests covering equality, factory Some/None paths

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 822 passed, 0 failed

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)