### PR TITLE
fix(apps/desktop): extract IDownloadWorkerFactory — decouple pipeline from concrete DownloadWorker (#287)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorkerFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadWorkerFactory.cs
@@ -1,0 +1,43 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenADownloadWorkerFactory
+{
+    private readonly IHttpDownloader _downloader = Substitute.For<IHttpDownloader>();
+    private readonly IGraphService _graphService = Substitute.For<IGraphService>();
+    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
+    private readonly IFileSystem _fileSystem = Substitute.For<IFileSystem>();
+
+    private DownloadWorkerFactory CreateSut() => new(_downloader, _graphService, _syncRepository, _fileSystem);
+
+    [Fact]
+    public void when_create_is_called_then_returns_non_null_worker()
+    {
+        var worker = CreateSut().Create(1);
+
+        worker.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void when_create_is_called_then_returns_download_worker_instance()
+    {
+        var worker = CreateSut().Create(1);
+
+        worker.ShouldBeOfType<DownloadWorker>();
+    }
+
+    [Fact]
+    public void when_create_is_called_with_different_ids_then_returns_distinct_instances()
+    {
+        var sut = CreateSut();
+
+        var worker1 = sut.Create(1);
+        var worker2 = sut.Create(2);
+
+        worker1.ShouldNotBeSameAs(worker2);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelDownloadPipeline.cs
@@ -1,9 +1,7 @@
-using System.IO.Abstractions;
-using AStar.Dev.Functional.Extensions;
+using System.Threading.Channels;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
@@ -16,18 +14,15 @@ public sealed class GivenAParallelDownloadPipeline
     private const string FolderIdValue  = "folder-1";
     private const string AccessToken = "test-token";
 
-    private readonly IHttpDownloader  _downloader     = Substitute.For<IHttpDownloader>();
-    private readonly IGraphService    _graphService   = Substitute.For<IGraphService>();
-    private readonly ISyncRepository  _syncRepository = Substitute.For<ISyncRepository>();
-    private readonly IFileSystem      _fileSystem     = Substitute.For<IFileSystem>();
+    private readonly IDownloadWorkerFactory _workerFactory = Substitute.For<IDownloadWorkerFactory>();
+    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
 
     public GivenAParallelDownloadPipeline()
     {
-        _downloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
+        _workerFactory.Create(Arg.Any<int>()).Returns(_ => new SucceedingDownloadWorker());
     }
 
-    private ParallelDownloadPipeline CreateSut() => new(_syncRepository, _graphService, _downloader, _fileSystem);
+    private ParallelDownloadPipeline CreateSut() => new(_workerFactory, _syncRepository);
 
     private static DownloadSyncJob MakeDownloadJob(string relativePath = "folder/file.txt")
     {
@@ -193,5 +188,24 @@ public sealed class GivenAParallelDownloadPipeline
         catch(OperationCanceledException) { }
 
         await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>());
+    }
+
+    [Fact]
+    public async Task when_worker_factory_is_called_then_one_worker_created_per_worker_count()
+    {
+        var sut = CreateSut();
+
+        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 3, ct: TestContext.Current.CancellationToken);
+
+        _workerFactory.Received(3).Create(Arg.Any<int>());
+    }
+
+    private sealed class SucceedingDownloadWorker : IDownloadWorker
+    {
+        public async Task RunAsync(ChannelReader<SyncJob> reader, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
+        {
+            await foreach(var job in reader.ReadAllAsync(ct))
+                onJobComplete(job, true, null);
+        }
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorker.cs
@@ -14,9 +14,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// <see cref="ChannelReader{T}"/> and executes them.
 /// Multiple workers run concurrently — one per degree of parallelism.
 /// </summary>
-public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGraphService graphService, ISyncRepository syncRepository, IFileSystem fileSystem)
+public sealed class DownloadWorker(int workerId, IHttpDownloader downloader, IGraphService graphService, ISyncRepository syncRepository, IFileSystem fileSystem) : IDownloadWorker
 {
-    /// <summary>Runs the worker, draining all jobs from <paramref name="reader"/> until the channel is complete or <paramref name="ct"/> is cancelled.</summary>
+    /// <inheritdoc />
     public async Task RunAsync(ChannelReader<SyncJob> reader, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
     {
         await foreach(var job in reader.ReadAllAsync(ct))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorkerFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadWorkerFactory.cs
@@ -1,0 +1,12 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class DownloadWorkerFactory(IHttpDownloader downloader, IGraphService graphService, ISyncRepository syncRepository, IFileSystem fileSystem) : IDownloadWorkerFactory
+{
+    /// <inheritdoc />
+    public IDownloadWorker Create(int workerId) => new DownloadWorker(workerId, downloader, graphService, syncRepository, fileSystem);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadWorker.cs
@@ -1,0 +1,11 @@
+using System.Threading.Channels;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>Drains sync jobs from a channel and executes each one.</summary>
+public interface IDownloadWorker
+{
+    /// <summary>Processes all jobs from <paramref name="reader"/> until the channel completes or <paramref name="ct"/> is cancelled.</summary>
+    Task RunAsync(ChannelReader<SyncJob> reader, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadWorkerFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadWorkerFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>Creates <see cref="IDownloadWorker"/> instances for the parallel download pipeline.</summary>
+public interface IDownloadWorkerFactory
+{
+    /// <summary>Creates a new worker with the given <paramref name="workerId"/>.</summary>
+    IDownloadWorker Create(int workerId);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelDownloadPipeline.cs
@@ -1,10 +1,7 @@
-using System.IO.Abstractions;
 using System.Threading.Channels;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
-
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -20,10 +17,11 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// never loads more than ~4 jobs per worker into memory at once.
 /// With 300k files this means memory stays flat regardless of job count.
 /// </summary>
-public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGraphService graphService, IHttpDownloader downloader, IFileSystem fileSystem) : IParallelDownloadPipeline
+public sealed class ParallelDownloadPipeline(IDownloadWorkerFactory workerFactory, ISyncRepository syncRepository) : IParallelDownloadPipeline
 {
     private readonly Lock _lock = new();
 
+    /// <inheritdoc />
     public async Task RunAsync(IEnumerable<SyncJob> jobs, string accessToken, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default)
     {
         var jobList = jobs.ToList();
@@ -58,8 +56,7 @@ public sealed class ParallelDownloadPipeline(ISyncRepository syncRepository, IGr
         }
 
         var workers = Enumerable.Range(1, workerCount)
-            .Select(id => new DownloadWorker(id, downloader, graphService, syncRepository, fileSystem)
-            .RunAsync(channel.Reader, accessToken, OnJobComplete, ct))
+            .Select(id => workerFactory.Create(id).RunAsync(channel.Reader, accessToken, OnJobComplete, ct))
             .ToList();
 
         try

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -45,6 +45,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ISyncEventAggregator, SyncEventAggregator>();
         _ = services.AddSingleton<ISettingsService, SettingsService>();
         _ = services.AddSingleton<IThemeService, ThemeService>();
+        _ = services.AddSingleton<IDownloadWorkerFactory, DownloadWorkerFactory>();
         _ = services.AddSingleton<IParallelDownloadPipeline, ParallelDownloadPipeline>();
         _ = services.AddSingleton<IAppBootstrapper, AppBootstrapper>();
         _ = services.AddOneDriveClient();


### PR DESCRIPTION
## Summary

- Introduces `IDownloadWorker` interface so the pipeline depends on an abstraction, not the concrete class
- Introduces `IDownloadWorkerFactory` / `DownloadWorkerFactory` — all worker construction now flows through DI instead of `new DownloadWorker(...)` inline
- `ParallelDownloadPipeline` now takes `(IDownloadWorkerFactory, ISyncRepository)` — no longer coupled to the full worker dependency graph
- Registers `IDownloadWorkerFactory` as singleton in `ShellServiceExtensions`
- Updates `GivenAParallelDownloadPipeline` to mock the factory via a private `SucceedingDownloadWorker` test double; adds `GivenADownloadWorkerFactory` with 3 tests covering `Create`

Closes #287

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `GivenAParallelDownloadPipeline` — 13 tests, all pass
- [x] `GivenADownloadWorker` — 8 tests, all pass (unchanged)
- [x] `GivenADownloadWorkerFactory` — 3 new tests, all pass
- [x] Full unit test suite — 830 pass, 8 pre-existing `GivenAThemeService` failures (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)