### PR TITLE
fix(apps/desktop): downgrade Tmds.DBus.Protocol 0.93.0 → 0.92.0 to fix TypeLoadException

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -163,7 +163,7 @@
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.93.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
   <ItemGroup Label="Blazor and web">
     <PackageVersion Include="MudBlazor" Version="8.3.0" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
@@ -23,7 +23,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" />
-    <PackageReference Include="Tmds.DBus.Protocol" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />


### PR DESCRIPTION
## Root cause

`Avalonia.FreeDesktop 12.0.2` was compiled against `Tmds.DBus.Protocol 0.92.0`, which exposes `Tmds.DBus.Protocol.Connection`. That type was **removed** in `0.93.0` (renamed to `DBusConnection`).

`CentralPackageTransitivePinningEnabled=true` in `Directory.Packages.props` forced the `0.93.0` pin onto the transitive dependency, so at runtime the CLR loaded `0.93.0` but `Avalonia.FreeDesktop` referenced `Connection` — throwing:

```
System.TypeLoadException: Could not load type 'Tmds.DBus.Protocol.Connection'
from assembly 'Tmds.DBus.Protocol, Version=0.93.0.0, ...'
```

## Changes

- `Directory.Packages.props`: pin `Tmds.DBus.Protocol` at `0.92.0` (was `0.93.0`)
- `AStar.Dev.OneDrive.Sync.Client.csproj`: remove unused direct `PackageReference` for `Tmds.DBus.Protocol` — no app code references it; it was only needed as a transitive dep from `Avalonia.Desktop`

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1010 tests pass (834 unit + 154 functional extensions + 20 source generators + 2 health checks)
- [x] `dotnet nuget why` confirms resolved version is now `0.92.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)