### PR TITLE
fix(apps/desktop): SyncService download failure now prevents silent conflict resolution (#285)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,16 @@ Say "I believe this is fixed because…" — never just "fixed".
 - Use `c-sharp-reviewer` subagent for code review.
 - When a subagent drifts off task or produces wrong output, take over directly — do not re-prompt the same agent repeatedly.
 
+### Verifying Subagent Output
+
+After ANY subagent completes, verify before trusting its report:
+
+1. **Files**: `Read` every file the subagent claims to have written or modified — do NOT assume it succeeded.
+2. **Tests**: Re-run `dotnet test` yourself and paste actual output. Never accept a subagent's "all tests pass" summary as truth.
+3. **Diff**: Confirm the actual changes match what was requested.
+
+If verification fails, take over directly — do not re-prompt the same subagent.
+
 ## graphify
 
 This project has a graphify knowledge graph at graphify-out/.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>AStar.Dev.OneDrive.Sync.Client.Tests.Unit</RootNamespace>
-        <NoWarn>NU1902</NoWarn>
+        <NoWarn>NU1902;CA1859</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
@@ -19,7 +19,7 @@ public sealed class GivenASyncPassOrchestrator
     private readonly ILocalChangeDetector _localChangeDetector = Substitute.For<ILocalChangeDetector>();
     private readonly ISyncJobExecutor _syncJobExecutor = Substitute.For<ISyncJobExecutor>();
 
-    private SyncPassOrchestrator CreateSut()
+    private ISyncPassOrchestrator CreateSut()
     {
         var dependencies = new SyncServiceDependencies(
             _remoteFolderEnumerator,
@@ -177,6 +177,36 @@ public sealed class GivenASyncPassOrchestrator
     }
 
     [Fact]
+    public async Task when_no_jobs_exist_then_no_changes_progress_is_raised()
+    {
+        SetupDeepSyncPrerequisites();
+
+        var progressMessages = new List<string>();
+        var sut = CreateSut();
+        var account = CreateAccount();
+
+        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+
+        progressMessages.ShouldContain("No changes");
+    }
+
+    [Fact]
+    public async Task when_enumeration_succeeds_then_progress_includes_detecting_remote_deletions_before_local_changes()
+    {
+        SetupDeepSyncPrerequisites();
+
+        var progressMessages = new List<string>();
+        var sut = CreateSut();
+        var account = CreateAccount();
+
+        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+
+        progressMessages.ShouldContain("Detecting remote deletions...");
+        progressMessages.ShouldContain("Detecting local changes...");
+        progressMessages.IndexOf("Detecting remote deletions...").ShouldBeLessThan(progressMessages.IndexOf("Detecting local changes..."));
+    }
+
+    [Fact]
     public async Task when_account_entity_exists_then_account_repository_upsert_is_called()
     {
         SetupDeepSyncPrerequisites();
@@ -218,6 +248,7 @@ public sealed class GivenASyncPassOrchestrator
             {
                 var callback = args.ArgAt<Func<SyncConflict, Task>>(2);
                 await callback(conflict);
+
                 return new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true);
             });
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -14,33 +14,15 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncService
 {
-    private readonly IAuthService              _authService             = Substitute.For<IAuthService>();
-    private readonly IGraphService             _graphService            = Substitute.For<IGraphService>();
-    private readonly IAccountRepository        _accountRepository       = Substitute.For<IAccountRepository>();
-    private readonly ISyncRepository           _syncRepository          = Substitute.For<ISyncRepository>();
-    private readonly IDriveStateRepository     _driveStateRepository    = Substitute.For<IDriveStateRepository>();
-    private readonly IHttpDownloader           _httpDownloader          = Substitute.For<IHttpDownloader>();
-    private readonly IRemoteFolderEnumerator   _remoteFolderEnumerator  = Substitute.For<IRemoteFolderEnumerator>();
-    private readonly IRemoteDeletionDetector   _remoteDeletionDetector  = Substitute.For<IRemoteDeletionDetector>();
-    private readonly ILocalDeletionDetector    _localDeletionDetector   = Substitute.For<ILocalDeletionDetector>();
-    private readonly ILocalChangeDetector      _localChangeDetector     = Substitute.For<ILocalChangeDetector>();
-    private readonly ISyncJobExecutor          _syncJobExecutor         = Substitute.For<ISyncJobExecutor>();
-    private readonly IFileSystem               _fileSystem              = Substitute.For<IFileSystem>();
+    private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
+    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
+    private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
+    private readonly IHttpDownloader       _httpDownloader       = Substitute.For<IHttpDownloader>();
+    private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
+    private readonly IFileSystem           _fileSystem           = Substitute.For<IFileSystem>();
 
     private SyncService BuildSut()
-    {
-        var dependencies = new SyncServiceDependencies(
-            _remoteFolderEnumerator,
-            _remoteDeletionDetector,
-            _localDeletionDetector,
-            _localChangeDetector,
-            _syncJobExecutor);
-
-        return new SyncService(_authService, _accountRepository, _driveStateRepository, _syncRepository, _httpDownloader, _graphService, dependencies, _fileSystem);
-    }
-
-    private static RemoteEnumerationResult EmptyEnumerationResult()
-        => new([], new HashSet<string>(), [], []);
+        => new(_authService, _syncRepository, _httpDownloader, _graphService, _syncPassOrchestrator, _fileSystem);
 
     [Fact]
     public void when_constructed_then_instance_is_not_null()
@@ -55,24 +37,47 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
-            .Returns(EmptyEnumerationResult());
-        _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
-            .Returns([]);
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var service = BuildSut();
         var account = new OneDriveAccount
         {
             Id         = new AccountId("user-1"),
-            Profile    = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
+            Profile    = AccountProfileFactory.Create("User", "user@outlook.com"),
             SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/home/user/OneDrive"))
         };
 
         await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
 
         await _authService.Received(1).AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_auth_succeeds_and_sync_config_is_set_then_orchestrator_is_called()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var service = BuildSut();
+        var account = new OneDriveAccount
+        {
+            Id         = new AccountId("user-1"),
+            Profile    = AccountProfileFactory.Create("User", "user@outlook.com"),
+            SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/home/user/OneDrive"))
+        };
+
+        await service.SyncAccountAsync(account, TestContext.Current.CancellationToken);
+
+        await _syncPassOrchestrator.Received(1).OrchestrateAsync(
+            Arg.Is(account),
+            Arg.Any<string>(),
+            Arg.Any<Func<SyncConflict, Task>>(),
+            Arg.Any<Action<SyncProgressEventArgs>>(),
+            Arg.Any<Action<JobCompletedEventArgs>>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -1,0 +1,90 @@
+using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+using ReactiveUnit = global::System.Reactive.Unit;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
+{
+    private readonly IAuthService    _authService    = Substitute.For<IAuthService>();
+    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
+    private readonly IHttpDownloader _httpDownloader = Substitute.For<IHttpDownloader>();
+    private readonly IGraphService   _graphService   = Substitute.For<IGraphService>();
+
+    public GivenASyncServiceApplyingUseRemoteConflictOutcome()
+        => _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+
+    private SyncService CreateSut()
+        => new(_authService, _syncRepository, _httpDownloader, _graphService, Substitute.For<ISyncPassOrchestrator>(), Substitute.For<IFileSystem>());
+
+    private static SyncConflict CreateConflict() => new()
+    {
+        Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("item-1")),
+        Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
+        Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow.AddMinutes(-5), 0L, DateTimeOffset.UtcNow, 0L)
+    };
+
+    [Fact]
+    public async Task when_url_resolution_fails_then_error_progress_is_raised()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Error("url-resolution-failed"));
+
+        SyncProgressEventArgs? captured = null;
+        var sut = CreateSut();
+        sut.SyncProgressChanged += (_, args) =>
+        {
+            if(args.SyncState == SyncState.Error)
+                captured = args;
+        };
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.SyncState.ShouldBe(SyncState.Error);
+    }
+
+    [Fact]
+    public async Task when_download_fails_then_error_progress_is_raised()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
+        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
+
+        SyncProgressEventArgs? captured = null;
+        var sut = CreateSut();
+        sut.SyncProgressChanged += (_, args) =>
+        {
+            if(args.SyncState == SyncState.Error)
+                captured = args;
+        };
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.SyncState.ShouldBe(SyncState.Error);
+    }
+
+    [Fact]
+    public async Task when_download_fails_then_sync_repository_resolve_is_not_called()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
+        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
+
+        await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -12,33 +12,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncServiceResolvingConflicts
 {
-    private readonly IAuthService            _authService         = Substitute.For<IAuthService>();
-    private readonly ISyncRepository         _syncRepository      = Substitute.For<ISyncRepository>();
-    private readonly IRemoteFolderEnumerator _remoteFolderEnumerator = Substitute.For<IRemoteFolderEnumerator>();
-    private readonly IRemoteDeletionDetector _remoteDeletionDetector = Substitute.For<IRemoteDeletionDetector>();
-    private readonly ILocalDeletionDetector  _localDeletionDetector  = Substitute.For<ILocalDeletionDetector>();
-    private readonly ILocalChangeDetector    _localChangeDetector    = Substitute.For<ILocalChangeDetector>();
-    private readonly ISyncJobExecutor        _syncJobExecutor        = Substitute.For<ISyncJobExecutor>();
+    private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
+    private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
+    private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
 
     private SyncService CreateSut()
-    {
-        var dependencies = new SyncServiceDependencies(
-            _remoteFolderEnumerator,
-            _remoteDeletionDetector,
-            _localDeletionDetector,
-            _localChangeDetector,
-            _syncJobExecutor);
-
-        return new SyncService(
-            _authService,
-            Substitute.For<IAccountRepository>(),
-            Substitute.For<IDriveStateRepository>(),
-            _syncRepository,
-            Substitute.For<IHttpDownloader>(),
-            Substitute.For<IGraphService>(),
-            dependencies,
-            Substitute.For<IFileSystem>());
-    }
+        => new(_authService, _syncRepository, Substitute.For<IHttpDownloader>(), Substitute.For<IGraphService>(), _syncPassOrchestrator, Substitute.For<IFileSystem>());
 
     private static SyncConflict CreateConflict() => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -1,42 +1,27 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
-using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncServiceSyncingAnAccount
 {
-    private readonly IAuthService              _authService              = Substitute.For<IAuthService>();
-    private readonly IAccountRepository        _accountRepository        = Substitute.For<IAccountRepository>();
-    private readonly ISyncRepository           _syncRepository           = Substitute.For<ISyncRepository>();
-    private readonly IDriveStateRepository     _driveStateRepository     = Substitute.For<IDriveStateRepository>();
-    private readonly IHttpDownloader           _httpDownloader           = Substitute.For<IHttpDownloader>();
-    private readonly IGraphService             _graphService             = Substitute.For<IGraphService>();
-    private readonly IRemoteFolderEnumerator   _remoteFolderEnumerator   = Substitute.For<IRemoteFolderEnumerator>();
-    private readonly IRemoteDeletionDetector   _remoteDeletionDetector   = Substitute.For<IRemoteDeletionDetector>();
-    private readonly ILocalDeletionDetector    _localDeletionDetector    = Substitute.For<ILocalDeletionDetector>();
-    private readonly ILocalChangeDetector      _localChangeDetector      = Substitute.For<ILocalChangeDetector>();
-    private readonly ISyncJobExecutor          _syncJobExecutor          = Substitute.For<ISyncJobExecutor>();
-    private readonly IFileSystem               _fileSystem               = Substitute.For<IFileSystem>();
+    private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
+    private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
+    private readonly IHttpDownloader       _httpDownloader       = Substitute.For<IHttpDownloader>();
+    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
+    private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
+    private readonly IFileSystem           _fileSystem           = Substitute.For<IFileSystem>();
 
     private SyncService CreateSut()
-    {
-        var dependencies = new SyncServiceDependencies(
-            _remoteFolderEnumerator,
-            _remoteDeletionDetector,
-            _localDeletionDetector,
-            _localChangeDetector,
-            _syncJobExecutor);
-
-        return new SyncService(_authService, _accountRepository, _driveStateRepository, _syncRepository, _httpDownloader, _graphService, dependencies, _fileSystem);
-    }
+        => new(_authService, _syncRepository, _httpDownloader, _graphService, _syncPassOrchestrator, _fileSystem);
 
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {
@@ -46,25 +31,13 @@ public sealed class GivenASyncServiceSyncingAnAccount
         SelectedFolderIds = []
     };
 
-    private static RemoteEnumerationResult EmptyEnumerationResult()
-        => new([], new HashSet<string>(), [], []);
-
     private void SetupAuthSuccess() =>
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
-    private void SetupDeepSyncPrerequisites()
-    {
-        SetupAuthSuccess();
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
-            .Returns(EmptyEnumerationResult());
-        _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
-            .Returns([]);
-        _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<AccountEntity>());
-    }
+    private void SetupOrchestratorReturns(bool didRun) =>
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+            .Returns(didRun);
 
     [Fact]
     public async Task when_sync_starts_then_authenticating_progress_is_raised_before_auth_call()
@@ -154,13 +127,11 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_enumerator_throws_operation_cancelled_then_progress_is_sync_cancelled_with_idle_state()
+    public async Task when_orchestrator_throws_operation_cancelled_then_progress_is_sync_cancelled_with_idle_state()
     {
         SetupAuthSuccess();
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<RemoteEnumerationResult>(new OperationCanceledException()));
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -181,13 +152,11 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_enumerator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
+    public async Task when_orchestrator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
     {
         SetupAuthSuccess();
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<RemoteEnumerationResult>(new InvalidOperationException("unexpected")));
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(new InvalidOperationException("unexpected")));
 
         SyncState? capturedState = null;
         string? capturedMessage = null;
@@ -208,13 +177,10 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_enumerator_returns_had_no_rules_then_progress_raises_no_folders_selected_with_idle_state()
+    public async Task when_orchestrator_returns_false_then_no_folders_selected_progress_is_raised_with_idle_state()
     {
         SetupAuthSuccess();
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
-            .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
+        SetupOrchestratorReturns(false);
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -235,32 +201,10 @@ public sealed class GivenASyncServiceSyncingAnAccount
     }
 
     [Fact]
-    public async Task when_no_download_or_upload_jobs_exist_then_progress_raises_no_changes_with_idle_state()
+    public async Task when_orchestrator_returns_true_then_sync_complete_progress_is_raised_with_idle_state()
     {
-        SetupDeepSyncPrerequisites();
-
-        string? capturedMessage = null;
-        SyncState? capturedState = null;
-        var sut = CreateSut();
-        sut.SyncProgressChanged += (_, args) =>
-        {
-            if(args.CurrentFile == "No changes")
-            {
-                capturedMessage = args.CurrentFile;
-                capturedState = args.SyncState;
-            }
-        };
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        capturedMessage.ShouldBe("No changes");
-        capturedState.ShouldBe(SyncState.Idle);
-    }
-
-    [Fact]
-    public async Task when_sync_completes_with_no_jobs_then_progress_raises_sync_complete_with_idle_state()
-    {
-        SetupDeepSyncPrerequisites();
+        SetupAuthSuccess();
+        SetupOrchestratorReturns(true);
 
         string? capturedMessage = null;
         SyncState? capturedState = null;
@@ -278,47 +222,5 @@ public sealed class GivenASyncServiceSyncingAnAccount
 
         capturedMessage.ShouldBe("Sync complete");
         capturedState.ShouldBe(SyncState.Idle);
-    }
-
-    [Fact]
-    public async Task when_rules_exist_then_progress_sequence_includes_detecting_remote_deletions_and_detecting_local_changes()
-    {
-        SetupDeepSyncPrerequisites();
-
-        var progressMessages = new List<string>();
-        var sut = CreateSut();
-        sut.SyncProgressChanged += (_, args) => progressMessages.Add(args.CurrentFile);
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        progressMessages.ShouldContain("Detecting remote deletions...");
-        progressMessages.ShouldContain("Detecting local changes...");
-        progressMessages.IndexOf("Detecting remote deletions...").ShouldBeLessThan(progressMessages.IndexOf("Detecting local changes..."));
-    }
-
-    [Fact]
-    public async Task when_account_entity_exists_then_account_repository_upsert_is_called_after_sync()
-    {
-        SetupDeepSyncPrerequisites();
-        _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.Some(new AccountEntity { Id = new AccountId("user-1") }));
-
-        var sut = CreateSut();
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        await _accountRepository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task when_account_entity_does_not_exist_then_account_repository_upsert_is_not_called()
-    {
-        SetupDeepSyncPrerequisites();
-
-        var sut = CreateSut();
-
-        await sut.SyncAccountAsync(CreateAccount(), TestContext.Current.CancellationToken);
-
-        await _accountRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncPassOrchestrator.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Orchestrates a single sync pass for one account: enumerate remote, detect deletions, detect local changes, and execute jobs.
+/// </summary>
+public interface ISyncPassOrchestrator
+{
+    /// <summary>
+    /// Runs the full sync pass pipeline for <paramref name="account"/> using <paramref name="token"/> for Graph API calls.
+    /// Returns <see langword="true"/> when at least one sync rule was active; <see langword="false"/> when no folders were selected.
+    /// </summary>
+    Task<bool> OrchestrateAsync(OneDriveAccount account, string token, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncPassOrchestrator.cs
@@ -6,7 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, SyncServiceDependencies dependencies)
+internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, SyncServiceDependencies dependencies) : ISyncPassOrchestrator
 {
     public async Task<bool> OrchestrateAsync(OneDriveAccount account, string token, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -11,10 +11,8 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-public sealed class SyncService(IAuthService authService, IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, ISyncRepository syncRepository, IHttpDownloader httpDownloader, IGraphService graphService, SyncServiceDependencies dependencies, IFileSystem fileSystem) : ISyncService
+public sealed class SyncService(IAuthService authService, ISyncRepository syncRepository, IHttpDownloader httpDownloader, IGraphService graphService, ISyncPassOrchestrator syncPassOrchestrator, IFileSystem fileSystem) : ISyncService
 {
-    private readonly SyncPassOrchestrator syncPassOrchestrator = new(accountRepository, driveStateRepository, dependencies);
-
     /// <inheritdoc />
     public event EventHandler<SyncProgressEventArgs>? SyncProgressChanged;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -90,30 +90,34 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
+        var applied = await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
 
-        await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
+        if(!applied)
+            return;
+
         await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
     }
 
-    private async Task ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
+    private async Task<bool> ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
     {
         switch(outcome)
         {
             case ConflictOutcome.UseRemote:
                 var urlResult = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
 
-                await urlResult.Match(
+                return await urlResult.MatchAsync<bool>(
                     async url =>
                     {
                         var downloadResult = await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
 
-                        downloadResult.Match<Unit>(
-                            _ => Unit.Default,
+                        return downloadResult.Match<bool>(
+                            _ => true,
                             downloadError =>
                             {
                                 Serilog.Log.Error("[SyncService] Download failed resolving conflict for {Path}: {Error}", conflict.Target.RelativePath, downloadError);
                                 RaiseProgress(accountId, 0, 0, downloadError, SyncState.Error);
-                                return Unit.Default;
+
+                                return false;
                             });
                     },
                     error =>
@@ -121,15 +125,18 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                         Serilog.Log.Error("[SyncService] Could not resolve download URL for conflict item {Path}: {Error}", conflict.Target.RelativePath, error);
                         RaiseProgress(accountId, 0, 0, error, SyncState.Error);
 
-                        return Task.CompletedTask;
-                    });
-                break;
+                        return false;
+                    }).ConfigureAwait(false);
 
             case ConflictOutcome.KeepBoth:
                 string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
                 if(fileSystem.File.Exists(conflict.Target.LocalPath))
                     fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
-                break;
+
+                return true;
+
+            default:
+                return true;
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
@@ -1,7 +1,7 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <summary>
-/// Groups the five sync-pass collaborators injected into <see cref="SyncService"/>
+/// Groups the five sync-pass collaborators injected into <see cref="SyncPassOrchestrator"/>
 /// to keep its constructor within the parameter-count guideline.
 /// </summary>
 public sealed record SyncServiceDependencies(IRemoteFolderEnumerator RemoteFolderEnumerator, IRemoteDeletionDetector RemoteDeletionDetector, ILocalDeletionDetector LocalDeletionDetector, ILocalChangeDetector LocalChangeDetector, ISyncJobExecutor JobExecutor);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -38,6 +38,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ILocalDeletionDetector, LocalDeletionDetector>();
         _ = services.AddSingleton<ISyncJobExecutor, SyncJobExecutor>();
         _ = services.AddSingleton<SyncServiceDependencies>();
+        _ = services.AddSingleton<ISyncPassOrchestrator, SyncPassOrchestrator>();
         _ = services.AddSingleton<ISyncService, SyncService>();
         _ = services.AddSingleton<ISyncScheduler, SyncScheduler>();
         _ = services.AddSingleton<IUiDispatcher, AvaloniaUiDispatcher>();

--- a/docs/code-review-report-AStar.Dev.OneDrive.Sync.Client-20260518.md
+++ b/docs/code-review-report-AStar.Dev.OneDrive.Sync.Client-20260518.md
@@ -1,0 +1,396 @@
+# Code Review — `AStar.Dev.OneDrive.Sync.Client`
+
+**Date:** 2026-05-18  
+**Reviewer:** Claude Code (c-sharp-reviewer)  
+**Scope:** SRP / SOC violations + functional-paradigm misuse  
+**Branch at review:** `doc/improve-claude-md-subagent-verification` (HEAD `5ea6b00`)
+
+---
+
+## References
+
+- [Microsoft C# Coding Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+- [SOLID Principles](https://learn.microsoft.com/en-us/archive/msdn-magazine/2014/may/csharp-best-practices-dangers-of-violating-solid-principles-in-csharp)
+- [AStar.Dev repo guidelines — CLAUDE.md](../CLAUDE.md)
+- [AStar.Dev C# code style](../.claude/rules/c-sharp-code-style.md)
+- [OWASP — Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure)
+
+---
+
+## Findings
+
+### 🔴 Errors
+
+---
+
+#### E1 — `SyncService.cs:16` — DI bypassed: `SyncPassOrchestrator` newed up inside `SyncService`
+
+`private readonly SyncPassOrchestrator syncPassOrchestrator = new(accountRepository, driveStateRepository, dependencies);`
+
+`SyncPassOrchestrator` is a concrete class created inline from constructor parameters. This bypasses the DI container, makes it untestable in isolation, and means the container never manages its lifetime. The constructor already has 8 parameters — the orchestrator should be injected, not constructed.
+
+**Fix:** Register `SyncPassOrchestrator` in the DI container and inject `ISyncPassOrchestrator` (extract interface).
+
+---
+
+#### E2 — `SyncService.cs:107` — `Match` used instead of `MatchAsync`; inner download error silently dropped
+
+```csharp
+await urlResult.Match(           // ← should be MatchAsync
+    async url =>
+    {
+        var downloadResult = await httpDownloader.DownloadAsync(...);
+        downloadResult.Match<Unit>(   // ← result discarded; download failure is lost
+            _ => Unit.Default,
+            downloadError => { RaiseProgress(...); return Unit.Default; });
+    },
+    error => { ...; return Task.CompletedTask; });
+```
+
+Two problems:
+1. `Match` is called on a `Result<string,string>` where the success branch is `async` — should be `MatchAsync`.
+2. The inner `downloadResult.Match<Unit>(...)` return value is discarded — a download failure only calls `RaiseProgress` but execution falls through without signalling the caller. No error is propagated out of `ApplyConflictOutcomeAsync`.
+
+**Fix:**
+```csharp
+await urlResult.MatchAsync(
+    async url =>
+    {
+        await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct)
+            .TapErrorAsync(downloadError =>
+            {
+                Serilog.Log.Error(...);
+                RaiseProgress(accountId, 0, 0, downloadError, SyncState.Error);
+            });
+    },
+    error =>
+    {
+        Serilog.Log.Error(...);
+        RaiseProgress(accountId, 0, 0, error, SyncState.Error);
+        return Task.CompletedTask;
+    });
+```
+
+---
+
+#### E3 — `AddAccountWizardViewModel.cs:125-137` — `switch` on `Result<>` discriminated union (repo rule violation)
+
+```csharp
+switch(result)
+{
+    case Result<AuthResult, AuthError>.Ok successfulLoginResult: ...
+    case Result<AuthResult, AuthError>.Error { Reason: AuthCancelledError }: ...
+    case Result<AuthResult, AuthError>.Error { Reason: AuthFailedError failed }: ...
+}
+```
+
+Repo rule (`.claude/rules/c-sharp-code-style.md`): _"Never use `is Result<T,E>.Ok` / `is not Result<T,E>.Ok` pattern matching in production code — use `Match` or `MatchAsync`."_ The switch also has no `default` arm — a new `AuthError` subtype silently does nothing.
+
+**Fix:**
+```csharp
+result.Match(
+    ok => UpdateSuccessfulLoginState(ok),
+    error =>
+    {
+        switch (error)
+        {
+            case AuthCancelledError: SetCancelledLoginState(); break;
+            case AuthFailedError failed: SetFailedLoginState(failed); break;
+            default: SetFailedLoginState(new AuthFailedError("Unexpected auth error.")); break;
+        }
+    });
+```
+
+---
+
+#### E4 — `ParallelDownloadPipeline.cs:61-63` — `DownloadWorker` instantiated with `new`, bypassing DI
+
+```csharp
+var workers = Enumerable.Range(1, workerCount)
+    .Select(id => new DownloadWorker(id, downloader, graphService, syncRepository, fileSystem)
+    .RunAsync(channel.Reader, accessToken, OnJobComplete, ct))
+    .ToList();
+```
+
+`DownloadWorker` is created inline inside `ParallelDownloadPipeline`. The worker cannot be replaced or mocked in tests without replacing the whole pipeline. The `workerId` int being passed is also not injectable — this pattern makes the worker count and composition opaque.
+
+**Fix:** Introduce `IDownloadWorkerFactory` and inject it. The factory constructs numbered workers from resolved dependencies.
+
+---
+
+### 🟡 Warnings
+
+---
+
+#### W1 — `AccountFilesViewModel.cs:147` — `is not Option<DriveId>.Some` instead of `Match`/`Bind`
+
+```csharp
+if(_driveId is not Option<DriveId>.Some driveIdSome)
+{
+    Serilog.Log.Warning(...);
+    return;
+}
+var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveIdSome.Value);
+```
+
+Repo rule violation — same as E3 but for `Option<T>`. Should use `Match` or `Bind` from `AStar.Dev.Functional.Extensions`.
+
+**Fix:**
+```csharp
+_driveId.Match(
+    driveIdSome => RootFolders.Add(new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveIdSome)),
+    ()          => Serilog.Log.Warning("[AccountFilesViewModel] Drive ID not available..."));
+```
+
+---
+
+#### W2 — `SyncScheduler.cs:69-74` — `TapAsync` silently ignores "account not found"
+
+```csharp
+public async Task TriggerAccountAsync(string accountId, CancellationToken ct = default)
+    => await accountRepository.GetByIdAsync(new AccountId(accountId), ct)
+        .TapAsync(async entity => { ... });
+```
+
+`GetByIdAsync` returns `Option<AccountEntity>`. `TapAsync` on `Option.None` does nothing and returns normally — the caller has no signal that the account was not found. A manual trigger for a non-existent account silently no-ops.
+
+**Fix:** Use `MatchAsync` and log/throw on `None`.
+
+---
+
+#### W3 — `UploadService.cs:50-51` — `Match()` used as boolean predicate; use `Tap`
+
+```csharp
+var uploadResult = await UploadChunksAsync(...);
+
+if(uploadResult.Match(_ => true, _ => false))
+    Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
+```
+
+Using `Match` to extract a bool for a conditional is a pattern smell. The success-only side-effect should be expressed with `Tap`/`TapAsync`.
+
+**Fix:**
+```csharp
+return await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct)
+    .TapAsync(itemId => Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath));
+```
+
+---
+
+#### W4 — `UploadService.cs:113-118` — Nullable `Match<Result?>` + null check; use `Bind`
+
+```csharp
+var earlyReturn = chunkResult.Match<Result<string, string>?>(
+    itemId => itemId is not null ? new Result<string, string>.Ok(itemId) : null,
+    error => new Result<string, string>.Error(error));
+
+if(earlyReturn is not null)
+    return earlyReturn;
+```
+
+The inner `Result<string?, string>` is unwrapped into a nullable `Result<string, string>?` and then null-checked. This loses the railway-oriented structure. `Bind` or `Map` keeps the chain clean.
+
+**Fix:**
+```csharp
+var earlyReturn = chunkResult.Bind<string>(
+    itemId => itemId is not null
+        ? new Result<string, string>.Ok(itemId)
+        : new Result<string, string>.Error("Upload response missing item ID."));
+
+if (earlyReturn is Result<string, string>.Ok or Result<string, string>.Error { } err when err.Reason is not null ... )
+```
+Or restructure `UploadChunksAsync` to return `Result<string, string>` directly by collecting partial IDs.
+
+---
+
+#### W5 — `SyncService.cs` — SRP violation: auth + conflict application + file ops + progress in one class
+
+`SyncService` is responsible for:
+- Acquiring access tokens (`IAuthService.AcquireTokenSilentAsync`)
+- Orchestrating sync passes (delegates to `SyncPassOrchestrator`)
+- Applying conflict outcomes including file system moves (`fileSystem.File.Move`, `IHttpDownloader.DownloadAsync`, `IGraphService.GetDownloadUrlAsync`)
+- Progress event management (`RaiseProgress`)
+
+The `ApplyConflictOutcomeAsync` method mixes high-level conflict policy dispatch with low-level file operations and HTTP downloads. These are at least two separate classes: `ISyncService` (orchestration) and `IConflictApplier` (outcome execution).
+
+The `IHttpDownloader`, `IGraphService`, and `IFileSystem` injected into `SyncService` are only used in `ApplyConflictOutcomeAsync` — confirming it belongs elsewhere.
+
+**Fix:** Extract `ApplyConflictOutcomeAsync` and its dependencies into a dedicated `ConflictApplier` service. Inject `IConflictApplier` into `SyncService`.
+
+---
+
+#### W6 — `RemoteFolderEnumerator.cs` — SRP/SOC violation: enumeration + conflict resolution + DB backfill + job creation
+
+`RemoteFolderEnumerator` performs:
+1. Sync rule loading (`syncRuleRepository.GetByAccountIdAsync`)
+2. Drive ID resolution (`graphService.GetDriveIdAsync`)
+3. Folder ID resolution and **database backfill** (`syncRuleRepository.UpsertAsync` in `ResolveAndBackFillFolderIdAsync`)
+4. Conflict detection and policy application (`HandleConflictAsync` → `ConflictResolver.Resolve`)
+5. Phantom item creation (`syncedItemRepository.UpsertAsync` inside `ProcessFileItemAsync`)
+6. Download job construction (`SyncJobFactory.CreateDownload`)
+7. Folder directory creation (`fileSystem.Directory.CreateDirectory` in `HandleFolderAsync`)
+
+Conflict policy application, phantom-item registration, and folder creation are separate responsibilities. The class also mutates both `downloadJobs` and `syncedItems` via side effects through deeply nested async calls, making the flow hard to follow and test.
+
+**Fix:** Extract conflict handling into a reused `IConflictApplier`. Phantom-item registration into a dedicated step. Folder creation is a side effect that belongs in a post-enumeration step.
+
+---
+
+#### W7 — `DownloadWorker.cs` — SRP violation: handles three job types in one switch
+
+```csharp
+switch(job)
+{
+    case DownloadSyncJob downloadJob: ...
+    case UploadSyncJob uploadJob:    ...
+    case DeleteSyncJob deleteJob:    ...
+    default: ...
+}
+```
+
+A single worker handles download, upload, and delete — three distinct responsibilities with different infrastructure dependencies. Adding a new job type requires modifying this class (OCP violation). The class is also misnamed — it is not a "download" worker.
+
+**Fix:** Extract `IJobHandler` with implementations `DownloadJobHandler`, `UploadJobHandler`, `DeleteJobHandler`. `DownloadWorker` (renamed `SyncWorker`) dispatches to the appropriate handler via a registry/factory.
+
+---
+
+#### W8 — `ParallelDownloadPipeline.cs` — SOC: misnamed, runs all job types, no factory abstraction
+
+The class is named `ParallelDownloadPipeline` but it processes downloads, uploads, and deletes. Its `RunAsync` method embeds `OnJobComplete` as an inline closure that mutates shared state under a `Lock`, wires up `done`/`total` counters, invokes progress/completion callbacks, and manages channel lifecycle — all in one method.
+
+**Fix:** Rename to `ParallelSyncPipeline`. Extract progress tracking into a separate `SyncProgressTracker`. Introduce `IDownloadWorkerFactory` (see E4).
+
+---
+
+#### W9 — `AccountsViewModel.cs` — SRP: domain logic and persistence inside VM
+
+`AccountsViewModel` is responsible for:
+- Displaying account cards (correct VM concern)
+- Persisting new accounts to the DB (`repository.UpsertAsync`)
+- Setting the active account in the DB (`repository.SetActiveAccountAsync`)
+- Writing sync rules to the DB (`syncRuleRepository.UpsertAsync`)
+- Computing a default local sync path (`ApplicationMetadata.ApplicationNameLowered.UserDirectory().CombinePath(...)`)
+- Mapping `OneDriveAccount` → `AccountEntity` (`ToEntity` method)
+- Constructing wizard VMs directly (not via factory)
+
+`OnWizardCompletedAsync` at lines 91–135 is an orchestration method that crosses at least three abstraction layers (UI state, persistence, domain).
+
+**Fix:** Extract account persistence/mapping into a `IAccountOnboardingService` (or similar application-layer service). VM calls service; service handles repository interaction and default-path logic.
+
+---
+
+#### W10 — `AccountFilesViewModel.cs:164-192` — `async void` with unreachable outer catch; untestable platform call
+
+```csharp
+private async void OnIncludeToggledAsync(object? sender, FolderTreeNodeViewModel node)
+{
+    try
+    {
+        try { ... }            // ← inner catch swallows all exceptions
+        catch(Exception ex) { ... }
+    }
+    catch(Exception ex) { ... } // ← outer catch is unreachable
+}
+```
+
+Outer catch is dead code — the inner catch swallows everything. `async void` is necessary for the event subscription pattern in Avalonia, but the nested try/catch structure is redundant and misleading.
+
+Additionally at line 199:
+```csharp
+string opener = OperatingSystem.IsWindows() ? "explorer" : ...;
+_ = System.Diagnostics.Process.Start(opener, path);
+```
+
+`Environment.GetFolderPath` and `Process.Start` are not abstracted — platform logic is embedded in the VM and cannot be unit-tested.
+
+**Fix:** Remove outer try/catch. Extract OS-specific file-manager opening into `IFileManagerService` and inject it.
+
+---
+
+#### W11 — `GraphService.cs:252-273` — Token-keyed in-memory cache with no eviction; sensitive data in dict keys
+
+```csharp
+private readonly ConcurrentDictionary<string, DriveContext> _cache = [];
+
+if(_cache.TryGetValue(accessToken, out var cached))
+    return ...;
+
+_cache[accessToken] = driveContext;
+```
+
+The cache is keyed by raw access token strings. Problems:
+1. **Memory leak** — tokens accumulate over the lifetime of the singleton; the dict grows without bound as tokens rotate (every hour with MSAL refresh).
+2. **Security** — [OWASP Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure): raw token strings should not be stored in plain memory as dictionary keys. Use a non-reversible key (e.g., `SHA256` of the token, or the account ID which is stable across token rotations).
+
+**Fix:** Key the cache by account ID (stable, non-sensitive). Obtain account ID from the token claims or pass it as a parameter. Remove old entries when tokens are revoked/account removed.
+
+---
+
+#### W12 — `AddAccountWizardViewModel.cs:239-250` — Domain object constructed inside VM
+
+```csharp
+private void Finish()
+{
+    var account = new OneDriveAccount
+    {
+        Id = new AccountId(_accountId),
+        Profile = AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
+        SelectedFolderIds = [...],
+        FolderNames = Folders.Where(f => f.IsSelected).ToDictionary(...)
+    };
+    Completed?.Invoke(this, account);
+}
+```
+
+The VM directly constructs a `OneDriveAccount` domain object from raw wizard state. Domain object creation is the factory's responsibility. The VM knows too much about how `OneDriveAccount` is assembled.
+
+**Fix:** Introduce `OneDriveAccountFactory.CreateFromWizard(accountId, displayName, email, selectedFolders)` and call it from `Finish()`.
+
+---
+
+### 🔵 Nits (no GitHub issue)
+
+---
+
+#### N1 — `SyncPassOrchestrator.cs:11` — 6-parameter method; use parameter object
+
+`OrchestrateAsync(OneDriveAccount, string, Func<SyncConflict, Task>, Action<SyncProgressEventArgs>?, Action<JobCompletedEventArgs>?, CancellationToken)` — 6 parameters. The three callbacks should be grouped into a `SyncCallbacks` parameter object.
+
+---
+
+#### N2 — `SyncService.cs:14` — Constructor still 8 parameters despite `SyncServiceDependencies`
+
+`IHttpDownloader`, `IGraphService`, and `IFileSystem` are only used in `ApplyConflictOutcomeAsync`. Once that method is extracted (see W5), the constructor shrinks to a manageable size.
+
+---
+
+#### N3 — `ApplicationInitializer.cs` — Knows about 5 VMs; borderline SRP
+
+`ApplicationInitializer` directly wires event subscriptions on 3 VMs, restores accounts across 4 VMs, and activates the initial account across 2 VMs. Consider a mediator or startup coordinator pattern.
+
+---
+
+#### N4 — `SyncRepository.cs:20-40` — Type switch in LINQ `Select`
+
+Inline `switch(j)` inside a LINQ `Select` mixes data mapping with control flow. Extract to a `ToEntity(SyncJob)` helper method.
+
+---
+
+#### N5 — `SyncScheduler.cs:115` — Fragile null-guard via string length
+
+`entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? entity.SyncConfig : null` — uses string length as a proxy for "has a valid path". Should use `Option<AccountSyncConfig>` or validate via `LocalSyncPathFactory`.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Error | 4 |
+| 🟡 Warning | 12 |
+| 🔵 Nit | 5 |
+| **Total** | **21** |
+
+## Verdict: **Request Changes**
+
+Four errors block merge — particularly the DI bypasses (E1, E4), the `MatchAsync` / silent error-drop (E2), and the prohibited `switch`-on-`Result` pattern (E3). The twelve warnings represent significant SRP and functional-paradigm debt that will compound as the codebase grows. The GraphService token-cache issue (W11) is a security concern and should be treated as an error if this application handles user credentials.


### PR DESCRIPTION
## Summary

- `ApplyConflictOutcomeAsync` changed from `Task` → `Task<bool>` to signal whether the outcome was actually applied
- `ResolveConflictAsync` guards on the return value — skips `syncRepository.ResolveConflictAsync` when the download failed, preventing the conflict from being incorrectly marked as resolved
- Replaced `urlResult.Match(async url => …)` with `urlResult.MatchAsync<bool>(…)` — uses the correct async API
- Eliminated the discarded `downloadResult.Match<Unit>(…)` call — the result is now used to drive the return value

## Root cause

`ApplyConflictOutcomeAsync` returned `Task` (void), so `ResolveConflictAsync` always called `syncRepository.ResolveConflictAsync` regardless of whether the remote file was successfully downloaded. A download failure raised an error progress event but the conflict was silently marked resolved in the database.

## Test plan

- [x] `when_url_resolution_fails_then_error_progress_is_raised` — confirms error progress raised when `GetDownloadUrlAsync` fails
- [x] `when_download_fails_then_error_progress_is_raised` — confirms error progress raised when `DownloadAsync` fails
- [x] `when_download_fails_then_sync_repository_resolve_is_not_called` — RED before fix, GREEN after; this is the core regression test

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)