### PR TITLE
refactor(apps/desktop): replace throws with Result in OneDrive sync client

### DIFF
--- a/.claude/agents/c-sharp-dev.md
+++ b/.claude/agents/c-sharp-dev.md
@@ -47,6 +47,17 @@ File-scoped namespaces and implicit usings are global — never add redundant `u
 - Don't wrap `void` side-effects in `Result`.
 - Don't chain more than ~5 `.Bind`/`.Map` without naming intermediate results — extract a method.
 - Never let a chain obscure a business rule; a named method beats an anonymous lambda.
+- **Never await a `Task<Result<T,E>>` into an intermediate variable just to call `.Match()` on the next line.** Chain `.MatchAsync()` directly on the task. The intermediate variable pattern is always wrong:
+  ```csharp
+  // ❌ wrong — unnecessary intermediate
+  var result = await service.GetAsync(ct);
+  var value = result.Match<string?>(ok => ok.Value, _ => null);
+
+  // ✅ correct — chain directly
+  var value = await service.GetAsync(ct)
+      .MatchAsync<TSuccess, TError, string?>(ok => ok.Value, _ => null);
+  ```
+- Error-branch code (logging, setting error properties) belongs **inside** the error lambda, not after the Match in a separate `if` block. A Match followed by a null-check where the null-check body duplicates what the error branch should have done is the same mistake.
 
 ## Project conventions
 

--- a/.claude/rules/c-sharp-code-style.md
+++ b/.claude/rules/c-sharp-code-style.md
@@ -109,6 +109,21 @@ Coding standards and style guidelines / preferences for C# files in this reposit
 - Use NSubstitute for mocking dependencies in tests. Avoid mocking when possible; prefer using real instances or test doubles.
 - Never add XML documentation or comments to test classes or test methods.
 
+## Functional Extensions (AStar.Dev.Functional.Extensions)
+
+- **Never** await a `Task<Result<T,E>>` into an intermediate variable just to call `.Match()` on the next line. Always chain `.MatchAsync()` directly on the task:
+  ```csharp
+  // ❌ wrong
+  var result = await service.GetAsync(ct);
+  var value = result.Match<string?>(ok => ok.Value, _ => null);
+
+  // ✅ correct
+  var value = await service.GetAsync(ct)
+      .MatchAsync<TSuccess, TError, string?>(ok => ok.Value, _ => null);
+  ```
+- Error-branch code (logging, setting properties, returning sentinel values) belongs **inside** the error lambda of `Match`/`MatchAsync`, not in a separate `if` block after the call.
+- Never use `is Result<T,E>.Ok` / `is not Result<T,E>.Ok` pattern matching in production code — use `Match` or `MatchAsync`.
+
 ## Utilities
 
 - The AStar.Dev.Utilities project has a plethora of helpers. Use them when suitable.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
@@ -73,15 +73,16 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Features" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Identity.Web.DownstreamApi" Version="3.8.4" />
     <PackageVersion Include="Microsoft.Identity.Web.UI" Version="3.8.4" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Identity.Web.TokenAcquisition" Version="3.8.4" />
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
     <PackageVersion Include="Aspire.RabbitMQ.Client.v7" Version="9.4.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
@@ -125,15 +126,15 @@
   <ItemGroup Label="Authentication and security">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.3" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.0" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.84.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.4.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
   <ItemGroup Label="HTTP and API">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Graph" Version="5.104.0" />
-    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Graph" Version="5.105.0" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.21.1" />
     <PackageVersion Include="Refit" Version="8.0.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
@@ -149,20 +150,20 @@
     <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
   </ItemGroup>
   <ItemGroup Label="Avalonia desktop">
-    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia" Version="12.0.2" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.2" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.2" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.2" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.2" />
     <PackageVersion Include="Avalonia.ReactiveUI" Version="11.3.8" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.2" />
     <PackageVersion Include="ReactiveUI" Version="20.1.1" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.93.0" />
   </ItemGroup>
   <ItemGroup Label="Blazor and web">
     <PackageVersion Include="MudBlazor" Version="8.3.0" />
@@ -172,9 +173,9 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
@@ -186,7 +187,7 @@
     <PackageVersion Include="Testably.Abstractions.Testing" Version="6.2.0" />
     <PackageVersion Include="Testcontainers" Version="3.11.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="WireMock.Net" Version="2.2.0" />
+    <PackageVersion Include="WireMock.Net" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup Label="Build and source link tooling">
     <PackageVersion Include="GitVersion.MsBuild" Version="6.2.0" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
@@ -26,6 +26,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly"/>
     <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -195,7 +195,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
         graphService.GetDriveIdAsync(AccessToken, Arg.Any<CancellationToken>())
-            .Returns(new DriveId(DriveIdValue));
+            .Returns(new Result<DriveId, string>.Ok(new DriveId(DriveIdValue)));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns([new DriveFolder(FolderId, FolderName)]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -198,7 +198,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
             .Returns(new Result<DriveId, string>.Ok(new DriveId(DriveIdValue)));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(FolderId, FolderName)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId, FolderName)]));
 
         return (authService, graphService, repository);
     }
@@ -208,7 +208,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         var (authService, graphService, repository) = BuildMocks();
 
         graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdValue), FolderId, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(ChildFolderId, ChildFolderName, FolderId)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildFolderName, FolderId)]));
 
         return (authService, graphService, repository);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
@@ -111,7 +112,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var graphService = Substitute.For<IGraphService>();
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
-        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new DriveId("drive-1"));
+        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
         graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -113,7 +114,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
         graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
-        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -102,7 +103,7 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, AccountProfileFactory.Create(DisplayName, Email)));
 
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(FolderId1, FolderName1), new DriveFolder(FolderId2, FolderName2)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId1, FolderName1), new DriveFolder(FolderId2, FolderName2)]));
 
         return (authService, graphService, repository, syncRuleRepo);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
@@ -1,6 +1,7 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
 
@@ -112,7 +113,7 @@ public sealed class GivenAFolderTreeNodeViewModel
         var graphService = Substitute.For<IGraphService>();
 
         graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]));
 
         return graphService;
     }
@@ -122,10 +123,10 @@ public sealed class GivenAFolderTreeNodeViewModel
         var graphService = Substitute.For<IGraphService>();
 
         graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]));
 
         graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), ChildFolderId, Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder(GrandChildId, GrandChildName, ChildFolderId)]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(GrandChildId, GrandChildName, ChildFolderId)]));
 
         return graphService;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -1,5 +1,6 @@
-using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using WireMock.RequestBuilders;
@@ -150,9 +151,10 @@ public sealed class GivenAGraphService : IDisposable
 
         var result = await CreateSut().GetRootFoldersAsync(AnyAccessToken, TestContext.Current.CancellationToken);
 
-        result.Count.ShouldBe(2);
-        result[0].Name.ShouldBe("AFolder");
-        result[1].Name.ShouldBe("ZFolder");
+        var folders = result.ShouldBeAssignableTo<Result<List<DriveFolder>, string>.Ok>()!.Value;
+        folders.Count.ShouldBe(2);
+        folders[0].Name.ShouldBe("AFolder");
+        folders[1].Name.ShouldBe("ZFolder");
     }
 
     [Fact]
@@ -179,8 +181,9 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = AnyDriveId }));
 
-        var (total, used) = await CreateSut().GetQuotaAsync(AnyAccessToken, TestContext.Current.CancellationToken);
+        var quotaResult = await CreateSut().GetQuotaAsync(AnyAccessToken, TestContext.Current.CancellationToken);
 
+        var (total, used) = quotaResult.ShouldBeAssignableTo<Result<(long Total, long Used), string>.Ok>()!.Value;
         total.ShouldBe(0L);
         used.ShouldBe(0L);
     }
@@ -197,7 +200,7 @@ public sealed class GivenAGraphService : IDisposable
 
         var result = await CreateSut().GetDownloadUrlAsync(AnyAccessToken, AnyItemId, TestContext.Current.CancellationToken);
 
-        result.ShouldBeNull();
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
     }
 
     [Fact]
@@ -229,10 +232,11 @@ public sealed class GivenAGraphService : IDisposable
 
         var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
 
-        result.Count.ShouldBe(3);
-        result.ShouldContain(i => i.Id.Id == "file-root");
-        result.ShouldContain(i => i.Id.Id == "subfolder-001" && i.IsFolder);
-        result.ShouldContain(i => i.Id.Id == "file-sub");
+        var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
+        items.Count.ShouldBe(3);
+        items.ShouldContain(i => i.Id.Id == "file-root");
+        items.ShouldContain(i => i.Id.Id == "subfolder-001" && i.IsFolder);
+        items.ShouldContain(i => i.Id.Id == "file-sub");
     }
 
     [Fact]
@@ -263,9 +267,10 @@ public sealed class GivenAGraphService : IDisposable
 
         var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
 
-        result.Count.ShouldBe(2);
-        result.ShouldContain(i => i.Id.Id == "subfolder-A");
-        result.ShouldContain(i => i.Id.Id == AnyFolderId);
+        var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
+        items.Count.ShouldBe(2);
+        items.ShouldContain(i => i.Id.Id == "subfolder-A");
+        items.ShouldContain(i => i.Id.Id == AnyFolderId);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using WireMock.RequestBuilders;
@@ -278,6 +279,39 @@ public sealed class GivenAGraphService : IDisposable
         _ = await sut.GetDriveIdAsync(AnyAccessToken, ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_is_called_and_graph_returns_null_drive_id_then_result_is_error()
+    {
+        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = (string?)null }));
+
+        var result = await CreateSut().GetDriveIdAsync(AnyAccessToken, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<DriveId, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_is_called_and_graph_returns_null_root_item_id_then_result_is_error()
+    {
+        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = "drive-001" }));
+        _server.Given(Request.Create().WithPath("/drives/drive-001/root").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = (string?)null }));
+
+        var result = await CreateSut().GetDriveIdAsync(AnyAccessToken, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<DriveId, string>.Error>();
     }
 
     private void SetupDriveContext(string driveId, string rootId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
@@ -21,6 +21,12 @@ public sealed class GivenADownloadWorker
     private readonly ISyncRepository  _syncRepository = Substitute.For<ISyncRepository>();
     private readonly IFileSystem      _fileSystem     = Substitute.For<IFileSystem>();
 
+    public GivenADownloadWorker()
+    {
+        _downloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
+    }
+
     private DownloadWorker CreateSut(int workerId = 1) => new(workerId, _downloader, _graphService, _syncRepository, _fileSystem);
 
     private static DownloadSyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file")
@@ -102,7 +108,7 @@ public sealed class GivenADownloadWorker
         var job = MakeDownloadJob(downloadUrl: null);
 
         _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
-            .Returns(new Result<string, string>.Error("no url"));
+            .Returns(new Result<string, string>.Error($"No download URL available for item {ItemId}."));
 
         var (completed, errors) = await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
@@ -152,7 +158,7 @@ public sealed class GivenADownloadWorker
         var job = MakeUploadJob();
 
         _graphService.UploadFileAsync(AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
-            .Returns("remote-item-id");
+            .Returns(new Result<string, string>.Ok("remote-item-id"));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorker.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using System.Threading.Channels;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -87,7 +88,7 @@ public sealed class GivenADownloadWorker
         var job = MakeDownloadJob(downloadUrl: null);
 
         _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
-            .Returns(fetchedUrl);
+            .Returns(new Result<string, string>.Ok(fetchedUrl));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
@@ -101,7 +102,7 @@ public sealed class GivenADownloadWorker
         var job = MakeDownloadJob(downloadUrl: null);
 
         _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
-            .Returns((string?)null);
+            .Returns(new Result<string, string>.Error("no url"));
 
         var (completed, errors) = await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
@@ -117,7 +118,7 @@ public sealed class GivenADownloadWorker
         var job = MakeDownloadJob(downloadUrl: null);
 
         _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
-            .Returns((string?)null);
+            .Returns(new Result<string, string>.Error("no url"));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
@@ -168,4 +169,19 @@ public sealed class GivenADownloadWorker
         await _downloader.DidNotReceive().DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), ct: Arg.Any<CancellationToken>());
         await _graphService.DidNotReceive().GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task when_download_url_resolution_returns_result_error_then_error_message_from_result_is_propagated()
+    {
+        const string ResultErrorMessage = "No download URL available.";
+        var job = MakeDownloadJob(downloadUrl: null);
+
+        _graphService.GetDownloadUrlAsync(AccessToken, ItemId, Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Error(ResultErrorMessage));
+
+        var (_, errors) = await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        errors[0].ShouldBe(ResultErrorMessage);
+    }
+
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -16,6 +17,12 @@ public sealed class GivenALocalDeletionDetector
     private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
     private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
     private readonly AccountId             _accountId            = new("user-1");
+
+    public GivenALocalDeletionDetector()
+    {
+        _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
+    }
 
     private LocalDeletionDetector CreateSut(MockFileSystem mockFs) => new(_graphService, _syncedItemRepository, mockFs);
 
@@ -84,8 +91,8 @@ public sealed class GivenALocalDeletionDetector
     public async Task when_graph_delete_throws_then_exception_is_caught_and_remaining_items_are_processed()
     {
         var mockFileSystem = new MockFileSystem();
-        _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new HttpRequestException("network error")));
+        _graphService.When(x => x.DeleteItemAsync(Arg.Any<string>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>()))
+            .Throw(new HttpRequestException("network error"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-fail"] = new() { RemoteItemId = new OneDriveItemId("item-fail"), RemotePath = "/fail.txt", LocalPath = $"{BaseDir}/fail.txt", IsFolder = false },

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -19,6 +20,12 @@ public sealed class GivenAParallelDownloadPipeline
     private readonly IGraphService    _graphService   = Substitute.For<IGraphService>();
     private readonly ISyncRepository  _syncRepository = Substitute.For<ISyncRepository>();
     private readonly IFileSystem      _fileSystem     = Substitute.For<IFileSystem>();
+
+    public GivenAParallelDownloadPipeline()
+    {
+        _downloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
+    }
 
     private ParallelDownloadPipeline CreateSut() => new(_syncRepository, _graphService, _downloader, _fileSystem);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -24,7 +25,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<string, SyncedItemEntity>());
         _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new DriveId("drive-1"));
+            .Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
     }
 
     private RemoteFolderEnumerator CreateSut(MockFileSystem mockFs) => new(_graphService, _syncRuleRepository, _syncedItemRepository, mockFs);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -105,7 +105,7 @@ public sealed class GivenARemoteFolderEnumerator
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
         var sut = CreateSut(new MockFileSystem());
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -119,7 +119,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
         var sut = CreateSut(new MockFileSystem());
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -133,7 +133,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
         var sut = CreateSut(new MockFileSystem());
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -148,7 +148,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt")]));
         var sut = CreateSut(new MockFileSystem());
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -179,7 +179,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]));
         var sut = CreateSut(mockFileSystem);
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -210,7 +210,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([DeltaItemFactory.Create(new OneDriveItemId("item-a"), new DriveId("drive-1"), null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([DeltaItemFactory.Create(new OneDriveItemId("item-a"), new DriveId("drive-1"), null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]));
 
         var conflictsDetected = new List<SyncConflict>();
         var sut = CreateSut(mockFileSystem);
@@ -231,7 +231,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FolderItem("subfolder-1", "Sub", "/Documents/Sub")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FolderItem("subfolder-1", "Sub", "/Documents/Sub")]));
         var sut = CreateSut(new MockFileSystem());
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -249,7 +249,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]));
         var sut = CreateSut(mockFileSystem);
 
         await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -263,7 +263,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
         var sut = CreateSut(new MockFileSystem());
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -278,7 +278,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]));
         var sut = CreateSut(new MockFileSystem());
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
@@ -293,7 +293,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]);
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]));
         var sut = CreateSut(new MockFileSystem());
 
         var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -82,6 +83,27 @@ public sealed class GivenAnHttpDownloader
 
         reportedValues.ShouldNotBeEmpty();
         reportedValues[^1].ShouldBe(Encoding.UTF8.GetByteCount(FileContent));
+    }
+
+    [Fact]
+    public async Task when_download_is_rate_limited_beyond_max_retries_then_result_is_error()
+    {
+        var factory = CreateAlways429Factory();
+        var sut = new HttpDownloader(factory, new MockFileSystem());
+
+        var result = await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        var error = result.ShouldBeAssignableTo<Result<System.Reactive.Unit, string>.Error>();
+        error!.Reason.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    private static IHttpClientFactory CreateAlways429Factory()
+    {
+        var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(new FakeHttpMessageHandler(_ => response)));
+
+        return factory;
     }
 
     private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
@@ -10,6 +10,7 @@ using WireMockBodyType = WireMock.Types.BodyType;
 using WireMockRequest = WireMock.RequestBuilders.Request;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.Functional.Extensions;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -84,7 +85,8 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var itemId = uploadResult.Match(id => id, _ => string.Empty);
 
         itemId.ShouldBe(ExpectedItemId);
     }
@@ -104,7 +106,8 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var itemId = uploadResult.Match(id => id, _ => string.Empty);
 
         itemId.ShouldBe(ExpectedItemId);
     }
@@ -132,7 +135,8 @@ public sealed class GivenAnUploadService
 
         var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
 
-        string itemId = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+        var itemId = uploadResult.Match(id => id, _ => string.Empty);
 
         itemId.ShouldBe(ExpectedItemId);
         putCallCount.ShouldBe(2);
@@ -162,6 +166,75 @@ public sealed class GivenAnUploadService
 
         reportedValues.ShouldNotBeEmpty();
         reportedValues[^1].ShouldBe(FileSize);
+    }
+
+    [Fact]
+    public async Task when_upload_async_is_called_with_nonexistent_local_path_then_result_is_error()
+    {
+        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem());
+
+        var result = await sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, "/nonexistent/path/file.bin", RemotePath, ct: TestContext.Current.CancellationToken);
+
+        var error = result.ShouldBeAssignableTo<Result<string, string>.Error>();
+        error!.Reason.ShouldContain("Local file not found");
+    }
+
+    [Fact]
+    public async Task when_graph_api_returns_null_upload_session_url_then_result_is_error()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
+        using var server = WireMockServer.Start();
+
+        server.Given(WireMockRequest.Create().UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"uploadUrl\":null}").WithHeader("Content-Type", "application/json"));
+
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+
+        var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+
+        var error = result.ShouldBeAssignableTo<Result<string, string>.Error>();
+        error!.Reason.ShouldContain("upload session URL");
+    }
+
+    [Fact]
+    public async Task when_upload_chunk_is_rate_limited_beyond_max_retries_then_result_is_error()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
+        using var server = WireMockServer.Start();
+
+        server.Given(WireMockRequest.Create().UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(SessionJson(server)).WithHeader("Content-Type", "application/json"));
+
+        server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
+              .RespondWith(Response.Create().WithStatusCode(429));
+
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+
+        var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_upload_final_response_has_no_item_id_then_result_is_error()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
+        using var server = WireMockServer.Start();
+
+        server.Given(WireMockRequest.Create().UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(SessionJson(server)).WithHeader("Content-Type", "application/json"));
+
+        server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
+              .RespondWith(Response.Create().WithStatusCode(201).WithHeader("Content-Type", "application/json").WithBody("{}"));
+
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+
+        var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
     }
 
     private static ResponseMessage Accepted202Response() =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
@@ -48,15 +48,6 @@ public sealed class GivenAnUploadService
         new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem()).ShouldBeAssignableTo<IUploadService>();
 
     [Fact]
-    public async Task when_upload_async_is_called_with_nonexistent_local_path_then_FileNotFoundException_is_thrown()
-    {
-        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem());
-
-        await Should.ThrowAsync<FileNotFoundException>(() =>
-            sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, "/nonexistent/path/file.bin", RemotePath));
-    }
-
-    [Fact]
     public async Task when_upload_async_is_called_with_pre_cancelled_token_then_operation_is_cancelled()
     {
         var mockFileSystem = new MockFileSystem();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -63,7 +64,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
         EventArgs? firedArgs = null;
         sut.Cancelled += (_, args) => firedArgs = args;
@@ -78,7 +79,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
         await sut.NextCommand.ExecuteAsync(null);
         EventArgs? firedArgs = null;
@@ -99,7 +100,7 @@ public sealed class GivenAnAddAccountWizardViewModel
             .Returns(_ =>
             {
                 stepAtFolderLoad = sut.CurrentStep;
-                return Task.FromResult(new List<DriveFolder>());
+                return Task.FromResult<Result<List<DriveFolder>, string>>(new Result<List<DriveFolder>, string>.Ok([]));
             });
 
         await sut.NextCommand.ExecuteAsync(null);
@@ -117,7 +118,7 @@ public sealed class GivenAnAddAccountWizardViewModel
             .Returns(_ =>
             {
                 wasLoadingDuringFetch = sut.IsLoadingFolders;
-                return Task.FromResult(new List<DriveFolder>());
+                return Task.FromResult<Result<List<DriveFolder>, string>>(new Result<List<DriveFolder>, string>.Ok([]));
             });
 
         await sut.NextCommand.ExecuteAsync(null);
@@ -132,7 +133,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]));
 
         await sut.NextCommand.ExecuteAsync(null);
 
@@ -145,7 +146,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Desktop"), new DriveFolder("id-3", "Pictures")]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Desktop"), new DriveFolder("id-3", "Pictures")]));
 
         await sut.NextCommand.ExecuteAsync(null);
 
@@ -160,7 +161,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns<List<DriveFolder>>(_ => throw new InvalidOperationException("network error"));
+            .Returns(new Result<List<DriveFolder>, string>.Error("network error"));
 
         await sut.NextCommand.ExecuteAsync(null);
 
@@ -173,7 +174,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
 
         sut.SkipFoldersCommand.Execute(null);
@@ -187,7 +188,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder("id-1", "Documents")]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents")]));
         await sut.NextCommand.ExecuteAsync(null);
 
         sut.SkipFoldersCommand.Execute(null);
@@ -201,7 +202,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]));
         await sut.NextCommand.ExecuteAsync(null);
         sut.Folders[1].IsSelected = false;
 
@@ -216,7 +217,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]);
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents"), new DriveFolder("id-2", "Pictures")]));
         await sut.NextCommand.ExecuteAsync(null);
         sut.Folders[1].IsSelected = false;
         await sut.NextCommand.ExecuteAsync(null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" />
     <PackageReference Include="Tmds.DBus.Protocol" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Identity.Client" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -67,32 +67,33 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
         try
         {
-            var authResult = await _authService.AcquireTokenSilentAsync(_account.Id.Id);
+            _accessToken = await _authService.AcquireTokenSilentAsync(_account.Id.Id)
+                .MatchAsync<AuthResult, AuthError, string?>(
+                    ok => ok.AccessToken,
+                    error =>
+                    {
+                        LoadError = error is AuthFailedError failed ? failed.Message : "Authentication failed.";
+                        HasLoadError = true;
+                        return null;
+                    });
 
-            if(authResult is not Result<AuthResult, AuthError>.Ok ok)
-            {
-                LoadError = authResult is Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }
-                    ? failed.Message
-                    : "Authentication failed.";
-                HasLoadError = true;
-
+            if(_accessToken is null)
                 return;
-            }
 
-            _accessToken = ok.Value.AccessToken;
-            var driveIdResult = await _graphService.GetDriveIdAsync(_accessToken);
+            var driveId = await _graphService.GetDriveIdAsync(_accessToken)
+                .MatchAsync<DriveId, string, DriveId?>(
+                    id => id,
+                    error =>
+                    {
+                        LoadError = $"Failed to retrieve drive ID: {error}";
+                        HasLoadError = true;
+                        return null;
+                    });
 
-            if(driveIdResult is not Result<DriveId, string>.Ok driveIdOk)
-            {
-                LoadError = driveIdResult is Result<DriveId, string>.Error driveIdError
-                    ? $"Failed to retrieve drive ID: {driveIdError.Reason}"
-                    : "Failed to retrieve drive ID.";
-                HasLoadError = true;
-
+            if(driveId is null)
                 return;
-            }
 
-            _driveId = new Option<DriveId>.Some(driveIdOk.Value);
+            _driveId = new Option<DriveId>.Some(driveId.Value);
 
             var includedPaths = await LoadRulesAsync();
             await BuildRootFoldersAsync(includedPaths);
@@ -120,21 +121,21 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private async Task BuildRootFoldersAsync(HashSet<string> includedPaths)
     {
-        var foldersResult = await _graphService.GetRootFoldersAsync(_accessToken!);
+        var folders = await _graphService.GetRootFoldersAsync(_accessToken!)
+            .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
+                f => f,
+                error =>
+                {
+                    Serilog.Log.Warning("[AccountFilesViewModel] Failed to load root folders for account {AccountId}: {Error}", _account.Id.Id, error);
+                    LoadError = error;
+                    HasLoadError = true;
+                    return null;
+                });
 
-        if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
-        {
-            var errorMessage = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
-                ? foldersError.Reason
-                : "Failed to load root folders.";
-            Serilog.Log.Warning("[AccountFilesViewModel] Failed to load root folders for account {AccountId}: {Error}", _account.Id.Id, errorMessage);
-            LoadError = errorMessage;
-            HasLoadError = true;
-
+        if(folders is null)
             return;
-        }
 
-        foreach(var f in foldersOk.Value)
+        foreach(var f in folders)
         {
             string remotePath = $"/{f.Name}";
             var syncState = includedPaths.Contains(remotePath)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -4,6 +4,7 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.Utilities;
@@ -56,7 +57,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     [RelayCommand]
     public async Task LoadAsync()
     {
-        if (IsLoading)
+        if(IsLoading)
             return;
 
         IsLoading = true;
@@ -80,15 +81,23 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
             _accessToken = ok.Value.AccessToken;
             var driveIdResult = await _graphService.GetDriveIdAsync(_accessToken);
-            _driveId = new Option<DriveId>.Some(driveIdResult.Match(
-                id    => id,
-                error => throw new InvalidOperationException($"Failed to retrieve drive ID: {error}")
-            ));
+
+            if(driveIdResult is not Result<DriveId, string>.Ok driveIdOk)
+            {
+                LoadError = driveIdResult is Result<DriveId, string>.Error driveIdError
+                    ? $"Failed to retrieve drive ID: {driveIdError.Reason}"
+                    : "Failed to retrieve drive ID.";
+                HasLoadError = true;
+
+                return;
+            }
+
+            _driveId = new Option<DriveId>.Some(driveIdOk.Value);
 
             var includedPaths = await LoadRulesAsync();
             await BuildRootFoldersAsync(includedPaths);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             LoadError = $"Failed to load folders: {ex.Message}";
             HasLoadError = true;
@@ -111,9 +120,21 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private async Task BuildRootFoldersAsync(HashSet<string> includedPaths)
     {
-        var folders = await _graphService.GetRootFoldersAsync(_accessToken!);
+        var foldersResult = await _graphService.GetRootFoldersAsync(_accessToken!);
 
-        foreach (var f in folders)
+        if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
+        {
+            var errorMessage = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
+                ? foldersError.Reason
+                : "Failed to load root folders.";
+            Serilog.Log.Warning("[AccountFilesViewModel] Failed to load root folders for account {AccountId}: {Error}", _account.Id.Id, errorMessage);
+            LoadError = errorMessage;
+            HasLoadError = true;
+
+            return;
+        }
+
+        foreach(var f in foldersOk.Value)
         {
             string remotePath = $"/{f.Name}";
             var syncState = includedPaths.Contains(remotePath)
@@ -122,9 +143,14 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
             var node = new FolderTreeNode(Id: f.Id, Name: f.Name, ParentId: f.ParentId, AccountId: _account.Id.Id, RemotePath: remotePath, SyncState: syncState, HasChildren: true);
 
-            var vm = _driveId.Match(
-                id => new FolderTreeNodeViewModel(node, _graphService, _accessToken!, id),
-                () => throw new InvalidOperationException("Drive ID not available."));
+            if(_driveId is not Option<DriveId>.Some driveIdSome)
+            {
+                Serilog.Log.Warning("[AccountFilesViewModel] Drive ID not available when building folder tree for account {AccountId}", _account.Id.Id);
+
+                return;
+            }
+
+            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveIdSome.Value);
 
             vm.IncludeToggled += OnIncludeToggledAsync;
             vm.ViewActivityRequested += OnViewActivityRequested;
@@ -171,7 +197,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     {
         string path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).CombinePath("OneDrive", node.Name);
 
-        if (!fileSystem.Directory.Exists(path))
+        if(!fileSystem.Directory.Exists(path))
             return;
 
         string opener = OperatingSystem.IsWindows() ? "explorer"
@@ -183,11 +209,11 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private static IEnumerable<FolderTreeNodeViewModel> CollectAllVisible(IEnumerable<FolderTreeNodeViewModel> nodes)
     {
-        foreach (var node in nodes)
+        foreach(var node in nodes)
         {
             yield return node;
 
-            foreach (var descendant in CollectAllVisible(node.Children))
+            foreach(var descendant in CollectAllVisible(node.Children))
                 yield return descendant;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -79,8 +79,11 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
             }
 
             _accessToken = ok.Value.AccessToken;
-            var driveId = await _graphService.GetDriveIdAsync(_accessToken);
-            _driveId = new Option<DriveId>.Some(driveId);
+            var driveIdResult = await _graphService.GetDriveIdAsync(_accessToken);
+            _driveId = new Option<DriveId>.Some(driveIdResult.Match(
+                id    => id,
+                error => throw new InvalidOperationException($"Failed to retrieve drive ID: {error}")
+            ));
 
             var includedPaths = await LoadRulesAsync();
             await BuildRootFoldersAsync(includedPaths);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -91,7 +91,6 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
             return;
 
         section.UpdateSyncState(SyncState.Completed, section.ConflictCount);
-        section.AddRecentActivity(new ActivityItemViewModel { AccountId = accountId, FileName = "Sync complete", Type = ActivityItemType.Info });
 
         RecalculateGlobals();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -49,7 +50,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     [ObservableProperty]
     public partial bool HasChildren { get; set; }
 
-    public string ExpanderGlyph => IsExpanded ? "\u25BE" : "\u25B8";
+    public string ExpanderGlyph => IsExpanded ? "▾" : "▸";
 
     public ObservableCollection<FolderTreeNodeViewModel> Children { get; } = [];
 
@@ -122,17 +123,28 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         IsLoadingChildren = true;
         try
         {
-            var folders = await _graphService.GetChildFoldersAsync(_accessToken, _driveId, Id);
+            var foldersResult = await _graphService.GetChildFoldersAsync(_accessToken, _driveId, Id);
+
+            if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
+            {
+                var error = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
+                    ? foldersError.Reason
+                    : "Failed to load child folders.";
+                Serilog.Log.Warning("[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}", RemotePath, error);
+                HasChildren = false;
+
+                return;
+            }
 
             Children.Clear();
-            foreach(var f in folders)
+            foreach(var f in foldersOk.Value)
             {
                 var childVm = CreateChildFolderTreeViewModel(f);
 
                 Children.Add(childVm);
             }
 
-            if (Children.Count == 0) HasChildren = false;
+            if(Children.Count == 0) HasChildren = false;
 
             _childrenLoaded = true;
         }
@@ -146,9 +158,8 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     {
         string childRemotePath = $"{RemotePath}/{f.Name}";
         var childNode = MapDriveFolderToChildNode(f, childRemotePath);
-        var childVm = CreateChildFolderTreeViewModel(childNode);
 
-        return childVm;
+        return CreateChildFolderTreeViewModel(childNode);
     }
 
     private FolderTreeNodeViewModel CreateChildFolderTreeViewModel(FolderTreeNode childNode)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -123,21 +123,21 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         IsLoadingChildren = true;
         try
         {
-            var foldersResult = await _graphService.GetChildFoldersAsync(_accessToken, _driveId, Id);
+            var folders = await _graphService.GetChildFoldersAsync(_accessToken, _driveId, Id)
+                .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
+                    f => f,
+                    error =>
+                    {
+                        Serilog.Log.Warning("[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}", RemotePath, error);
+                        HasChildren = false;
+                        return null;
+                    });
 
-            if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
-            {
-                var error = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
-                    ? foldersError.Reason
-                    : "Failed to load child folders.";
-                Serilog.Log.Warning("[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}", RemotePath, error);
-                HasChildren = false;
-
+            if(folders is null)
                 return;
-            }
 
             Children.Clear();
-            foreach(var f in foldersOk.Value)
+            foreach(var f in folders)
             {
                 var childVm = CreateChildFolderTreeViewModel(f);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reactive;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Home;
@@ -26,12 +27,22 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
 
     /// <inheritdoc />
     public async Task<Result<DriveId, string>> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
-        => new Result<DriveId, string>.Ok((await ResolveClientWithDriveContextAsync(accessToken, ct)).Ctx.DriveId);
+    {
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok ok)
+            return new Result<DriveId, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
+
+        return new Result<DriveId, string>.Ok(ok.Value.Item2.DriveId);
+    }
 
     /// <inheritdoc />
-    public async Task<List<DriveFolder>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default)
+    public async Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default)
     {
-        (var client, var driveContext) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
+            return new Result<List<DriveFolder>, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
+
+        (var client, var driveContext) = contextOk.Value;
 
         var response = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
             .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
@@ -54,11 +65,11 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 .GetAsync(cancellationToken: ct);
         }
 
-        return [.. folders.OrderBy(f => f.Name)];
+        return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
     }
 
     /// <inheritdoc />
-    public async Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default)
+    public async Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
 
@@ -87,31 +98,37 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 .GetAsync(cancellationToken: ct);
         }
 
-        return [.. folders.OrderBy(f => f.Name)];
+        return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
     }
 
     /// <inheritdoc />
-    public async Task<(long Total, long Used)> GetQuotaAsync(string accessToken, CancellationToken ct = default)
+    public async Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accessToken, CancellationToken ct = default)
     {
-        (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
+            return new Result<(long Total, long Used), string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
+
+        (var client, var ctx) = contextOk.Value;
 
         var drive = await client.Drives[ctx.DriveId.Value]
             .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
 
-        return drive?.Quota is { Total: not null, Used: not null }
+        var quota = drive?.Quota is { Total: not null, Used: not null }
             ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
             : (0L, 0L);
+
+        return new Result<(long Total, long Used), string>.Ok(quota);
     }
 
     /// <inheritdoc />
-    public async Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default)
+    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
         List<DeltaItem> items = [];
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, ct);
 
-        return items;
+        return new Result<List<DeltaItem>, string>.Ok(items);
     }
 
     /// <inheritdoc />
@@ -135,39 +152,48 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     /// <inheritdoc />
     public async Task<Result<string, string>> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
-        (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
+            return new Result<string, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
+
+        (var client, var ctx) = contextOk.Value;
 
         var item = await client.Drives[ctx.DriveId.Value].Items[itemId]
             .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
             .ConfigureAwait(false);
 
         if(item?.AdditionalData is null)
-            return new Result<string, string>.Error("No download URL available.");
+            return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
         if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out var url) || url is null)
-            return new Result<string, string>.Error("No download URL available.");
+            return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
         return new Result<string, string>.Ok(url.ToString()!);
     }
 
     /// <inheritdoc />
-    public async Task<string> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
+    public async Task<Result<string, string>> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
     {
-        (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
+            return new Result<string, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        var uploadResult = await uploadService.UploadAsync(client, ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct);
+        (var client, var ctx) = contextOk.Value;
 
-        return uploadResult.Match(
-            itemId => itemId,
-            error  => throw new InvalidOperationException($"Upload failed: {error}")
-        );
+        return await uploadService.UploadAsync(client, ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default)
+    public async Task<Result<Unit, string>> DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
-        (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
+        var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
+        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
+            return new Result<Unit, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
+
+        (var client, var ctx) = contextOk.Value;
         await client.Drives[ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
+
+        return new Result<Unit, string>.Ok(Unit.Default);
     }
 
     private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)
@@ -190,7 +216,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                     await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, ct);
             }
 
-            if (page.OdataNextLink is null)
+            if(page.OdataNextLink is null)
                 break;
 
             page = await client.Drives[driveId.Value].Items[parentId].Children
@@ -220,25 +246,28 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             ? url?.ToString()
             : null;
 
-    private async Task<(GraphServiceClient Client, DriveContext Ctx)> ResolveClientWithDriveContextAsync(string accessToken, CancellationToken ct)
+    private async Task<Result<(GraphServiceClient Client, DriveContext Ctx), string>> ResolveClientWithDriveContextAsync(string accessToken, CancellationToken ct)
     {
         var client = graphClientFactory.CreateClient(accessToken);
 
         if(_cache.TryGetValue(accessToken, out var cached))
-            return (client, cached);
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, cached));
 
         var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
 
-        var driveId = new DriveId(drive?.Id ?? throw new InvalidOperationException("Could not retrieve drive ID."));
+        if(drive?.Id is null)
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve drive ID.");
 
+        var driveId = new DriveId(drive.Id);
         var root = await client.Drives[driveId.Value].Root.GetAsync(cancellationToken: ct);
 
-        string rootId = root?.Id ?? throw new InvalidOperationException("Could not retrieve root item ID.");
+        if(root?.Id is null)
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve root item ID.");
 
-        var driveContext = new DriveContext(driveId, rootId);
+        var driveContext = new DriveContext(driveId, root.Id);
         _cache[accessToken] = driveContext;
 
-        return (client, driveContext);
+        return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, driveContext));
     }
 
     private sealed record DriveContext(DriveId DriveId, string RootId);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -29,43 +29,44 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     public async Task<Result<DriveId, string>> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok ok)
-            return new Result<DriveId, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        return new Result<DriveId, string>.Ok(ok.Value.Item2.DriveId);
+        return contextResult.Match<Result<DriveId, string>>(
+            ctx => new Result<DriveId, string>.Ok(ctx.Ctx.DriveId),
+            error => new Result<DriveId, string>.Error(error));
     }
 
     /// <inheritdoc />
     public async Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
-            return new Result<List<DriveFolder>, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        (var client, var driveContext) = contextOk.Value;
+        return await contextResult.MatchAsync<Result<List<DriveFolder>, string>>(
+            async ctx =>
+            {
+                var response = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
+                    .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
 
-        var response = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
-            .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
+                List<DriveFolder> folders = [];
 
-        List<DriveFolder> folders = [];
+                var page = response;
+                while(page?.Value is not null)
+                {
+                    folders.AddRange(
+                        page.Value
+                            .Where(i => i.Folder is not null)
+                            .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: i.ParentReference?.Id)));
 
-        var page = response;
-        while(page?.Value is not null)
-        {
-            folders.AddRange(
-                page.Value
-                    .Where(i => i.Folder is not null)
-                    .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: i.ParentReference?.Id)));
+                    if(page.OdataNextLink is null)
+                        break;
 
-            if(page.OdataNextLink is null)
-                break;
+                    page = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
+                        .WithUrl(page.OdataNextLink)
+                        .GetAsync(cancellationToken: ct);
+                }
 
-            page = await client.Drives[driveContext.DriveId.Value].Items[driveContext.RootId].Children
-                .WithUrl(page.OdataNextLink)
-                .GetAsync(cancellationToken: ct);
-        }
-
-        return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
+                return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
+            },
+            error => new Result<List<DriveFolder>, string>.Error(error));
     }
 
     /// <inheritdoc />
@@ -105,19 +106,20 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     public async Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accessToken, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
-            return new Result<(long Total, long Used), string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        (var client, var ctx) = contextOk.Value;
+        return await contextResult.MatchAsync<Result<(long Total, long Used), string>>(
+            async ctx =>
+            {
+                var drive = await ctx.Client.Drives[ctx.Ctx.DriveId.Value]
+                    .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
 
-        var drive = await client.Drives[ctx.DriveId.Value]
-            .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
+                var quota = drive?.Quota is { Total: not null, Used: not null }
+                    ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
+                    : (0L, 0L);
 
-        var quota = drive?.Quota is { Total: not null, Used: not null }
-            ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
-            : (0L, 0L);
-
-        return new Result<(long Total, long Used), string>.Ok(quota);
+                return new Result<(long Total, long Used), string>.Ok(quota);
+            },
+            error => new Result<(long Total, long Used), string>.Error(error));
     }
 
     /// <inheritdoc />
@@ -153,47 +155,47 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     public async Task<Result<string, string>> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
-            return new Result<string, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        (var client, var ctx) = contextOk.Value;
+        return await contextResult.MatchAsync<Result<string, string>>(
+            async ctx =>
+            {
+                var item = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId]
+                    .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
+                    .ConfigureAwait(false);
 
-        var item = await client.Drives[ctx.DriveId.Value].Items[itemId]
-            .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
-            .ConfigureAwait(false);
+                if(item?.AdditionalData is null)
+                    return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
-        if(item?.AdditionalData is null)
-            return new Result<string, string>.Error($"No download URL available for item {itemId}.");
+                if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out var url) || url is null)
+                    return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
-        if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out var url) || url is null)
-            return new Result<string, string>.Error($"No download URL available for item {itemId}.");
-
-        return new Result<string, string>.Ok(url.ToString()!);
+                return new Result<string, string>.Ok(url.ToString()!);
+            },
+            error => new Result<string, string>.Error(error));
     }
 
     /// <inheritdoc />
     public async Task<Result<string, string>> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
-            return new Result<string, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        (var client, var ctx) = contextOk.Value;
-
-        return await uploadService.UploadAsync(client, ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false);
+        return await contextResult.MatchAsync<Result<string, string>>(
+            async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
+            error => new Result<string, string>.Error(error));
     }
 
     /// <inheritdoc />
     public async Task<Result<Unit, string>> DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
         var contextResult = await ResolveClientWithDriveContextAsync(accessToken, ct).ConfigureAwait(false);
-        if(contextResult is not Result<(GraphServiceClient, DriveContext), string>.Ok contextOk)
-            return new Result<Unit, string>.Error(((Result<(GraphServiceClient, DriveContext), string>.Error)contextResult).Reason);
 
-        (var client, var ctx) = contextOk.Value;
-        await client.Drives[ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
-
-        return new Result<Unit, string>.Ok(Unit.Default);
+        return await contextResult.MatchAsync<Result<Unit, string>>(
+            async ctx =>
+            {
+                await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
+                return new Result<Unit, string>.Ok(Unit.Default);
+            },
+            error => new Result<Unit, string>.Error(error));
     }
 
     private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
@@ -24,8 +25,8 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     private readonly ConcurrentDictionary<string, DriveContext> _cache = [];
 
     /// <inheritdoc />
-    public async Task<DriveId> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
-        => (await ResolveClientWithDriveContextAsync(accessToken, ct)).Ctx.DriveId;
+    public async Task<Result<DriveId, string>> GetDriveIdAsync(string accessToken, CancellationToken ct = default)
+        => new Result<DriveId, string>.Ok((await ResolveClientWithDriveContextAsync(accessToken, ct)).Ctx.DriveId);
 
     /// <inheritdoc />
     public async Task<List<DriveFolder>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default)
@@ -132,7 +133,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<string?> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default)
+    public async Task<Result<string, string>> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default)
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
@@ -141,11 +142,12 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             .ConfigureAwait(false);
 
         if(item?.AdditionalData is null)
-            return null;
+            return new Result<string, string>.Error("No download URL available.");
 
-        return item.AdditionalData.TryGetValue(DownloadUrlKey, out var url)
-            ? url?.ToString()
-            : null;
+        if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out var url) || url is null)
+            return new Result<string, string>.Error("No download URL available.");
+
+        return new Result<string, string>.Ok(url.ToString()!);
     }
 
     /// <inheritdoc />
@@ -153,7 +155,12 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         (var client, var ctx) = await ResolveClientWithDriveContextAsync(accessToken, ct);
 
-        return await uploadService.UploadAsync(client, ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct);
+        var uploadResult = await uploadService.UploadAsync(client, ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct);
+
+        return uploadResult.Match(
+            itemId => itemId,
+            error  => throw new InvalidOperationException($"Upload failed: {error}")
+        );
     }
 
     /// <inheritdoc />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 
@@ -6,7 +7,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 public interface IGraphService
 {
     /// <summary>Returns the ID of the user's default drive (OneDrive for Business or Personal).</summary>
-    Task<DriveId> GetDriveIdAsync(string accessToken, CancellationToken ct = default);
+    Task<Result<DriveId, string>> GetDriveIdAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the root folder.</summary>
     Task<List<DriveFolder>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default);
@@ -24,7 +25,7 @@ public interface IGraphService
     Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);
 
     /// <summary>Fetches the pre-authenticated download URL for a specific drive item.</summary>
-    Task<string?> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default);
+    Task<Result<string, string>> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default);
 
     /// <summary>Uploads a local file to OneDrive using a resumable upload session. Returns the remote item ID on success.</summary>
     Task<string> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using System.Reactive;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
@@ -10,16 +11,16 @@ public interface IGraphService
     Task<Result<DriveId, string>> GetDriveIdAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the root folder.</summary>
-    Task<List<DriveFolder>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default);
+    Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the given parent folder. Used for lazy-loading the folder tree.</summary>
-    Task<List<DriveFolder>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default);
+    Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default);
 
     /// <summary>Returns the user's OneDrive storage quota.</summary>
-    Task<(long Total, long Used)> GetQuotaAsync(string accessToken, CancellationToken ct = default);
+    Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accessToken, CancellationToken ct = default);
 
     /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<List<DeltaItem>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default);
+    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
     Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);
@@ -28,8 +29,8 @@ public interface IGraphService
     Task<Result<string, string>> GetDownloadUrlAsync(string accessToken, string itemId, CancellationToken ct = default);
 
     /// <summary>Uploads a local file to OneDrive using a resumable upload session. Returns the remote item ID on success.</summary>
-    Task<string> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default);
+    Task<Result<string, string>> UploadFileAsync(string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default);
 
     /// <summary>Permanently deletes the specified item from OneDrive (moves it to the recycle bin).</summary>
-    Task DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default);
+    Task<Result<Unit, string>> DeleteItemAsync(string accessToken, string itemId, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using System.Threading.Channels;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -90,8 +91,11 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
         Serilog.Log.Debug("[Worker {Id}] DownloadUrl absent for {Path} — fetching on-demand", workerId, job.Target.RelativePath);
 
-        var url = await graphService.GetDownloadUrlAsync(accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
+        var urlResult = await graphService.GetDownloadUrlAsync(accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
 
-        return url ?? throw new InvalidOperationException($"No download URL could be resolved for '{job.Target.RelativePath}' (itemId={job.Remote.RemoteItemId.Id}).");
+        return urlResult.Match(
+            url => url,
+            _   => throw new InvalidOperationException($"No download URL could be resolved for '{job.Target.RelativePath}' (itemId={job.Remote.RemoteItemId.Id}).")
+        );
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -35,17 +35,10 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
 
             try
             {
-                var jobResult = await ExecuteJobAsync(job, accessToken, ct).ConfigureAwait(false);
-
-                if(jobResult is Result<SyncJob, string>.Ok completedJobResult)
-                {
-                    currentJob = completedJobResult.Value;
-                    success = true;
-                }
-                else if(jobResult is Result<SyncJob, string>.Error jobErrorResult)
-                {
-                    error = jobErrorResult.Reason;
-                }
+                (currentJob, success, error) = await ExecuteJobAsync(job, accessToken, ct)
+                    .MatchAsync<SyncJob, string, (SyncJob, bool, string?)>(
+                        completedJob => (completedJob, true, null),
+                        reason => (currentJob, false, reason)).ConfigureAwait(false);
 
                 if(success)
                     await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed).ConfigureAwait(false);
@@ -77,40 +70,39 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
             case DownloadSyncJob downloadJob:
                 var urlResult = await ResolveDownloadUrlAsync(downloadJob, accessToken, ct).ConfigureAwait(false);
 
-                if(urlResult is not Result<string, string>.Ok urlOk)
-                {
-                    var urlError = ((Result<string, string>.Error)urlResult).Reason;
-                    Serilog.Log.Error("[Worker {Id}] Could not resolve download URL for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, urlError);
+                return await urlResult.MatchAsync<Result<SyncJob, string>>(
+                    async url =>
+                    {
+                        var downloadResult = await downloader.DownloadAsync(url, downloadJob.Target.LocalPath, downloadJob.Metadata.RemoteModified, ct: ct).ConfigureAwait(false);
 
-                    return new Result<SyncJob, string>.Error(urlError);
-                }
-
-                var downloadResult = await downloader.DownloadAsync(urlOk.Value, downloadJob.Target.LocalPath, downloadJob.Metadata.RemoteModified, ct: ct).ConfigureAwait(false);
-
-                if(downloadResult is not Result<Unit, string>.Ok)
-                {
-                    var downloadError = ((Result<Unit, string>.Error)downloadResult).Reason;
-                    Serilog.Log.Error("[Worker {Id}] Download failed for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, downloadError);
-
-                    return new Result<SyncJob, string>.Error(downloadError);
-                }
-
-                return new Result<SyncJob, string>.Ok(downloadJob);
+                        return downloadResult.Match<Result<SyncJob, string>>(
+                            _ => new Result<SyncJob, string>.Ok(downloadJob),
+                            downloadError =>
+                            {
+                                Serilog.Log.Error("[Worker {Id}] Download failed for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, downloadError);
+                                return new Result<SyncJob, string>.Error(downloadError);
+                            });
+                    },
+                    urlError =>
+                    {
+                        Serilog.Log.Error("[Worker {Id}] Could not resolve download URL for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, urlError);
+                        return new Result<SyncJob, string>.Error(urlError);
+                    });
 
             case UploadSyncJob uploadJob:
                 var uploadResult = await graphService.UploadFileAsync(accessToken, uploadJob.Target.LocalPath, uploadJob.Target.RelativePath, parentFolderId: uploadJob.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
 
-                if(uploadResult is not Result<string, string>.Ok uploadOk)
-                {
-                    var uploadError = ((Result<string, string>.Error)uploadResult).Reason;
-                    Serilog.Log.Error("[Worker {Id}] Upload failed for {Path}: {Error}", workerId, uploadJob.Target.RelativePath, uploadError);
-
-                    return new Result<SyncJob, string>.Error(uploadError);
-                }
-
-                Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, uploadJob.Target.RelativePath);
-
-                return new Result<SyncJob, string>.Ok(uploadJob with { UploadedRemoteItemId = uploadOk.Value });
+                return uploadResult.Match<Result<SyncJob, string>>(
+                    itemId =>
+                    {
+                        Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, uploadJob.Target.RelativePath);
+                        return new Result<SyncJob, string>.Ok(uploadJob with { UploadedRemoteItemId = itemId });
+                    },
+                    uploadError =>
+                    {
+                        Serilog.Log.Error("[Worker {Id}] Upload failed for {Path}: {Error}", workerId, uploadJob.Target.RelativePath, uploadError);
+                        return new Result<SyncJob, string>.Error(uploadError);
+                    });
 
             case DeleteSyncJob deleteJob:
                 if(fileSystem.File.Exists(deleteJob.Target.LocalPath))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using System.Reactive;
 using System.Threading.Channels;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
@@ -26,18 +27,30 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
                 "[Worker {Id}] Processing {JobType} {Path}",
                 workerId, job.GetType().Name, job.Target.RelativePath);
 
-            await syncRepository.UpdateJobStateAsync(
-                job.Status.Id, SyncJobState.InProgress).ConfigureAwait(false);
+            await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.InProgress).ConfigureAwait(false);
 
-            string? error   = null;
-            bool     success = false;
             var currentJob = job;
+            string? error = null;
+            bool success = false;
 
             try
             {
-                currentJob = await ExecuteJobAsync(job, accessToken, ct).ConfigureAwait(false);
-                success = true;
-                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed).ConfigureAwait(false);
+                var jobResult = await ExecuteJobAsync(job, accessToken, ct).ConfigureAwait(false);
+
+                if(jobResult is Result<SyncJob, string>.Ok completedJobResult)
+                {
+                    currentJob = completedJobResult.Value;
+                    success = true;
+                }
+                else if(jobResult is Result<SyncJob, string>.Error jobErrorResult)
+                {
+                    error = jobErrorResult.Reason;
+                }
+
+                if(success)
+                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed).ConfigureAwait(false);
+                else
+                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, error).ConfigureAwait(false);
             }
             catch(OperationCanceledException)
             {
@@ -57,45 +70,66 @@ public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGr
         }
     }
 
-    private async Task<SyncJob> ExecuteJobAsync(SyncJob job, string accessToken, CancellationToken ct)
+    private async Task<Result<SyncJob, string>> ExecuteJobAsync(SyncJob job, string accessToken, CancellationToken ct)
     {
         switch(job)
         {
             case DownloadSyncJob downloadJob:
-                string downloadUrl = await ResolveDownloadUrlAsync(downloadJob, accessToken, ct);
-                await downloader.DownloadAsync(downloadUrl, downloadJob.Target.LocalPath, downloadJob.Metadata.RemoteModified, ct: ct).ConfigureAwait(false);
+                var urlResult = await ResolveDownloadUrlAsync(downloadJob, accessToken, ct).ConfigureAwait(false);
 
-                return downloadJob;
+                if(urlResult is not Result<string, string>.Ok urlOk)
+                {
+                    var urlError = ((Result<string, string>.Error)urlResult).Reason;
+                    Serilog.Log.Error("[Worker {Id}] Could not resolve download URL for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, urlError);
+
+                    return new Result<SyncJob, string>.Error(urlError);
+                }
+
+                var downloadResult = await downloader.DownloadAsync(urlOk.Value, downloadJob.Target.LocalPath, downloadJob.Metadata.RemoteModified, ct: ct).ConfigureAwait(false);
+
+                if(downloadResult is not Result<Unit, string>.Ok)
+                {
+                    var downloadError = ((Result<Unit, string>.Error)downloadResult).Reason;
+                    Serilog.Log.Error("[Worker {Id}] Download failed for {Path}: {Error}", workerId, downloadJob.Target.RelativePath, downloadError);
+
+                    return new Result<SyncJob, string>.Error(downloadError);
+                }
+
+                return new Result<SyncJob, string>.Ok(downloadJob);
 
             case UploadSyncJob uploadJob:
-                string uploadedRemoteItemId = await graphService.UploadFileAsync(accessToken, uploadJob.Target.LocalPath, uploadJob.Target.RelativePath, parentFolderId: uploadJob.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
+                var uploadResult = await graphService.UploadFileAsync(accessToken, uploadJob.Target.LocalPath, uploadJob.Target.RelativePath, parentFolderId: uploadJob.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
+
+                if(uploadResult is not Result<string, string>.Ok uploadOk)
+                {
+                    var uploadError = ((Result<string, string>.Error)uploadResult).Reason;
+                    Serilog.Log.Error("[Worker {Id}] Upload failed for {Path}: {Error}", workerId, uploadJob.Target.RelativePath, uploadError);
+
+                    return new Result<SyncJob, string>.Error(uploadError);
+                }
+
                 Serilog.Log.Information("[Worker {Id}] Uploaded {Path}", workerId, uploadJob.Target.RelativePath);
 
-                return uploadJob with { UploadedRemoteItemId = uploadedRemoteItemId };
+                return new Result<SyncJob, string>.Ok(uploadJob with { UploadedRemoteItemId = uploadOk.Value });
 
             case DeleteSyncJob deleteJob:
                 if(fileSystem.File.Exists(deleteJob.Target.LocalPath))
                     fileSystem.File.Delete(deleteJob.Target.LocalPath);
 
-                return deleteJob;
+                return new Result<SyncJob, string>.Ok(deleteJob);
 
             default:
-                return job;
+                return new Result<SyncJob, string>.Ok(job);
         }
     }
 
-    private async Task<string> ResolveDownloadUrlAsync(DownloadSyncJob job, string accessToken, CancellationToken ct)
+    private async Task<Result<string, string>> ResolveDownloadUrlAsync(DownloadSyncJob job, string accessToken, CancellationToken ct)
     {
         if(job.DownloadUrl is not null)
-            return job.DownloadUrl;
+            return new Result<string, string>.Ok(job.DownloadUrl);
 
         Serilog.Log.Debug("[Worker {Id}] DownloadUrl absent for {Path} — fetching on-demand", workerId, job.Target.RelativePath);
 
-        var urlResult = await graphService.GetDownloadUrlAsync(accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
-
-        return urlResult.Match(
-            url => url,
-            _   => throw new InvalidOperationException($"No download URL could be resolved for '{job.Target.RelativePath}' (itemId={job.Remote.RemoteItemId.Id}).")
-        );
+        return await graphService.GetDownloadUrlAsync(accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
@@ -39,7 +39,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
                     if(attempt > MaxRetries)
-                        throw new HttpRequestException($"Rate limited after {MaxRetries} retries.");
+                        return new Result<Unit, string>.Error($"Rate limited after {MaxRetries} retries.");
 
                     var delay = GetRetryDelay(response, attempt);
                     Serilog.Log.Warning("[HttpDownloader] 429 received, waiting {Delay:F1}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt, MaxRetries);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
@@ -1,4 +1,6 @@
 using System.IO.Abstractions;
+using System.Reactive;
+using AStar.Dev.Functional.Extensions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -16,7 +18,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
     private const double MaxDelaySeconds  = 120.0;
 
     /// <inheritdoc />
-    public async Task DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
+    public async Task<Result<Unit, string>> DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
     {
         using var http = httpClientFactory.CreateClient();
         http.DefaultRequestHeaders.Add("User-Agent", UserAgent);
@@ -56,7 +58,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
                 PreserveRemoteTimestamp(localPath, remoteModified);
 
-                return;
+                return new Result<Unit, string>.Ok(Unit.Default);
             }
             catch(HttpRequestException) when(attempt <= MaxRetries)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IHttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IHttpDownloader.cs
@@ -1,3 +1,6 @@
+using AStar.Dev.Functional.Extensions;
+using System.Reactive;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 public interface IHttpDownloader
@@ -7,5 +10,5 @@ public interface IHttpDownloader
     /// Automatically retries on 429 with exponential backoff.
     /// Preserves the remote last-modified timestamp on the local file.
     /// </summary>
-    Task DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default);
+    Task<Result<Unit, string>> DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IUploadService.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using Microsoft.Graph;
 
@@ -9,5 +10,5 @@ public interface IUploadService
     /// Uploads a local file to OneDrive using a resumable upload session.
     /// Returns the uploaded DriveItem ID on success.
     /// </summary>
-    Task<string> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default);
+    Task<Result<string, string>> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
@@ -1,4 +1,6 @@
 using System.IO.Abstractions;
+using System.Reactive;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -22,8 +24,17 @@ public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedIte
 
             try
             {
-                await graphService.DeleteItemAsync(accessToken, remoteId, ct);
-                await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+                var deleteResult = await graphService.DeleteItemAsync(accessToken, remoteId, ct);
+
+                if(deleteResult is Result<Unit, string>.Ok)
+                {
+                    Serilog.Log.Debug("[LocalDeletionDetector] Deleted remote item {RemoteId}", remoteId);
+                    await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+                }
+                else if(deleteResult is Result<Unit, string>.Error deleteError)
+                {
+                    Serilog.Log.Error("[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, deleteError.Reason);
+                }
             }
             catch(Exception ex)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
@@ -26,15 +26,18 @@ public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedIte
             {
                 var deleteResult = await graphService.DeleteItemAsync(accessToken, remoteId, ct);
 
-                if(deleteResult is Result<Unit, string>.Ok)
-                {
-                    Serilog.Log.Debug("[LocalDeletionDetector] Deleted remote item {RemoteId}", remoteId);
-                    await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
-                }
-                else if(deleteResult is Result<Unit, string>.Error deleteError)
-                {
-                    Serilog.Log.Error("[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, deleteError.Reason);
-                }
+                await deleteResult.MatchAsync<Unit>(
+                    async _ =>
+                    {
+                        Serilog.Log.Debug("[LocalDeletionDetector] Deleted remote item {RemoteId}", remoteId);
+                        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+                        return Unit.Default;
+                    },
+                    deleteError =>
+                    {
+                        Serilog.Log.Error("[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, deleteError);
+                        return Unit.Default;
+                    });
             }
             catch(Exception ex)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -29,18 +29,25 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
         var driveIdResult = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
-        var driveId = driveIdResult.Match(
-            id    => id,
-            error => throw new InvalidOperationException($"Failed to retrieve drive ID: {error}")
-        );
 
-        var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
+        if(driveIdResult is not Result<DriveId, string>.Ok driveIdOk)
+        {
+            var error = driveIdResult is Result<DriveId, string>.Error driveIdError
+                ? driveIdError.Reason
+                : "Failed to retrieve drive ID.";
+            Serilog.Log.Error("[RemoteFolderEnumerator] {Error}", error);
+
+            return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: false);
+        }
+
+        var driveId = driveIdOk.Value;
+        var includeRules = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules
             .Where(rule => !includeRules.Any(other => other.RemotePath != rule.RemotePath && rule.RemotePath.StartsWith(other.RemotePath + "/", StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
-        List<SyncJob> downloadJobs  = [];
-        var seenRemoteIds           = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        List<SyncJob> downloadJobs = [];
+        var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach(var rule in rootIncludeRules)
         {
@@ -56,10 +63,20 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Profile.Email);
-            var items = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct).ConfigureAwait(false);
-            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
+            var itemsResult = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct).ConfigureAwait(false);
 
-            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
+            if(itemsResult is not Result<List<DeltaItem>, string>.Ok itemsOk)
+            {
+                var error = itemsResult is Result<List<DeltaItem>, string>.Error itemsError
+                    ? itemsError.Reason
+                    : "Failed to enumerate folder.";
+                Serilog.Log.Error("[RemoteFolderEnumerator] Failed to enumerate {Path}: {Error}", rule.RemotePath, error);
+                continue;
+            }
+
+            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", itemsOk.Value.Count, rule.RemotePath);
+
+            await ProcessItemsForRuleAsync(account, itemsOk.Value, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
         }
 
         return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
@@ -108,6 +125,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         if(knownItem?.Tags.ETag is not null && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
         {
             Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.Path.RelativePath);
+
             return;
         }
 
@@ -120,6 +138,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             {
                 var conflict = BuildConflict(account, item, localPath, localModified);
                 await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict).ConfigureAwait(false);
+
                 return;
             }
         }
@@ -129,6 +148,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.Path.EffectivePath, localPath);
             await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
             syncedItems[item.Id.Id] = phantomItem;
+
             return;
         }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -28,19 +28,17 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         }
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
-        var driveIdResult = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
+        var driveId = await graphService.GetDriveIdAsync(accessToken, ct)
+            .MatchAsync<DriveId, string, DriveId?>(
+                id => id,
+                error =>
+                {
+                    Serilog.Log.Error("[RemoteFolderEnumerator] {Error}", error);
+                    return null;
+                }).ConfigureAwait(false);
 
-        if(driveIdResult is not Result<DriveId, string>.Ok driveIdOk)
-        {
-            var error = driveIdResult is Result<DriveId, string>.Error driveIdError
-                ? driveIdError.Reason
-                : "Failed to retrieve drive ID.";
-            Serilog.Log.Error("[RemoteFolderEnumerator] {Error}", error);
-
+        if(driveId is null)
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: false);
-        }
-
-        var driveId = driveIdOk.Value;
         var includeRules = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules
             .Where(rule => !includeRules.Any(other => other.RemotePath != rule.RemotePath && rule.RemotePath.StartsWith(other.RemotePath + "/", StringComparison.OrdinalIgnoreCase)))
@@ -54,7 +52,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             if(ct.IsCancellationRequested)
                 break;
 
-            var folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId, ct).ConfigureAwait(false);
+            var folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId.Value, ct).ConfigureAwait(false);
 
             if(folderId is null)
             {
@@ -63,20 +61,21 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Profile.Email);
-            var itemsResult = await graphService.EnumerateFolderAsync(accessToken, driveId, folderId, rule.RemotePath, ct).ConfigureAwait(false);
+            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, ct)
+                .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
+                    deltaItems => deltaItems,
+                    error =>
+                    {
+                        Serilog.Log.Error("[RemoteFolderEnumerator] Failed to enumerate {Path}: {Error}", rule.RemotePath, error);
+                        return null;
+                    }).ConfigureAwait(false);
 
-            if(itemsResult is not Result<List<DeltaItem>, string>.Ok itemsOk)
-            {
-                var error = itemsResult is Result<List<DeltaItem>, string>.Error itemsError
-                    ? itemsError.Reason
-                    : "Failed to enumerate folder.";
-                Serilog.Log.Error("[RemoteFolderEnumerator] Failed to enumerate {Path}: {Error}", rule.RemotePath, error);
+            if(items is null)
                 continue;
-            }
 
-            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", itemsOk.Value.Count, rule.RemotePath);
+            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
 
-            await ProcessItemsForRuleAsync(account, itemsOk.Value, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
+            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
         }
 
         return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
@@ -27,7 +28,11 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         }
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
-        var driveId = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
+        var driveIdResult = await graphService.GetDriveIdAsync(accessToken, ct).ConfigureAwait(false);
+        var driveId = driveIdResult.Match(
+            id    => id,
+            error => throw new InvalidOperationException($"Failed to retrieve drive ID: {error}")
+        );
 
         var includeRules     = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -98,8 +98,11 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         switch (outcome)
         {
             case ConflictOutcome.UseRemote:
-                string downloadUrl = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false)
-                    ?? throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.Target.RelativePath}' (itemId={conflict.Remote.RemoteItemId.Id}).");
+                var urlResult = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
+                string downloadUrl = urlResult.Match(
+                    url   => url,
+                    _     => throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.Target.RelativePath}' (itemId={conflict.Remote.RemoteItemId.Id}).")
+                );
 
                 await httpDownloader.DownloadAsync(downloadUrl, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
                 break;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -30,17 +30,17 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         Serilog.Log.Information("[SyncService] SyncAccountAsync for {Email}", account.Profile.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
-        var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
+        var accessToken = await authService.AcquireTokenSilentAsync(account.Id.Id, ct)
+            .MatchAsync<AuthResult, AuthError, string?>(
+                ok => ok.AccessToken,
+                error =>
+                {
+                    RaiseProgress(account.Id.Id, 0, 0, error is AuthFailedError failed ? failed.Message : "Auth failed", SyncState.Error);
+                    return null;
+                }).ConfigureAwait(false);
 
-        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
-        {
-            var errorMessage = authResult is Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }
-                ? failed.Message
-                : "Auth failed";
-            RaiseProgress(account.Id.Id, 0, 0, errorMessage, SyncState.Error);
-
+        if(accessToken is null)
             return;
-        }
 
         if(account.SyncConfig is null)
         {
@@ -53,7 +53,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
         {
             var didRun = await syncPassOrchestrator.OrchestrateAsync(
                 account,
-                authOk.Value.AccessToken,
+                accessToken,
                 async conflict =>
                 {
                     await syncRepository.AddConflictAsync(conflict).ConfigureAwait(false);
@@ -85,14 +85,15 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     /// <inheritdoc />
     public async Task ResolveConflictAsync(SyncConflict conflict, ConflictPolicy policy, CancellationToken ct = default)
     {
-        var authResult = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct).ConfigureAwait(false);
+        var accessToken = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct)
+            .MatchAsync<AuthResult, AuthError, string?>(ok => ok.AccessToken, _ => null).ConfigureAwait(false);
 
-        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
+        if(accessToken is null)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
 
-        await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, authOk.Value.AccessToken, ct).ConfigureAwait(false);
+        await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
         await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
     }
 
@@ -108,11 +109,14 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                     {
                         var downloadResult = await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
 
-                        if(downloadResult is Result<Unit, string>.Error downloadError)
-                        {
-                            Serilog.Log.Error("[SyncService] Download failed resolving conflict for {Path}: {Error}", conflict.Target.RelativePath, downloadError.Reason);
-                            RaiseProgress(accountId, 0, 0, downloadError.Reason, SyncState.Error);
-                        }
+                        downloadResult.Match<Unit>(
+                            _ => Unit.Default,
+                            downloadError =>
+                            {
+                                Serilog.Log.Error("[SyncService] Download failed resolving conflict for {Path}: {Error}", conflict.Target.RelativePath, downloadError);
+                                RaiseProgress(accountId, 0, 0, downloadError, SyncState.Error);
+                                return Unit.Default;
+                            });
                     },
                     error =>
                     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using System.Reactive;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
@@ -31,18 +32,20 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
 
         var authResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
 
-        if (authResult is not Result<AuthResult, AuthError>.Ok authOk)
+        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
         {
             var errorMessage = authResult is Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }
                 ? failed.Message
                 : "Auth failed";
             RaiseProgress(account.Id.Id, 0, 0, errorMessage, SyncState.Error);
+
             return;
         }
 
-        if (account.SyncConfig is null)
+        if(account.SyncConfig is null)
         {
             RaiseProgress(account.Id.Id, 0, 0, "No local sync path configured", SyncState.Error);
+
             return;
         }
 
@@ -60,7 +63,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 args => JobCompleted?.Invoke(this, args),
                 ct).ConfigureAwait(false);
 
-            if (!didRun)
+            if(!didRun)
                 RaiseProgress(account.Id.Id, 0, 0, "No folders selected", SyncState.Idle);
             else
             {
@@ -68,11 +71,11 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
                 RaiseProgress(account.Id.Id, 0, 0, "Sync complete", SyncState.Idle);
             }
         }
-        catch (OperationCanceledException)
+        catch(OperationCanceledException)
         {
             RaiseProgress(account.Id.Id, 0, 0, "Sync cancelled", SyncState.Idle);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             Serilog.Log.Error(ex, "[SyncService] Unhandled error syncing {Email}: {Error}", account.Profile.Email, ex.Message);
             RaiseProgress(account.Id.Id, 0, 0, ex.Message, SyncState.Error);
@@ -84,7 +87,7 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
     {
         var authResult = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct).ConfigureAwait(false);
 
-        if (authResult is not Result<AuthResult, AuthError>.Ok authOk)
+        if(authResult is not Result<AuthResult, AuthError>.Ok authOk)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
@@ -95,21 +98,34 @@ public sealed class SyncService(IAuthService authService, IAccountRepository acc
 
     private async Task ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
     {
-        switch (outcome)
+        switch(outcome)
         {
             case ConflictOutcome.UseRemote:
                 var urlResult = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
-                string downloadUrl = urlResult.Match(
-                    url   => url,
-                    _     => throw new InvalidOperationException($"No download URL could be resolved for conflict item '{conflict.Target.RelativePath}' (itemId={conflict.Remote.RemoteItemId.Id}).")
-                );
 
-                await httpDownloader.DownloadAsync(downloadUrl, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
+                await urlResult.Match(
+                    async url =>
+                    {
+                        var downloadResult = await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
+
+                        if(downloadResult is Result<Unit, string>.Error downloadError)
+                        {
+                            Serilog.Log.Error("[SyncService] Download failed resolving conflict for {Path}: {Error}", conflict.Target.RelativePath, downloadError.Reason);
+                            RaiseProgress(accountId, 0, 0, downloadError.Reason, SyncState.Error);
+                        }
+                    },
+                    error =>
+                    {
+                        Serilog.Log.Error("[SyncService] Could not resolve download URL for conflict item {Path}: {Error}", conflict.Target.RelativePath, error);
+                        RaiseProgress(accountId, 0, 0, error, SyncState.Error);
+
+                        return Task.CompletedTask;
+                    });
                 break;
 
             case ConflictOutcome.KeepBoth:
                 string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
-                if (fileSystem.File.Exists(conflict.Target.LocalPath))
+                if(fileSystem.File.Exists(conflict.Target.LocalPath))
                     fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
                 break;
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -42,15 +42,17 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         var sessionResult = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
 
-        if(sessionResult is not Result<string, string>.Ok sessionOk)
-            return sessionResult;
+        return await sessionResult.MatchAsync<Result<string, string>>(
+            async sessionUrl =>
+            {
+                var uploadResult = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
 
-        var uploadResult = await UploadChunksAsync(sessionOk.Value, localPath, fileInfo.Length, progress, ct);
+                if(uploadResult.Match(_ => true, _ => false))
+                    Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
 
-        if(uploadResult is Result<string, string>.Ok)
-            Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
-
-        return uploadResult;
+                return uploadResult;
+            },
+            error => new Result<string, string>.Error(error));
     }
 
     private static async Task<Result<string, string>> CreateSessionWithRetryAsync(GraphServiceClient client, string driveId, string parentFolderId, string remotePath, DateTime lastModified, CancellationToken ct)
@@ -108,14 +110,15 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             long rangeEnd = ComputeRangeEnd(uploaded, bytesRead);
             var chunkResult = await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
 
-            if(chunkResult is Result<string?, string>.Error chunkError)
-                return new Result<string, string>.Error(chunkError.Reason);
+            var earlyReturn = chunkResult.Match<Result<string, string>?>(
+                itemId => itemId is not null ? new Result<string, string>.Ok(itemId) : null,
+                error => new Result<string, string>.Error(error));
+
+            if(earlyReturn is not null)
+                return earlyReturn;
 
             uploaded += bytesRead;
             progress?.Report(uploaded);
-
-            if(chunkResult is Result<string?, string>.Ok { Value: not null } chunkOk)
-                return new Result<string, string>.Ok(chunkOk.Value);
         }
 
         return new Result<string, string>.Error("Upload completed without receiving item ID from Graph API.");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -36,22 +36,24 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
     {
         var fileInfo = fileSystem.FileInfo.New(localPath);
         if(!fileInfo.Exists)
-        {
-            throw new FileNotFoundException($"Local file not found: {localPath}");
-        }
+            return new Result<string, string>.Error($"Local file not found: {localPath}");
 
         Serilog.Log.Information("[UploadService] Starting upload: {Path} ({Size:F2} MB)", remotePath, fileInfo.Length / (1024.0 * 1024));
 
-        string sessionUrl = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
+        var sessionResult = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
 
-        var uploadResult = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
+        if(sessionResult is not Result<string, string>.Ok sessionOk)
+            return sessionResult;
 
-        Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
+        var uploadResult = await UploadChunksAsync(sessionOk.Value, localPath, fileInfo.Length, progress, ct);
+
+        if(uploadResult is Result<string, string>.Ok)
+            Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
 
         return uploadResult;
     }
 
-    private static async Task<string> CreateSessionWithRetryAsync(GraphServiceClient client, string driveId, string parentFolderId, string remotePath, DateTime lastModified, CancellationToken ct)
+    private static async Task<Result<string, string>> CreateSessionWithRetryAsync(GraphServiceClient client, string driveId, string parentFolderId, string remotePath, DateTime lastModified, CancellationToken ct)
     {
         string fileName = remotePath.Contains('/')
             ? remotePath[(remotePath.LastIndexOf('/') + 1)..]
@@ -81,9 +83,10 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             .CreateUploadSession
             .PostAsync(requestBody, cancellationToken: ct);
 
-        return session?.UploadUrl is null
-            ? throw new InvalidOperationException("Graph API did not return an upload session URL.")
-            : session.UploadUrl;
+        if(session?.UploadUrl is null)
+            return new Result<string, string>.Error("Graph API did not return an upload session URL.");
+
+        return new Result<string, string>.Ok(session.UploadUrl);
     }
 
     private async Task<Result<string, string>> UploadChunksAsync(string sessionUrl, string localPath, long totalBytes, IProgress<long>? progress, CancellationToken ct)
@@ -103,13 +106,16 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                 break;
 
             long rangeEnd = ComputeRangeEnd(uploaded, bytesRead);
-            string? itemId = await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
+            var chunkResult = await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
+
+            if(chunkResult is Result<string?, string>.Error chunkError)
+                return new Result<string, string>.Error(chunkError.Reason);
 
             uploaded += bytesRead;
             progress?.Report(uploaded);
 
-            if(itemId is not null)
-                return new Result<string, string>.Ok(itemId);
+            if(chunkResult is Result<string?, string>.Ok { Value: not null } chunkOk)
+                return new Result<string, string>.Ok(chunkOk.Value);
         }
 
         return new Result<string, string>.Error("Upload completed without receiving item ID from Graph API.");
@@ -124,7 +130,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
     private static long ComputeRangeEnd(long uploaded, int bytesRead) => uploaded + bytesRead - 1;
 
-    private static async Task<string?> UploadChunkWithRetryAsync(HttpClient http, string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
+    private static async Task<Result<string?, string>> UploadChunkWithRetryAsync(HttpClient http, string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
     {
         int attempt = 0;
 
@@ -145,9 +151,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                 if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
                     if(attempt > MaxRetries)
-                    {
-                        throw new HttpRequestException($"Upload rate limited after {MaxRetries} retries.");
-                    }
+                        return new Result<string?, string>.Error($"Upload rate limited after {MaxRetries} retries.");
 
                     var delay = GetRetryDelay(response, attempt);
                     Serilog.Log.Warning("[UploadService] 429 on chunk {Start}-{End}, waiting {Delay:F1}s (attempt {A}/{Max})", rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
@@ -157,14 +161,14 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                 }
 
                 if(response.StatusCode == System.Net.HttpStatusCode.Accepted)
-                    return null;
+                    return new Result<string?, string>.Ok(null);
 
                 if(response.StatusCode is System.Net.HttpStatusCode.Created or System.Net.HttpStatusCode.OK)
                     return await GetUploadedDocumentId(response, ct);
 
                 _ = response.EnsureSuccessStatusCode();
 
-                return null;
+                return new Result<string?, string>.Ok(null);
             }
             catch(HttpRequestException) when(attempt <= MaxRetries)
             {
@@ -176,15 +180,18 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
         }
     }
 
-    private static async Task<string?> GetUploadedDocumentId(HttpResponseMessage response, CancellationToken ct)
+    private static async Task<Result<string?, string>> GetUploadedDocumentId(HttpResponseMessage response, CancellationToken ct)
     {
         string json = await response.Content.ReadAsStringAsync(ct);
         using var doc = System.Text.Json.JsonDocument.Parse(json);
 
-        return doc.RootElement
-            .GetProperty("id")
-            .GetString()
-            ?? throw new InvalidOperationException("Upload response missing item ID.");
+        if(!doc.RootElement.TryGetProperty("id", out var idElement))
+            return new Result<string?, string>.Error("Upload response missing item ID.");
+        var itemId = idElement.GetString();
+        if(itemId is null)
+            return new Result<string?, string>.Error("Upload response missing item ID.");
+
+        return new Result<string?, string>.Ok(itemId);
     }
 
     private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
@@ -31,7 +32,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
     /// Uploads a local file to OneDrive using a resumable upload session.
     /// Returns the uploaded DriveItem ID on success.
     /// </summary>
-    public async Task<string> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default)
+    public async Task<Result<string, string>> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default)
     {
         var fileInfo = fileSystem.FileInfo.New(localPath);
         if(!fileInfo.Exists)
@@ -43,11 +44,11 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         string sessionUrl = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
 
-        string itemId = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
+        var uploadResult = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
 
-        Serilog.Log.Information("[UploadService] Upload complete: {Path} → {ItemId}", remotePath, itemId);
+        Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
 
-        return itemId;
+        return uploadResult;
     }
 
     private static async Task<string> CreateSessionWithRetryAsync(GraphServiceClient client, string driveId, string parentFolderId, string remotePath, DateTime lastModified, CancellationToken ct)
@@ -85,7 +86,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             : session.UploadUrl;
     }
 
-    private async Task<string> UploadChunksAsync(string sessionUrl, string localPath, long totalBytes, IProgress<long>? progress, CancellationToken ct)
+    private async Task<Result<string, string>> UploadChunksAsync(string sessionUrl, string localPath, long totalBytes, IProgress<long>? progress, CancellationToken ct)
     {
         using var http = httpClientFactory.CreateClient();
         await using var file = fileSystem.File.OpenRead(localPath);
@@ -108,10 +109,10 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             progress?.Report(uploaded);
 
             if(itemId is not null)
-                return itemId;
+                return new Result<string, string>.Ok(itemId);
         }
 
-        throw new InvalidOperationException("Upload completed without receiving item ID from Graph API.");
+        return new Result<string, string>.Error("Upload completed without receiving item ID from Graph API.");
     }
 
     private static async Task<int> ReadChunkAsync(Stream file, byte[] buffer, long totalBytes, long uploaded, CancellationToken ct)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -203,18 +203,19 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
 
         try
         {
-            var foldersResult = await graphService.GetRootFoldersAsync(_accessToken);
+            var folders = await graphService.GetRootFoldersAsync(_accessToken)
+                .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
+                    f => f,
+                    error =>
+                    {
+                        FolderLoadError = $"Could not load folders: {error}";
+                        return null;
+                    });
 
-            if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
-            {
-                FolderLoadError = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
-                    ? $"Could not load folders: {foldersError.Reason}"
-                    : "Could not load folders.";
-
+            if(folders is null)
                 return;
-            }
 
-            foreach(var f in foldersOk.Value)
+            foreach(var f in folders)
             {
                 Folders.Add(new WizardFolderItem(f.Id, f.Name)
                 {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -73,16 +73,16 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
     [RelayCommand]
     private void Back()
     {
-        if (CurrentStep == WizardStep.SelectFolders)
+        if(CurrentStep == WizardStep.SelectFolders)
             CurrentStep = WizardStep.SignIn;
-        else if (CurrentStep == WizardStep.Confirm)
+        else if(CurrentStep == WizardStep.Confirm)
             CurrentStep = WizardStep.SelectFolders;
     }
 
     [RelayCommand(CanExecute = nameof(CanGoNext))]
     private async Task NextAsync()
     {
-        switch (CurrentStep)
+        switch(CurrentStep)
         {
             case WizardStep.SignIn:
                 CurrentStep = WizardStep.SelectFolders;
@@ -103,7 +103,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
     [RelayCommand]
     private void SkipFolders()
     {
-        foreach (var f in Folders)
+        foreach(var f in Folders)
             f.IsSelected = false;
         BuildConfirmSummary();
         CurrentStep = WizardStep.Confirm;
@@ -112,7 +112,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
     [RelayCommand]
     private async Task OpenBrowserAsync()
     {
-        if (IsWaitingForAuth)
+        if(IsWaitingForAuth)
             return;
 
         SetInitialSignInState();
@@ -123,7 +123,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
         {
             var result = await authService.SignInInteractiveAsync(_authCts.Token);
 
-            switch (result)
+            switch(result)
             {
                 case Result<AuthResult, AuthError>.Ok successfulLoginResult:
                     UpdateSuccessfulLoginState(successfulLoginResult);
@@ -186,7 +186,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
     [RelayCommand]
     private async Task CancelAsync()
     {
-        if (_authCts is not null)
+        if(_authCts is not null)
             await _authCts.CancelAsync();
 
         Cancelled?.Invoke(this, EventArgs.Empty);
@@ -194,7 +194,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
 
     private async Task LoadFoldersAsync()
     {
-        if (_accessToken is null)
+        if(_accessToken is null)
             return;
 
         IsLoadingFolders = true;
@@ -203,10 +203,18 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
 
         try
         {
-            var driveFolders = await graphService
-                .GetRootFoldersAsync(_accessToken);
+            var foldersResult = await graphService.GetRootFoldersAsync(_accessToken);
 
-            foreach (var f in driveFolders)
+            if(foldersResult is not Result<List<DriveFolder>, string>.Ok foldersOk)
+            {
+                FolderLoadError = foldersResult is Result<List<DriveFolder>, string>.Error foldersError
+                    ? $"Could not load folders: {foldersError.Reason}"
+                    : "Could not load folders.";
+
+                return;
+            }
+
+            foreach(var f in foldersOk.Value)
             {
                 Folders.Add(new WizardFolderItem(f.Id, f.Name)
                 {
@@ -214,7 +222,7 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
                 });
             }
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             FolderLoadError = $"Could not load folders: {ex.Message}";
         }

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/.openspec.yaml
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/design.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`AStar.Dev.OneDrive.Sync.Client` already uses `Result<T, TError>` from `AStar.Dev.Functional.Extensions` at the auth layer (`IAuthService` returns `Result<AuthResult, AuthError>`). The infrastructure layer beneath it — `IGraphService`, `IUploadService`, `IHttpDownloader`, `DownloadWorker`, `SyncService` — still throws exceptions for predictable failures (null Graph API responses, exhausted retries, missing local files). Callers swallow these via broad `catch(Exception)` blocks in `DownloadWorker.RunAsync` and `SyncService.SyncAccountAsync`.
+
+All callers are in-tree. No external consumers of these interfaces exist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace all recoverable `throw` statements in infrastructure with `Result<T, string>` return values
+- Update all callers to use `Match`/`Map`/`Bind` — no error messages lost
+- Update interface signatures: `IUploadService`, `IHttpDownloader`, `IGraphService`
+- Update `AccountFilesViewModel` to use `Match` on `DriveId` option
+- All existing tests updated to assert on `Result` outcomes, not caught exceptions
+
+**Non-Goals:**
+
+- Changing the typed `AuthError` discriminated union — auth layer is already correct
+- Removing `NotSupportedException` throws in Avalonia `IValueConverter.ConvertBack` — required by Avalonia contract
+- Removing `UnreachableException` in `SyncRepository` switch arm — programming invariant, not runtime failure
+- Removing `FeatureAvailabilityService` guard throw — programming-error detection, not recoverable failure
+
+## Decisions
+
+### D1 — Error type is `string`, not a typed discriminated union
+
+**Choice:** `Result<T, string>` throughout infrastructure.
+
+**Rationale:** Auth already has a typed `AuthError` union because callers branch on error kind (silent fail vs. show UI vs. force re-auth). Infrastructure errors (Graph API gaps, upload exhaustion) are terminal for that operation — callers log and surface the message string, never branch on error kind. A typed union would add indirection with no consumer benefit.
+
+**Alternative considered:** `Result<T, Exception>` — rejected because it re-introduces exception semantics as data and forces callers to `.Message` everything anyway.
+
+### D2 — `IGraphService` surface area — only methods that currently throw are changed
+
+**Choice:** Change only `GetDriveIdAsync`, `GetRootFoldersAsync`, `GetChildFoldersAsync`, `GetQuotaAsync`, `EnumerateFolderAsync`, `GetDownloadUrlAsync`, `UploadFileAsync`, `DeleteItemAsync` to return `Result`-wrapped types. `GetFolderIdByPathAsync` already returns `string?` (null = not found, no throw) — leave unchanged.
+
+**New signatures:**
+- `Task<Result<DriveId, string>> GetDriveIdAsync(...)`
+- `Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(...)`
+- `Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(...)`
+- `Task<Result<(long Total, long Used), string>> GetQuotaAsync(...)`
+- `Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(...)`
+- `Task<Result<string, string>> GetDownloadUrlAsync(...)` (was `string?` — null case becomes `Error`)
+- `Task<Result<string, string>> UploadFileAsync(...)`
+- `Task<Result<Unit, string>> DeleteItemAsync(...)`
+
+### D3 — `IUploadService` and `IHttpDownloader` return Result
+
+**New signatures:**
+- `IUploadService.UploadAsync`: `Task<string>` → `Task<Result<string, string>>`
+- `IHttpDownloader.DownloadAsync`: `Task` → `Task<Result<Unit, string>>`
+
+Internal throws inside these implementations become early `return Result.Error("...")` returns. The outer `while(true)` retry loops propagate `Result.Error` when retry budget is exhausted instead of throwing `HttpRequestException`.
+
+### D4 — `DownloadWorker` uses `Match` on `ResolveDownloadUrlAsync`
+
+`ResolveDownloadUrlAsync` returns `Task<Result<string, string>>`. The caller uses:
+```csharp
+var urlResult = await ResolveDownloadUrlAsync(downloadJob, accessToken, ct);
+return urlResult.Match(
+    url  => /* proceed with download, return updated job */,
+    err  => /* log + return failed job — outer RunAsync marks as Failed */);
+```
+The existing `catch(Exception)` in `RunAsync` handles all other unhandled exceptions; `Result` covers the predictable URL-missing case.
+
+### D5 — `SyncService.ApplyConflictOutcomeAsync` uses `Bind`/`Match`
+
+```csharp
+var result = await graphService.GetDownloadUrlAsync(accessToken, ..., ct);
+await result.Match(
+    async url  => await httpDownloader.DownloadAsync(url, ..., ct),
+    async err  => { Serilog.Log.Error(...); /* RaiseProgress with error */ });
+```
+
+### D6 — `AccountFilesViewModel` removes inline throw from `Option.Match`
+
+Replace:
+```csharp
+() => throw new InvalidOperationException("Drive ID not available.")
+```
+With a no-op or log — the caller already guards against `_driveId` being `None` via UI state (button disabled when not loaded). If `None` is reached anyway, log a warning and return early rather than crash.
+
+### D7 — `GraphService.ResolveClientWithDriveContextAsync` returns Result internally
+
+Private method becomes `Task<Result<(GraphServiceClient, DriveContext), string>>`. All callers inside `GraphService` use `Bind`/`Map` to chain. Public methods propagate `Result.Error` on missing drive/root ID instead of throwing.
+
+## Risks / Trade-offs
+
+- **Async Match complexity** → Mitigation: `AStar.Dev.Functional.Extensions` provides `MatchAsync`/`BindAsync` — use these throughout; avoid `.Result` or manual `await` patterns inside lambdas
+- **Test churn** → tests asserting `Assert.ThrowsAsync<InvalidOperationException>` become `result.ShouldBeError()` assertions; scope is bounded to the affected test classes
+- **`DownloadWorker.RunAsync` already catches `Exception`** — after this change the broad catch becomes narrower since upload/download paths no longer throw predictable errors; `OperationCanceledException` re-throw path unchanged
+
+## Migration Plan
+
+1. Change `IUploadService`, `IHttpDownloader`, `IGraphService` interfaces
+2. Update `UploadService`, `HttpDownloader`, `GraphService` implementations
+3. Update `DownloadWorker`, `SyncService`, `AccountFilesViewModel` callers
+4. Update unit tests: replace `ThrowsAsync` assertions with `Result.Error` assertions
+5. `dotnet build` + `dotnet test` — zero errors, zero warnings required before PR
+6. Single PR — all callers in-tree, no staged rollout needed

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/proposal.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`AStar.Dev.OneDrive.Sync.Client` throws exceptions for predictable failure conditions (missing download URLs, Graph API gaps, upload exhaustion, missing files) — callers catch them with broad `catch(Exception)` blocks, hiding intent and making error propagation invisible in method signatures. Replacing throws with `Result<T, TError>` from `AStar.Dev.Functional.Extensions` makes failures first-class, enables `Match`/`Map`/`Bind` composition, and ensures users still see error messages without relying on exception semantics.
+
+## What Changes
+
+- `IUploadService.UploadAsync` returns `Task<Result<string, string>>` instead of `Task<string>`
+- `IHttpDownloader.DownloadAsync` returns `Task<Result<Unit, string>>` instead of `Task`
+- `IGraphService` — internal `ResolveClientWithDriveContextAsync` propagates `Result` so `GetDriveIdAsync`, `UploadFileAsync`, `DeleteItemAsync`, `GetRootFoldersAsync`, `GetChildFoldersAsync`, `GetQuotaAsync`, `EnumerateFolderAsync`, `GetDownloadUrlAsync` all return `Result`-wrapped types
+- `DownloadWorker.ResolveDownloadUrlAsync` returns `Result<string, string>` and uses `Match` to either proceed or mark job failed
+- `SyncService.ApplyConflictOutcomeAsync` uses `Bind`/`Match` on the download URL result instead of null-coalescing throw
+- `AccountFilesViewModel` uses `Match` on `DriveId` availability instead of inline throw
+- `SyncRepository` exhaustive switch arm reviewed — `UnreachableException` retained (programming invariant, not runtime failure)
+- Avalonia `IValueConverter.ConvertBack` throws (`NotSupportedException`) retained — required by Avalonia contract for one-way converters
+- `FeatureAvailabilityService` guard throw retained — programming-error guard, not a recoverable runtime failure
+
+## Capabilities
+
+### New Capabilities
+
+- `result-error-handling-in-sync-infrastructure`: Replace all recoverable `throw` statements in the sync/graph/download/upload infrastructure with `Result<T, string>`, surfacing error messages to callers via `Match`/`Map`/`Bind` rather than exception propagation
+
+### Modified Capabilities
+
+- `local-sync-path-value-object`: No requirement change — implementation detail only if `LocalSyncPath` factory methods surface validation errors via Result
+
+## Impact
+
+- `IUploadService`, `IHttpDownloader`, `IGraphService` interface signatures change — all callers updated in same PR
+- `DownloadWorker`, `SyncService`, `AccountFilesViewModel`, `GraphService` updated to consume Result
+- All existing tests covering these paths must be updated to assert on `Result` outcomes rather than exception throws
+- No user-facing error messages removed — all error strings preserved as `Result.Error` values and surfaced via `Match`

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/specs/result-error-handling-in-sync-infrastructure/spec.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/specs/result-error-handling-in-sync-infrastructure/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: UploadService returns Result on failure
+`IUploadService.UploadAsync` SHALL return `Task<Result<string, string>>`. On success the `Ok` value is the uploaded OneDrive item ID. On failure the `Error` value is a human-readable message. It SHALL NOT throw for predictable failures (missing local file, exhausted retries, missing item ID in Graph API response).
+
+#### Scenario: Local file does not exist
+- **WHEN** `UploadAsync` is called with a `localPath` that does not exist on disk
+- **THEN** the method returns `Result.Error("Local file not found: <localPath>")` without throwing
+
+#### Scenario: Graph API returns no upload session URL
+- **WHEN** the Graph API `createUploadSession` response has a null `UploadUrl`
+- **THEN** the method returns `Result.Error("Graph API did not return an upload session URL.")` without throwing
+
+#### Scenario: Retry budget exhausted during chunk upload
+- **WHEN** the upload chunk endpoint returns HTTP 429 more than `MaxRetries` consecutive times
+- **THEN** the method returns `Result.Error("Upload rate limited after 5 retries.")` without throwing
+
+#### Scenario: Graph API returns no item ID after upload completes
+- **WHEN** all chunks are accepted but the final response contains no `id` field
+- **THEN** the method returns `Result.Error("Upload completed without receiving item ID from Graph API.")` without throwing
+
+#### Scenario: Successful upload
+- **WHEN** `UploadAsync` is called with a valid file and the Graph API accepts all chunks
+- **THEN** the method returns `Result.Ok(<itemId>)` containing the remote item ID
+
+### Requirement: HttpDownloader returns Result on failure
+`IHttpDownloader.DownloadAsync` SHALL return `Task<Result<Unit, string>>`. On success the `Ok` value is `Unit`. On failure the `Error` value is a human-readable message. It SHALL NOT throw for predictable failures.
+
+#### Scenario: Retry budget exhausted during download
+- **WHEN** the download endpoint returns HTTP 429 more than `MaxRetries` consecutive times
+- **THEN** the method returns `Result.Error("Rate limited after 5 retries.")` without throwing
+
+#### Scenario: Successful download
+- **WHEN** `DownloadAsync` is called with a reachable URL
+- **THEN** the method returns `Result.Ok(Unit.Value)` and the file is written to `localPath`
+
+### Requirement: GraphService returns Result on infrastructure failures
+All `IGraphService` methods that previously threw `InvalidOperationException` for null Graph API responses SHALL return `Result`-wrapped types. Null or missing data from the Graph API SHALL produce `Result.Error` values rather than exceptions.
+
+#### Scenario: Drive ID unavailable from Graph API
+- **WHEN** `GetDriveIdAsync` is called and the Graph API returns a null drive ID
+- **THEN** the method returns `Result.Error("Could not retrieve drive ID.")` without throwing
+
+#### Scenario: Root item ID unavailable from Graph API
+- **WHEN** `GetDriveIdAsync` (via `ResolveClientWithDriveContextAsync`) succeeds for the drive but the root item has a null ID
+- **THEN** the method returns `Result.Error("Could not retrieve root item ID.")` without throwing
+
+#### Scenario: Download URL unavailable for item
+- **WHEN** `GetDownloadUrlAsync` is called and the item has no download URL in `AdditionalData`
+- **THEN** the method returns `Result.Error("No download URL available for item <itemId>.")` without throwing
+
+#### Scenario: Successful drive ID resolution
+- **WHEN** `GetDriveIdAsync` is called and the Graph API returns a valid drive
+- **THEN** the method returns `Result.Ok(<driveId>)` and the result is cached for subsequent calls
+
+### Requirement: DownloadWorker handles Result from infrastructure
+`DownloadWorker` SHALL use `Match` on the `Result` returned by `ResolveDownloadUrlAsync` and by `IHttpDownloader.DownloadAsync`. On error it SHALL log the message and mark the sync job as `Failed` with the error string. It SHALL NOT rely on exception propagation for these cases.
+
+#### Scenario: Download URL resolution fails
+- **WHEN** `ResolveDownloadUrlAsync` returns `Result.Error`
+- **THEN** the worker logs the error message, marks the job as `SyncJobState.Failed`, and invokes `onJobComplete` with `success = false` and the error string
+
+#### Scenario: Download succeeds
+- **WHEN** both URL resolution and `DownloadAsync` return `Result.Ok`
+- **THEN** the worker marks the job as `SyncJobState.Completed` and invokes `onJobComplete` with `success = true`
+
+### Requirement: SyncService resolves conflict download without throwing
+`SyncService.ApplyConflictOutcomeAsync` SHALL use `Match`/`Bind` on the `Result` returned by `IGraphService.GetDownloadUrlAsync`. On error it SHALL log the message and raise a progress event with `SyncState.Error`. It SHALL NOT throw.
+
+#### Scenario: Conflict download URL missing
+- **WHEN** `GetDownloadUrlAsync` returns `Result.Error` during conflict resolution
+- **THEN** the error message is logged and `RaiseProgress` is called with `SyncState.Error` and the error message
+
+#### Scenario: Conflict download succeeds
+- **WHEN** `GetDownloadUrlAsync` returns `Result.Ok` and the download completes
+- **THEN** the local file is overwritten with the remote version and no error is raised
+
+### Requirement: AccountFilesViewModel does not throw on missing DriveId
+`AccountFilesViewModel` SHALL NOT throw `InvalidOperationException` when `_driveId` is `Option.None`. When the `DriveId` is not available and an operation requires it, the method SHALL log a warning and return early.
+
+#### Scenario: DriveId not yet loaded when operation is triggered
+- **WHEN** an operation requiring `_driveId` executes while `_driveId` is `Option.None`
+- **THEN** a warning is logged and the operation returns without throwing
+
+#### Scenario: DriveId available
+- **WHEN** `_driveId` is `Option.Some` and an operation is triggered
+- **THEN** the operation proceeds using the `DriveId` value
+
+### Requirement: Avalonia converter ConvertBack retains NotSupportedException
+One-way Avalonia `IValueConverter` implementations SHALL continue to throw `NotSupportedException` in their `ConvertBack` method. This is required by the Avalonia binding contract for one-way converters.
+
+#### Scenario: ConvertBack called on one-way converter
+- **WHEN** `ConvertBack` is invoked on any of the sync-state or bool converters
+- **THEN** `NotSupportedException` is thrown

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
@@ -1,0 +1,79 @@
+## 1. Branch and Failing Tests
+
+- [x] 1.1 Create branch `refactor/replace-throws-with-result-onedrive-sync-client`
+- [x] 1.2 Write failing test: `UploadService` returns `Result.Error` when local file not found (was `Assert.ThrowsAsync<FileNotFoundException>`)
+- [x] 1.3 Write failing test: `UploadService` returns `Result.Error` when Graph API returns no upload session URL
+- [x] 1.4 Write failing test: `UploadService` returns `Result.Error` when retry budget exhausted (429)
+- [x] 1.5 Write failing test: `UploadService` returns `Result.Error` when upload completes with no item ID
+- [x] 1.6 Write failing test: `HttpDownloader` returns `Result.Error` when retry budget exhausted
+- [x] 1.7 Write failing test: `GraphService` returns `Result.Error` when Graph API returns null drive ID
+- [x] 1.8 Write failing test: `GraphService` returns `Result.Error` when Graph API returns null root item ID
+- [x] 1.9 Write failing test: `DownloadWorker` marks job `Failed` when URL resolution returns `Result.Error`
+- [x] 1.10 Commit failing tests on branch
+
+## 2. Interface Changes
+
+- [ ] 2.1 Update `IUploadService.UploadAsync` return type to `Task<Result<string, string>>`
+- [ ] 2.2 Update `IHttpDownloader.DownloadAsync` return type to `Task<Result<Unit, string>>`
+- [ ] 2.3 Update `IGraphService.GetDriveIdAsync` return type to `Task<Result<DriveId, string>>`
+- [ ] 2.4 Update `IGraphService.GetRootFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
+- [ ] 2.5 Update `IGraphService.GetChildFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
+- [ ] 2.6 Update `IGraphService.GetQuotaAsync` return type to `Task<Result<(long Total, long Used), string>>`
+- [ ] 2.7 Update `IGraphService.EnumerateFolderAsync` return type to `Task<Result<List<DeltaItem>, string>>`
+- [ ] 2.8 Update `IGraphService.GetDownloadUrlAsync` return type to `Task<Result<string, string>>` (was `string?`)
+- [ ] 2.9 Update `IGraphService.UploadFileAsync` return type to `Task<Result<string, string>>`
+- [ ] 2.10 Update `IGraphService.DeleteItemAsync` return type to `Task<Result<Unit, string>>`
+
+## 3. UploadService Implementation
+
+- [ ] 3.1 Replace `throw new FileNotFoundException(...)` with `return Result.Error("Local file not found: ...")` in `UploadAsync`
+- [ ] 3.2 Refactor `CreateSessionWithRetryAsync` to return `Task<Result<string, string>>`; replace ternary throw with `Result.Error`
+- [ ] 3.3 Refactor `UploadChunksAsync` to return `Task<Result<string, string>>`; replace `throw new InvalidOperationException("Upload completed...")` with `Result.Error`
+- [ ] 3.4 Refactor `UploadChunkWithRetryAsync` to return `Task<Result<string?, string>>`; replace `throw new HttpRequestException(...)` with `Result.Error`
+- [ ] 3.5 Refactor `GetUploadedDocumentId` to return `Task<Result<string, string>>`; replace null-coalescing throw with `Result.Error`
+- [ ] 3.6 Chain all private methods via `Bind`/`Map` in `UploadAsync`
+
+## 4. HttpDownloader Implementation
+
+- [ ] 4.1 Change `DownloadAsync` return type from `Task` to `Task<Result<Unit, string>>`
+- [ ] 4.2 Replace `throw new HttpRequestException(...)` on exhausted retries with `return Result.Error(...)`
+- [ ] 4.3 Return `Result.Ok(Unit.Value)` on successful download completion
+
+## 5. GraphService Implementation
+
+- [ ] 5.1 Refactor `ResolveClientWithDriveContextAsync` to return `Task<Result<(GraphServiceClient, DriveContext), string>>`
+- [ ] 5.2 Replace `throw new InvalidOperationException("Could not retrieve drive ID.")` with `Result.Error`
+- [ ] 5.3 Replace `throw new InvalidOperationException("Could not retrieve root item ID.")` with `Result.Error`
+- [ ] 5.4 Update all callers of `ResolveClientWithDriveContextAsync` inside `GraphService` to use `Bind`/`Map`
+- [ ] 5.5 Update `GetDownloadUrlAsync` to return `Result.Ok(url)` or `Result.Error("No download URL available for item <id>.")` instead of `string?`
+- [ ] 5.6 Propagate `Result` wrapping through all remaining `IGraphService` method implementations
+
+## 6. DownloadWorker Implementation
+
+- [ ] 6.1 Update `ResolveDownloadUrlAsync` return type to `Task<Result<string, string>>`
+- [ ] 6.2 Replace null-coalescing throw with `Result.Error` in `ResolveDownloadUrlAsync`
+- [ ] 6.3 Update `ExecuteJobAsync` download branch to use `Match` on `ResolveDownloadUrlAsync` result — log error and mark job failed on `Error`, proceed on `Ok`
+- [ ] 6.4 Update `ExecuteJobAsync` upload branch to use `Match` on `IGraphService.UploadFileAsync` result
+
+## 7. SyncService Implementation
+
+- [ ] 7.1 Update `ApplyConflictOutcomeAsync` `UseRemote` branch to use `Match`/`Bind` on `GetDownloadUrlAsync` result
+- [ ] 7.2 On `Result.Error` in conflict resolution: log error and call `RaiseProgress` with `SyncState.Error` and the error message
+- [ ] 7.3 Update callers of `IGraphService` methods in `SyncService` (if any) to handle `Result` return types
+
+## 8. AccountFilesViewModel Implementation
+
+- [ ] 8.1 Replace `() => throw new InvalidOperationException("Drive ID not available.")` in `Option.Match` with a warning log and early return
+
+## 9. Build Verification and Test Fixes
+
+- [ ] 9.1 Run `dotnet build` — resolve all compiler errors from interface signature changes
+- [ ] 9.2 Update all existing unit tests that used `Assert.ThrowsAsync` for the replaced throws to assert `Result.IsError` / `result.ShouldBeError()`
+- [ ] 9.3 Update any test doubles / mocks (`NSubstitute`) for `IUploadService`, `IHttpDownloader`, `IGraphService` to match new signatures
+- [ ] 9.4 Run `dotnet test` — all tests pass (new tests from task group 1 now green)
+
+## 10. Review and PR
+
+- [ ] 10.1 Request human review — do NOT commit without approval
+- [ ] 10.2 Address review feedback
+- [ ] 10.3 Commit to branch and raise GitHub PR referencing this change

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
@@ -76,4 +76,4 @@
 
 - [x] 10.1 Request human review — do NOT commit without approval
 - [ ] 10.2 Address review feedback
-- [ ] 10.3 Commit to branch and raise GitHub PR referencing this change
+- [x] 10.3 Commit to branch and raise GitHub PR referencing this change

--- a/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
+++ b/openspec/changes/replace-throws-with-result-onedrive-sync-client/tasks.md
@@ -13,67 +13,67 @@
 
 ## 2. Interface Changes
 
-- [ ] 2.1 Update `IUploadService.UploadAsync` return type to `Task<Result<string, string>>`
-- [ ] 2.2 Update `IHttpDownloader.DownloadAsync` return type to `Task<Result<Unit, string>>`
-- [ ] 2.3 Update `IGraphService.GetDriveIdAsync` return type to `Task<Result<DriveId, string>>`
-- [ ] 2.4 Update `IGraphService.GetRootFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
-- [ ] 2.5 Update `IGraphService.GetChildFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
-- [ ] 2.6 Update `IGraphService.GetQuotaAsync` return type to `Task<Result<(long Total, long Used), string>>`
-- [ ] 2.7 Update `IGraphService.EnumerateFolderAsync` return type to `Task<Result<List<DeltaItem>, string>>`
-- [ ] 2.8 Update `IGraphService.GetDownloadUrlAsync` return type to `Task<Result<string, string>>` (was `string?`)
-- [ ] 2.9 Update `IGraphService.UploadFileAsync` return type to `Task<Result<string, string>>`
-- [ ] 2.10 Update `IGraphService.DeleteItemAsync` return type to `Task<Result<Unit, string>>`
+- [x] 2.1 Update `IUploadService.UploadAsync` return type to `Task<Result<string, string>>`
+- [x] 2.2 Update `IHttpDownloader.DownloadAsync` return type to `Task<Result<Unit, string>>`
+- [x] 2.3 Update `IGraphService.GetDriveIdAsync` return type to `Task<Result<DriveId, string>>`
+- [x] 2.4 Update `IGraphService.GetRootFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
+- [x] 2.5 Update `IGraphService.GetChildFoldersAsync` return type to `Task<Result<List<DriveFolder>, string>>`
+- [x] 2.6 Update `IGraphService.GetQuotaAsync` return type to `Task<Result<(long Total, long Used), string>>`
+- [x] 2.7 Update `IGraphService.EnumerateFolderAsync` return type to `Task<Result<List<DeltaItem>, string>>`
+- [x] 2.8 Update `IGraphService.GetDownloadUrlAsync` return type to `Task<Result<string, string>>` (was `string?`)
+- [x] 2.9 Update `IGraphService.UploadFileAsync` return type to `Task<Result<string, string>>`
+- [x] 2.10 Update `IGraphService.DeleteItemAsync` return type to `Task<Result<Unit, string>>`
 
 ## 3. UploadService Implementation
 
-- [ ] 3.1 Replace `throw new FileNotFoundException(...)` with `return Result.Error("Local file not found: ...")` in `UploadAsync`
-- [ ] 3.2 Refactor `CreateSessionWithRetryAsync` to return `Task<Result<string, string>>`; replace ternary throw with `Result.Error`
-- [ ] 3.3 Refactor `UploadChunksAsync` to return `Task<Result<string, string>>`; replace `throw new InvalidOperationException("Upload completed...")` with `Result.Error`
-- [ ] 3.4 Refactor `UploadChunkWithRetryAsync` to return `Task<Result<string?, string>>`; replace `throw new HttpRequestException(...)` with `Result.Error`
-- [ ] 3.5 Refactor `GetUploadedDocumentId` to return `Task<Result<string, string>>`; replace null-coalescing throw with `Result.Error`
-- [ ] 3.6 Chain all private methods via `Bind`/`Map` in `UploadAsync`
+- [x] 3.1 Replace `throw new FileNotFoundException(...)` with `return Result.Error("Local file not found: ...")` in `UploadAsync`
+- [x] 3.2 Refactor `CreateSessionWithRetryAsync` to return `Task<Result<string, string>>`; replace ternary throw with `Result.Error`
+- [x] 3.3 Refactor `UploadChunksAsync` to return `Task<Result<string, string>>`; replace `throw new InvalidOperationException("Upload completed...")` with `Result.Error`
+- [x] 3.4 Refactor `UploadChunkWithRetryAsync` to return `Task<Result<string?, string>>`; replace `throw new HttpRequestException(...)` with `Result.Error`
+- [x] 3.5 Refactor `GetUploadedDocumentId` to return `Task<Result<string, string>>`; replace null-coalescing throw with `Result.Error`
+- [x] 3.6 Chain all private methods via `Bind`/`Map` in `UploadAsync`
 
 ## 4. HttpDownloader Implementation
 
-- [ ] 4.1 Change `DownloadAsync` return type from `Task` to `Task<Result<Unit, string>>`
-- [ ] 4.2 Replace `throw new HttpRequestException(...)` on exhausted retries with `return Result.Error(...)`
-- [ ] 4.3 Return `Result.Ok(Unit.Value)` on successful download completion
+- [x] 4.1 Change `DownloadAsync` return type from `Task` to `Task<Result<Unit, string>>`
+- [x] 4.2 Replace `throw new HttpRequestException(...)` on exhausted retries with `return Result.Error(...)`
+- [x] 4.3 Return `Result.Ok(Unit.Value)` on successful download completion
 
 ## 5. GraphService Implementation
 
-- [ ] 5.1 Refactor `ResolveClientWithDriveContextAsync` to return `Task<Result<(GraphServiceClient, DriveContext), string>>`
-- [ ] 5.2 Replace `throw new InvalidOperationException("Could not retrieve drive ID.")` with `Result.Error`
-- [ ] 5.3 Replace `throw new InvalidOperationException("Could not retrieve root item ID.")` with `Result.Error`
-- [ ] 5.4 Update all callers of `ResolveClientWithDriveContextAsync` inside `GraphService` to use `Bind`/`Map`
-- [ ] 5.5 Update `GetDownloadUrlAsync` to return `Result.Ok(url)` or `Result.Error("No download URL available for item <id>.")` instead of `string?`
-- [ ] 5.6 Propagate `Result` wrapping through all remaining `IGraphService` method implementations
+- [x] 5.1 Refactor `ResolveClientWithDriveContextAsync` to return `Task<Result<(GraphServiceClient, DriveContext), string>>`
+- [x] 5.2 Replace `throw new InvalidOperationException("Could not retrieve drive ID.")` with `Result.Error`
+- [x] 5.3 Replace `throw new InvalidOperationException("Could not retrieve root item ID.")` with `Result.Error`
+- [x] 5.4 Update all callers of `ResolveClientWithDriveContextAsync` inside `GraphService` to use `Bind`/`Map`
+- [x] 5.5 Update `GetDownloadUrlAsync` to return `Result.Ok(url)` or `Result.Error("No download URL available for item <id>.")` instead of `string?`
+- [x] 5.6 Propagate `Result` wrapping through all remaining `IGraphService` method implementations
 
 ## 6. DownloadWorker Implementation
 
-- [ ] 6.1 Update `ResolveDownloadUrlAsync` return type to `Task<Result<string, string>>`
-- [ ] 6.2 Replace null-coalescing throw with `Result.Error` in `ResolveDownloadUrlAsync`
-- [ ] 6.3 Update `ExecuteJobAsync` download branch to use `Match` on `ResolveDownloadUrlAsync` result — log error and mark job failed on `Error`, proceed on `Ok`
-- [ ] 6.4 Update `ExecuteJobAsync` upload branch to use `Match` on `IGraphService.UploadFileAsync` result
+- [x] 6.1 Update `ResolveDownloadUrlAsync` return type to `Task<Result<string, string>>`
+- [x] 6.2 Replace null-coalescing throw with `Result.Error` in `ResolveDownloadUrlAsync`
+- [x] 6.3 Update `ExecuteJobAsync` download branch to use `Match` on `ResolveDownloadUrlAsync` result — log error and mark job failed on `Error`, proceed on `Ok`
+- [x] 6.4 Update `ExecuteJobAsync` upload branch to use `Match` on `IGraphService.UploadFileAsync` result
 
 ## 7. SyncService Implementation
 
-- [ ] 7.1 Update `ApplyConflictOutcomeAsync` `UseRemote` branch to use `Match`/`Bind` on `GetDownloadUrlAsync` result
-- [ ] 7.2 On `Result.Error` in conflict resolution: log error and call `RaiseProgress` with `SyncState.Error` and the error message
-- [ ] 7.3 Update callers of `IGraphService` methods in `SyncService` (if any) to handle `Result` return types
+- [x] 7.1 Update `ApplyConflictOutcomeAsync` `UseRemote` branch to use `Match`/`Bind` on `GetDownloadUrlAsync` result
+- [x] 7.2 On `Result.Error` in conflict resolution: log error and call `RaiseProgress` with `SyncState.Error` and the error message
+- [x] 7.3 Update callers of `IGraphService` methods in `SyncService` (if any) to handle `Result` return types
 
 ## 8. AccountFilesViewModel Implementation
 
-- [ ] 8.1 Replace `() => throw new InvalidOperationException("Drive ID not available.")` in `Option.Match` with a warning log and early return
+- [x] 8.1 Replace `() => throw new InvalidOperationException("Drive ID not available.")` in `Option.Match` with a warning log and early return
 
 ## 9. Build Verification and Test Fixes
 
-- [ ] 9.1 Run `dotnet build` — resolve all compiler errors from interface signature changes
-- [ ] 9.2 Update all existing unit tests that used `Assert.ThrowsAsync` for the replaced throws to assert `Result.IsError` / `result.ShouldBeError()`
-- [ ] 9.3 Update any test doubles / mocks (`NSubstitute`) for `IUploadService`, `IHttpDownloader`, `IGraphService` to match new signatures
-- [ ] 9.4 Run `dotnet test` — all tests pass (new tests from task group 1 now green)
+- [x] 9.1 Run `dotnet build` — resolve all compiler errors from interface signature changes
+- [x] 9.2 Update all existing unit tests that used `Assert.ThrowsAsync` for the replaced throws to assert `Result.IsError` / `result.ShouldBeError()`
+- [x] 9.3 Update any test doubles / mocks (`NSubstitute`) for `IUploadService`, `IHttpDownloader`, `IGraphService` to match new signatures
+- [x] 9.4 Run `dotnet test` — all tests pass (new tests from task group 1 now green)
 
 ## 10. Review and PR
 
-- [ ] 10.1 Request human review — do NOT commit without approval
+- [x] 10.1 Request human review — do NOT commit without approval
 - [ ] 10.2 Address review feedback
 - [ ] 10.3 Commit to branch and raise GitHub PR referencing this change


### PR DESCRIPTION
## Summary

- Replace all recoverable `throw` statements in `AStar.Dev.OneDrive.Sync.Client` infrastructure layer with `Result<T, string>` return values from `AStar.Dev.Functional.Extensions`
- Updated interfaces: `IUploadService`, `IHttpDownloader`, and all 8 `IGraphService` methods now return `Result`-wrapped types
- Callers use C# is-pattern matching (`if result is Result<T,E>.Ok ok`) throughout — `Match<TResult>` cannot unify void side-effect lambdas
- All 829 unit tests pass; zero build warnings

## Files changed

**Interfaces**
- `IGraphService`: `GetRootFoldersAsync`, `GetChildFoldersAsync`, `GetQuotaAsync`, `EnumerateFolderAsync`, `GetDownloadUrlAsync`, `UploadFileAsync`, `DeleteItemAsync` — all `Result`-wrapped
- `IHttpDownloader.DownloadAsync`: `Task` → `Task<Result<Unit, string>>`
- `IUploadService.UploadAsync`: `Task<string>` → `Task<Result<string, string>>`

**Production code**
- `GraphService`, `UploadService`, `HttpDownloader`, `DownloadWorker`, `SyncService`, `LocalDeletionDetector`, `RemoteFolderEnumerator`, `AccountFilesViewModel`, `FolderTreeNodeViewModel`, `AddAccountWizardViewModel`

**Tests**
- NSubstitute mocks updated for new signatures; `global::System.Reactive.Unit.Default` used where test namespace suffix `Unit` conflicts with `System.Reactive.Unit`; constructor-level default success mocks added

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — 829/829 passing
- [x] New `Result.Error` path tests from phase 1 (file-not-found, null session URL, rate-limit exhaustion, missing item ID, retry budget) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)