### PR TITLE
fix(apps/desktop): replace forbidden Option pattern match with Match in AccountFilesViewModel (#288)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
@@ -1,0 +1,80 @@
+using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnAccountFilesViewModelWithDriveIdFetchFailure
+{
+    private const string AccountIdString = "account-1";
+    private const string AccessToken = "token-abc";
+    private const string DriveIdErrorMessage = "Failed to retrieve drive: 403 Forbidden";
+
+    [Fact]
+    public async Task when_get_drive_id_fails_then_has_load_error_is_true()
+    {
+        var sut = BuildSut();
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.HasLoadError.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_fails_then_load_error_contains_failure_message()
+    {
+        var sut = BuildSut();
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.LoadError.ShouldBe($"Failed to retrieve drive ID: {DriveIdErrorMessage}");
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_fails_then_root_folders_remain_empty()
+    {
+        var sut = BuildSut();
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.RootFolders.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_get_drive_id_fails_then_is_loading_is_false()
+    {
+        var sut = BuildSut();
+
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        sut.IsLoading.ShouldBeFalse();
+    }
+
+    private static AccountFilesViewModel BuildSut()
+    {
+        var authService = Substitute.For<IAuthService>();
+        var graphService = Substitute.For<IGraphService>();
+        var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
+
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
+
+        graphService.GetDriveIdAsync(AccessToken, Arg.Any<CancellationToken>())
+            .Returns(new Result<DriveId, string>.Error(DriveIdErrorMessage));
+
+        return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>());
+    }
+
+    private static OneDriveAccount BuildAccount() => new()
+    {
+        Id      = new AccountId(AccountIdString),
+        Profile = AccountProfileFactory.Create("Test User", "test@test.com")
+    };
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -135,6 +135,17 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         if(folders is null)
             return;
 
+        var driveId = _driveId.Match<DriveId?>(
+            id => id,
+            () =>
+            {
+                Serilog.Log.Warning("[AccountFilesViewModel] Drive ID not available when building folder tree for account {AccountId}", _account.Id.Id);
+                return null;
+            });
+
+        if(driveId is null)
+            return;
+
         foreach(var f in folders)
         {
             string remotePath = $"/{f.Name}";
@@ -143,15 +154,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                 : FolderSyncState.Excluded;
 
             var node = new FolderTreeNode(Id: f.Id, Name: f.Name, ParentId: f.ParentId, AccountId: _account.Id.Id, RemotePath: remotePath, SyncState: syncState, HasChildren: true);
-
-            if(_driveId is not Option<DriveId>.Some driveIdSome)
-            {
-                Serilog.Log.Warning("[AccountFilesViewModel] Drive ID not available when building folder tree for account {AccountId}", _account.Id.Id);
-
-                return;
-            }
-
-            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveIdSome.Value);
+            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveId.Value);
 
             vm.IncludeToggled += OnIncludeToggledAsync;
             vm.ViewActivityRequested += OnViewActivityRequested;


### PR DESCRIPTION
## Summary

- Removes `is not Option<DriveId>.Some` pattern matching in `BuildRootFoldersAsync` — prohibited by `.claude/rules/c-sharp-code-style.md`
- Replaces with `_driveId.Match<DriveId?>` (logging warning inside the None lambda) + null-guard
- Moves the drive-ID check **outside** the `foreach` loop — it ran redundantly per-iteration before; now runs once

## Test plan

- [x] Added `GivenAnAccountFilesViewModelWithDriveIdFetchFailure` (4 tests) covering the previously untested `GetDriveIdAsync` failure path
- [x] All 19 `GivenAnAccountFilesViewModel*` tests pass
- [x] `dotnet build` — 0 errors, 0 warnings

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)