### PR TITLE
refactor(apps/desktop): extract ConflictApplier from SyncService (#291)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAConflictApplier.cs
@@ -1,0 +1,148 @@
+using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+using ReactiveUnit = global::System.Reactive.Unit;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenAConflictApplier
+{
+    private readonly IGraphService   _graphService   = Substitute.For<IGraphService>();
+    private readonly IHttpDownloader _httpDownloader = Substitute.For<IHttpDownloader>();
+    private readonly IFileSystem     _fileSystem     = Substitute.For<IFileSystem>();
+
+    private ConflictApplier CreateSut() => new(_httpDownloader, _graphService, _fileSystem);
+
+    private static SyncConflict CreateUseRemoteConflict() => new()
+    {
+        Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("item-1")),
+        Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
+        Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow.AddMinutes(-5), 0L, DateTimeOffset.UtcNow, 0L)
+    };
+
+    [Fact]
+    public void when_constructed_then_instance_is_not_null()
+    {
+        var sut = CreateSut();
+
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task when_outcome_is_use_remote_and_url_resolution_succeeds_and_download_succeeds_then_returns_true()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
+        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<ReactiveUnit, string>.Ok(ReactiveUnit.Default));
+
+        var result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_outcome_is_use_remote_and_url_resolution_fails_then_returns_false()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Error("url-resolution-failed"));
+
+        var result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_outcome_is_use_remote_and_download_fails_then_returns_false()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
+        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
+
+        var result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_outcome_is_use_remote_and_url_resolution_fails_then_downloader_is_not_called()
+    {
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<string, string>.Error("url-resolution-failed"));
+
+        await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+
+        await _httpDownloader.DidNotReceive().DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_outcome_is_keep_both_and_local_file_exists_then_file_is_moved()
+    {
+        var mockPath = Substitute.For<IPath>();
+        mockPath.GetDirectoryName(Arg.Any<string>()).Returns("/local/path");
+        mockPath.GetFileNameWithoutExtension(Arg.Any<string>()).Returns("file");
+        mockPath.GetExtension(Arg.Any<string>()).Returns(".txt");
+        mockPath.Combine(Arg.Any<string>(), Arg.Any<string>()).Returns("/local/path/file (local 2024-01-01 00-00).txt");
+        _fileSystem.Path.Returns(mockPath);
+
+        var mockFile = Substitute.For<IFile>();
+        mockFile.Exists(Arg.Any<string>()).Returns(true);
+        _fileSystem.File.Returns(mockFile);
+
+        var conflict = new SyncConflict
+        {
+            Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
+            Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
+            Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow, 0L)
+        };
+
+        var result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+        mockFile.Received(1).Move(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task when_outcome_is_keep_both_and_local_file_does_not_exist_then_file_is_not_moved()
+    {
+        var mockPath = Substitute.For<IPath>();
+        mockPath.GetDirectoryName(Arg.Any<string>()).Returns("/local/path");
+        mockPath.GetFileNameWithoutExtension(Arg.Any<string>()).Returns("file");
+        mockPath.GetExtension(Arg.Any<string>()).Returns(".txt");
+        mockPath.Combine(Arg.Any<string>(), Arg.Any<string>()).Returns("/local/path/file (local 2024-01-01 00-00).txt");
+        _fileSystem.Path.Returns(mockPath);
+
+        var mockFile = Substitute.For<IFile>();
+        mockFile.Exists(Arg.Any<string>()).Returns(false);
+        _fileSystem.File.Returns(mockFile);
+
+        var conflict = new SyncConflict
+        {
+            Remote   = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
+            Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
+            Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow, 0L)
+        };
+
+        var result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+        mockFile.DidNotReceive().Move(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Theory]
+    [InlineData(ConflictOutcome.UseLocal)]
+    [InlineData(ConflictOutcome.Skip)]
+    public async Task when_outcome_is_not_requiring_action_then_returns_true(ConflictOutcome outcome)
+    {
+        var result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), outcome, "user-1", "token", TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -1,10 +1,9 @@
-using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
@@ -15,14 +14,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 public sealed class GivenASyncService
 {
     private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
-    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
     private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
-    private readonly IHttpDownloader       _httpDownloader       = Substitute.For<IHttpDownloader>();
     private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
-    private readonly IFileSystem           _fileSystem           = Substitute.For<IFileSystem>();
+    private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService BuildSut()
-        => new(_authService, _syncRepository, _httpDownloader, _graphService, _syncPassOrchestrator, _fileSystem);
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
 
     [Fact]
     public void when_constructed_then_instance_is_not_null()
@@ -141,6 +138,8 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var service = BuildSut();
         var conflict = new SyncConflict
@@ -179,6 +178,8 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var service = BuildSut();
         var conflict = new SyncConflict { Id = Guid.NewGuid(), Remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)) };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -1,30 +1,26 @@
-using System.IO.Abstractions;
-using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
-using ReactiveUnit = global::System.Reactive.Unit;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
 {
-    private readonly IAuthService    _authService    = Substitute.For<IAuthService>();
-    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
-    private readonly IHttpDownloader _httpDownloader = Substitute.For<IHttpDownloader>();
-    private readonly IGraphService   _graphService   = Substitute.For<IGraphService>();
+    private readonly IAuthService     _authService     = Substitute.For<IAuthService>();
+    private readonly ISyncRepository  _syncRepository  = Substitute.For<ISyncRepository>();
+    private readonly IConflictApplier _conflictApplier = Substitute.For<IConflictApplier>();
 
     public GivenASyncServiceApplyingUseRemoteConflictOutcome()
         => _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, _httpDownloader, _graphService, Substitute.For<ISyncPassOrchestrator>(), Substitute.For<IFileSystem>());
+        => new(_authService, _syncRepository, Substitute.For<ISyncPassOrchestrator>(), _conflictApplier);
 
     private static SyncConflict CreateConflict() => new()
     {
@@ -34,10 +30,10 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
     };
 
     [Fact]
-    public async Task when_url_resolution_fails_then_error_progress_is_raised()
+    public async Task when_applier_returns_false_then_error_progress_is_raised()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<string, string>.Error("url-resolution-failed"));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
 
         SyncProgressEventArgs? captured = null;
         var sut = CreateSut();
@@ -54,37 +50,24 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
     }
 
     [Fact]
-    public async Task when_download_fails_then_error_progress_is_raised()
+    public async Task when_applier_returns_false_then_sync_repository_resolve_is_not_called()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
-        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
-
-        SyncProgressEventArgs? captured = null;
-        var sut = CreateSut();
-        sut.SyncProgressChanged += (_, args) =>
-        {
-            if(args.SyncState == SyncState.Error)
-                captured = args;
-        };
-
-        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
-
-        captured.ShouldNotBeNull();
-        captured.SyncState.ShouldBe(SyncState.Error);
-    }
-
-    [Fact]
-    public async Task when_download_fails_then_sync_repository_resolve_is_not_called()
-    {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
-        _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
 
         await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
 
         await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+
+    [Fact]
+    public async Task when_applier_returns_true_then_sync_repository_resolve_is_called()
+    {
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -1,8 +1,7 @@
-using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
@@ -15,9 +14,10 @@ public sealed class GivenASyncServiceResolvingConflicts
     private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
     private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
     private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
+    private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, Substitute.For<IHttpDownloader>(), Substitute.For<IGraphService>(), _syncPassOrchestrator, Substitute.For<IFileSystem>());
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
 
     private static SyncConflict CreateConflict() => new()
     {
@@ -32,6 +32,8 @@ public sealed class GivenASyncServiceResolvingConflicts
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
         var sut = CreateSut();
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
@@ -61,5 +63,41 @@ public sealed class GivenASyncServiceResolvingConflicts
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
         await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+
+    [Fact]
+    public async Task when_conflict_applier_returns_false_then_sync_repository_resolve_is_not_called()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        var sut = CreateSut();
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+    }
+
+    [Fact]
+    public async Task when_conflict_applier_returns_false_then_error_progress_is_raised()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        SyncProgressEventArgs? captured = null;
+        var sut = CreateSut();
+        sut.SyncProgressChanged += (_, args) =>
+        {
+            if(args.SyncState == SyncState.Error)
+                captured = args;
+        };
+
+        await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.SyncState.ShouldBe(SyncState.Error);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -1,11 +1,9 @@
-using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
@@ -15,13 +13,11 @@ public sealed class GivenASyncServiceSyncingAnAccount
 {
     private readonly IAuthService          _authService          = Substitute.For<IAuthService>();
     private readonly ISyncRepository       _syncRepository       = Substitute.For<ISyncRepository>();
-    private readonly IHttpDownloader       _httpDownloader       = Substitute.For<IHttpDownloader>();
-    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
     private readonly ISyncPassOrchestrator _syncPassOrchestrator = Substitute.For<ISyncPassOrchestrator>();
-    private readonly IFileSystem           _fileSystem           = Substitute.For<IFileSystem>();
+    private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, _httpDownloader, _graphService, _syncPassOrchestrator, _fileSystem);
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
 
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ConflictApplier.cs
@@ -1,0 +1,61 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphService graphService, IFileSystem fileSystem) : IConflictApplier
+{
+    /// <inheritdoc />
+    public async Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
+    {
+        switch(outcome)
+        {
+            case ConflictOutcome.UseRemote:
+                return await ApplyUseRemoteAsync(conflict, accessToken, ct).ConfigureAwait(false);
+
+            case ConflictOutcome.KeepBoth:
+                ApplyKeepBoth(conflict);
+                return true;
+
+            default:
+                return true;
+        }
+    }
+
+    private async Task<bool> ApplyUseRemoteAsync(SyncConflict conflict, string accessToken, CancellationToken ct)
+    {
+        var urlResult = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
+
+        return await urlResult.MatchAsync<bool>(
+            async url =>
+            {
+                var downloadResult = await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
+
+                return downloadResult.Match<bool>(
+                    _ => true,
+                    downloadError =>
+                    {
+                        Serilog.Log.Error("[ConflictApplier] Download failed for {Path}: {Error}", conflict.Target.RelativePath, downloadError);
+
+                        return false;
+                    });
+            },
+            error =>
+            {
+                Serilog.Log.Error("[ConflictApplier] Could not resolve download URL for {Path}: {Error}", conflict.Target.RelativePath, error);
+
+                return false;
+            }).ConfigureAwait(false);
+    }
+
+    private void ApplyKeepBoth(SyncConflict conflict)
+    {
+        string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
+
+        if(fileSystem.File.Exists(conflict.Target.LocalPath))
+            fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IConflictApplier.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Applies a resolved conflict outcome by performing the required file-system or download operation.
+/// </summary>
+public interface IConflictApplier
+{
+    /// <summary>
+    /// Applies <paramref name="outcome"/> for <paramref name="conflict"/>.
+    /// Returns <see langword="true"/> on success; <see langword="false"/> when the operation could not be completed.
+    /// </summary>
+    Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -1,17 +1,14 @@
-using System.IO.Abstractions;
-using System.Reactive;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-public sealed class SyncService(IAuthService authService, ISyncRepository syncRepository, IHttpDownloader httpDownloader, IGraphService graphService, ISyncPassOrchestrator syncPassOrchestrator, IFileSystem fileSystem) : ISyncService
+public sealed class SyncService(IAuthService authService, ISyncRepository syncRepository, ISyncPassOrchestrator syncPassOrchestrator, IConflictApplier conflictApplier) : ISyncService
 {
     /// <inheritdoc />
     public event EventHandler<SyncProgressEventArgs>? SyncProgressChanged;
@@ -90,54 +87,16 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
-        var applied = await ApplyConflictOutcomeAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
+        var applied = await conflictApplier.ApplyAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
 
         if(!applied)
+        {
+            RaiseProgress(conflict.Remote.AccountId.Id, 0, 0, "Conflict resolution failed", SyncState.Error);
+
             return;
+        }
 
         await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
-    }
-
-    private async Task<bool> ApplyConflictOutcomeAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
-    {
-        switch(outcome)
-        {
-            case ConflictOutcome.UseRemote:
-                var urlResult = await graphService.GetDownloadUrlAsync(accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
-
-                return await urlResult.MatchAsync<bool>(
-                    async url =>
-                    {
-                        var downloadResult = await httpDownloader.DownloadAsync(url, conflict.Target.LocalPath, conflict.Snapshot.RemoteModified, ct: ct).ConfigureAwait(false);
-
-                        return downloadResult.Match<bool>(
-                            _ => true,
-                            downloadError =>
-                            {
-                                Serilog.Log.Error("[SyncService] Download failed resolving conflict for {Path}: {Error}", conflict.Target.RelativePath, downloadError);
-                                RaiseProgress(accountId, 0, 0, downloadError, SyncState.Error);
-
-                                return false;
-                            });
-                    },
-                    error =>
-                    {
-                        Serilog.Log.Error("[SyncService] Could not resolve download URL for conflict item {Path}: {Error}", conflict.Target.RelativePath, error);
-                        RaiseProgress(accountId, 0, 0, error, SyncState.Error);
-
-                        return false;
-                    }).ConfigureAwait(false);
-
-            case ConflictOutcome.KeepBoth:
-                string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
-                if(fileSystem.File.Exists(conflict.Target.LocalPath))
-                    fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
-
-                return true;
-
-            default:
-                return true;
-        }
     }
 
     private void RaiseProgress(string accountId, int completed, int total, string currentFile, SyncState syncState)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -32,6 +32,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IStartupService, StartupService>();
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();
         _ = services.AddSingleton<IUploadService, UploadService>();
+        _ = services.AddSingleton<IConflictApplier, ConflictApplier>();
         _ = services.AddSingleton<ILocalChangeDetector, LocalChangeDetector>();
         _ = services.AddSingleton<IRemoteFolderEnumerator, RemoteFolderEnumerator>();
         _ = services.AddSingleton<IRemoteDeletionDetector, RemoteDeletionDetector>();


### PR DESCRIPTION
## Summary

- Extracts `ApplyConflictOutcomeAsync` and its three dependencies (`IHttpDownloader`, `IGraphService`, `IFileSystem`) from `SyncService` into a new `ConflictApplier : IConflictApplier`
- `SyncService` constructor shrinks from 6 → 4 parameters
- `SyncService.ResolveConflictAsync` delegates to `IConflictApplier.ApplyAsync` and raises an error progress event when the applier returns `false`
- `IConflictApplier` and `ConflictApplier` registered in `ShellServiceExtensions`
- New `GivenAConflictApplier` test class covers the extracted class in isolation (UseRemote success/failure, KeepBoth with/without existing file, no-op outcomes)
- All affected `GivenASyncService*` test classes updated to inject `IConflictApplier` mock instead of the three removed dependencies

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test --filter "FullyQualifiedName~Infrastructure.Sync"` — 201 passed, 0 failed
- [x] Pre-existing `GivenAThemeService` failures confirmed unrelated (Avalonia UI thread issue, present on `main`)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)