### PR TITLE
fix(apps/desktop): replace Match bool predicate and nullable Result pattern in UploadService (#290)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -22,11 +22,11 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// </summary>
 public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSystem fileSystem) : IUploadService
 {
-    private const int ChunkSize10Mb = 10 * 1024 * 1024;
-
-    private const int    MaxRetries       = 5;
-    private const double BaseDelaySeconds = 2.0;
-    private const double MaxDelaySeconds  = 120.0;
+    private const int    ChunkSize10Mb                   = 10 * 1024 * 1024;
+    private const int    MaxRetries                      = 5;
+    private const double BaseDelaySeconds                = 2.0;
+    private const double MaxDelaySeconds                 = 120.0;
+    private const string UploadCompletedWithoutItemIdError = "Upload completed without receiving item ID from Graph API.";
 
     /// <summary>
     /// Uploads a local file to OneDrive using a resumable upload session.
@@ -44,14 +44,8 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         return await sessionResult.MatchAsync<Result<string, string>>(
             async sessionUrl =>
-            {
-                var uploadResult = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
-
-                if(uploadResult.Match(_ => true, _ => false))
-                    Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath);
-
-                return uploadResult;
-            },
+                await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct)
+                    .TapAsync(_ => Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath)),
             error => new Result<string, string>.Error(error));
     }
 
@@ -96,36 +90,35 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
         using var http = httpClientFactory.CreateClient();
         await using var file = fileSystem.File.OpenRead(localPath);
         byte[] buffer = new byte[ChunkSize10Mb];
-        long uploaded = 0L;
 
-        while(uploaded < totalBytes)
+        return await UploadNextChunkAsync(0L);
+
+        async Task<Result<string, string>> UploadNextChunkAsync(long uploaded)
         {
+            if(uploaded >= totalBytes)
+                return new Result<string, string>.Error(UploadCompletedWithoutItemIdError);
+
             ct.ThrowIfCancellationRequested();
 
             int bytesRead = await ReadChunkAsync(file, buffer, totalBytes, uploaded, ct);
 
             if(bytesRead == 0)
-                break;
+                return new Result<string, string>.Error(UploadCompletedWithoutItemIdError);
 
             long rangeEnd = ComputeRangeEnd(uploaded, bytesRead);
-            var chunkResult = await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct);
 
-            bool chunkFailed = false;
-            var earlyReturn = chunkResult.Match<Result<string, string>?>(
-                itemId => itemId is not null ? new Result<string, string>.Ok(itemId) : null,
-                error => { chunkFailed = true; return new Result<string, string>.Error(error); });
+            return await UploadChunkWithRetryAsync(http, sessionUrl, buffer.AsMemory(0, bytesRead), uploaded, rangeEnd, totalBytes, ct)
+                .BindAsync<string?, string, string>(async itemId =>
+                {
+                    long newUploaded = uploaded + bytesRead;
+                    progress?.Report(newUploaded);
 
-            if(chunkFailed)
-                return earlyReturn!;
+                    if(itemId is not null)
+                        return new Result<string, string>.Ok(itemId);
 
-            uploaded += bytesRead;
-            progress?.Report(uploaded);
-
-            if(earlyReturn is not null)
-                return earlyReturn;
+                    return await UploadNextChunkAsync(newUploaded);
+                });
         }
-
-        return new Result<string, string>.Error("Upload completed without receiving item ID from Graph API.");
     }
 
     private static async Task<int> ReadChunkAsync(Stream file, byte[] buffer, long totalBytes, long uploaded, CancellationToken ct)


### PR DESCRIPTION
## Summary

- **Fix A**: Replaced `uploadResult.Match(_ => true, _ => false)` bool predicate gating a log call with `TapAsync` — the correct tool for success-only side effects that leave the railway unchanged
- **Fix B**: Replaced the `bool chunkFailed` flag + nullable `Result<string,string>?` intermediate in `UploadChunksAsync` with a recursive local function using `BindAsync` — errors propagate automatically, `Ok(null)` (202 Accepted) recurses to the next chunk, `Ok(itemId)` (200/201) terminates with success
- Extracted the duplicate error message string to `private const string UploadCompletedWithoutItemIdError`

## Test plan

- [x] All 842 existing unit tests pass (`dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/`)
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Behaviour is identical: multi-chunk uploads, single-chunk uploads, error propagation, progress reporting all covered by existing integration-style tests against WireMock

🤖 Generated with [Claude Code](https://claude.com/claude-code)