### PR TITLE
fix(apps/desktop): SyncScheduler.TriggerAccountAsync now logs warning for unknown account (#289)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -66,12 +66,21 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
     /// <inheritdoc />
     public async Task TriggerAccountAsync(string accountId, CancellationToken ct = default)
-        => await accountRepository.GetByIdAsync(new AccountId(accountId), ct)
-            .TapAsync(async entity =>
+    {
+        var accountOption = await accountRepository.GetByIdAsync(new AccountId(accountId), ct).ConfigureAwait(false);
+
+        await accountOption.Match<Task>(
+            async entity =>
             {
-                var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct);
-                await TriggerAccountAsync(MapEntityToAccount(entity, rules), ct);
+                var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct).ConfigureAwait(false);
+                await TriggerAccountAsync(MapEntityToAccount(entity, rules), ct).ConfigureAwait(false);
+            },
+            () =>
+            {
+                Serilog.Log.Warning("[SyncScheduler] TriggerAccountAsync called for unknown account {AccountId}", accountId);
+                return Task.CompletedTask;
             });
+    }
 
     /// <inheritdoc />
     public async Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default)


### PR DESCRIPTION
## Summary

- `TapAsync` on `Option.None` completed silently — no log, no feedback
- Replace `TapAsync` with `Match<Task>` so the `None` branch is explicit
- `None` branch emits a structured `Serilog.Log.Warning` with the account ID
- `Some` branch behaviour unchanged; gains `ConfigureAwait(false)` consistency

## Root cause

`TapAsync` is a side-effect-only combinator that skips `None` by design. Using it here meant a manual trigger for a deleted/missing account produced zero observable output — impossible to diagnose from logs.

## Test plan

- [x] All 842 existing unit tests pass (`dotnet test` — zero failures)
- [x] `when_trigger_account_by_id_and_account_not_found_then_sync_service_not_called` confirms sync service is never called for `None`
- [ ] Warning log output verified manually (static `Serilog.Log` cannot be asserted without a test sink; no sink infrastructure currently exists in this test project)

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)