### PR TITLE
refactor(apps/desktop): extract DownloadJobBuilder and SyncedItemRegistrar from RemoteFolderEnumerator (#292)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
@@ -1,0 +1,291 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Testably.Abstractions.Testing;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenADownloadJobBuilder
+{
+    private const string BasePath = "/sync-root";
+
+    private readonly ISyncedItemRegistrar _syncedItemRegistrar = Substitute.For<ISyncedItemRegistrar>();
+
+    private DownloadJobBuilder CreateSut(MockFileSystem mockFs) => new(_syncedItemRegistrar, mockFs);
+
+    private static OneDriveAccount CreateAccount(ConflictPolicy policy = ConflictPolicy.Ignore) => new()
+    {
+        Id                = new AccountId("user-1"),
+        Profile           = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
+        SyncConfig        = AccountSyncConfigFactory.Create(policy, LocalSyncPath.Restore(BasePath)),
+        SelectedFolderIds = []
+    };
+
+    private static SyncRuleEntity IncludeRule(string remotePath)
+        => new() { RemotePath = remotePath, RuleType = RuleType.Include };
+
+    private static DeltaItem FileItem(string id, string relativePath, string? etag = null, DateTimeOffset? lastModified = null)
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), false, false, 100L, lastModified ?? DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
+
+    private static DeltaItem FolderItem(string id, string relativePath)
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+
+    [Fact]
+    public async Task when_item_path_is_not_included_by_rules_then_no_job_is_created()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FileItem("item-a", "/Other/a.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_folder_item_is_encountered_then_register_folder_is_called()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FolderItem("subfolder-1", "/Documents/Sub") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncedItemRegistrar.Received(1).RegisterFolderAsync(Arg.Any<AccountId>(), Arg.Is<DeltaItem>(i => i.Id.Id == "subfolder-1"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_folder_item_is_encountered_then_no_job_is_created()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FolderItem("subfolder-1", "/Documents/Sub") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_file_has_no_known_item_and_no_local_file_then_download_job_is_created()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeOfType<DownloadSyncJob>();
+        result[0].Remote.RemoteItemId.Id.ShouldBe("item-a");
+    }
+
+    [Fact]
+    public async Task when_etag_matches_and_local_file_exists_then_no_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("data"));
+
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            Tags             = VersionInfoFactory.Create("etag-123", null),
+            RemoteModifiedAt = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", etag: "etag-123") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_local_file_is_newer_than_known_remote_then_conflict_callback_is_invoked()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
+        mockFileSystem.File.SetLastWriteTime(localFile, DateTime.UtcNow);
+
+        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            RemoteModifiedAt = remoteModified
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var conflictsDetected = new List<SyncConflict>();
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, conflict =>
+        {
+            conflictsDetected.Add(conflict);
+            return Task.CompletedTask;
+        }, TestContext.Current.CancellationToken);
+
+        conflictsDetected.ShouldHaveSingleItem();
+        conflictsDetected[0].Remote.RemoteItemId.Id.ShouldBe("item-a");
+    }
+
+    [Fact]
+    public async Task when_phantom_file_is_detected_then_register_phantom_is_called()
+    {
+        const string localFile = $"{BasePath}/Documents/phantom.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("phantom"));
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-phantom", "/Documents/phantom.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        await _syncedItemRegistrar.Received(1).RegisterPhantomAsync(Arg.Any<AccountId>(), Arg.Is<DeltaItem>(i => i.Id.Id == "item-phantom"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_phantom_file_is_detected_then_no_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/phantom.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("phantom"));
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-phantom", "/Documents/phantom.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_file_item_has_nested_path_then_download_job_local_path_starts_with_base_path()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/2024/report.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].Target.LocalPath.ShouldStartWith(BasePath);
+    }
+
+    [Fact]
+    public async Task when_file_item_has_nested_path_then_download_job_local_path_is_not_equal_to_base_path()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/2024/report.txt") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].Target.LocalPath.ShouldNotBe(BasePath);
+    }
+
+    [Fact]
+    public async Task when_conflict_policy_is_use_remote_then_download_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
+        mockFileSystem.File.SetLastWriteTime(localFile, DateTime.UtcNow);
+
+        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            RemoteModifiedAt = remoteModified
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.RemoteWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeOfType<DownloadSyncJob>();
+    }
+
+    [Fact]
+    public async Task when_conflict_policy_is_use_local_then_upload_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
+        mockFileSystem.File.SetLastWriteTime(localFile, DateTime.UtcNow);
+
+        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            RemoteModifiedAt = remoteModified
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.LocalWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeOfType<UploadSyncJob>();
+    }
+
+    [Fact]
+    public async Task when_conflict_policy_is_ignore_then_no_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
+        mockFileSystem.File.SetLastWriteTime(localFile, DateTime.UtcNow);
+
+        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId        = new AccountId("user-1"),
+            RemoteItemId     = new OneDriveItemId("item-a"),
+            RemotePath       = "/Documents/a.txt",
+            LocalPath        = localFile,
+            RemoteModifiedAt = remoteModified
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.Ignore), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -8,17 +8,14 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenARemoteFolderEnumerator
 {
-    private const string BasePath = "/sync-root";
-
-    private readonly IGraphService            _graphService            = Substitute.For<IGraphService>();
-    private readonly ISyncRuleRepository      _syncRuleRepository      = Substitute.For<ISyncRuleRepository>();
-    private readonly ISyncedItemRepository    _syncedItemRepository    = Substitute.For<ISyncedItemRepository>();
+    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
+    private readonly ISyncRuleRepository   _syncRuleRepository   = Substitute.For<ISyncRuleRepository>();
+    private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
 
     public GivenARemoteFolderEnumerator()
     {
@@ -28,33 +25,29 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
     }
 
-    private RemoteFolderEnumerator CreateSut(MockFileSystem mockFs) => new(_graphService, _syncRuleRepository, _syncedItemRepository, mockFs);
+    private RemoteFolderEnumerator CreateSut() => new(_graphService, _syncRuleRepository, _syncedItemRepository);
 
     private static OneDriveAccount CreateAccount() => new()
     {
         Id                = new AccountId("user-1"),
         Profile           = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
-        SyncConfig        = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore(BasePath)),
+        SyncConfig        = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/sync-root")),
         SelectedFolderIds = []
     };
 
     private static SyncRuleEntity IncludeRule(string remotePath, string? remoteItemId = null)
         => new() { RemotePath = remotePath, RuleType = RuleType.Include, RemoteItemId = remoteItemId };
 
-    private static DeltaItem FileItem(string id, string name, string? relativePath = null, string? etag = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
-
-    private static DeltaItem FolderItem(string id, string name, string? relativePath = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+    private static DeltaItem FileItem(string id, string name, string? relativePath = null)
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
 
     [Fact]
     public async Task when_no_rules_configured_then_result_has_no_rules_flag_set()
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        var sut = CreateSut(new MockFileSystem());
 
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         result.HadNoRules.ShouldBeTrue();
     }
@@ -64,23 +57,21 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        var sut = CreateSut(new MockFileSystem());
 
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task when_no_rules_configured_then_download_jobs_is_empty()
+    public async Task when_no_rules_configured_then_delta_items_is_empty()
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        var sut = CreateSut(new MockFileSystem());
 
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
-        result.DownloadJobs.ShouldBeEmpty();
+        result.DeltaItems.ShouldBeEmpty();
     }
 
     [Fact]
@@ -90,9 +81,8 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents")]);
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
-        var sut = CreateSut(new MockFileSystem());
 
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -106,9 +96,8 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns("folder-resolved");
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
-        var sut = CreateSut(new MockFileSystem());
 
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-resolved"), Arg.Any<CancellationToken>());
     }
@@ -120,9 +109,8 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
-        var sut = CreateSut(new MockFileSystem());
 
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
@@ -134,127 +122,26 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
-        var sut = CreateSut(new MockFileSystem());
 
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         result.SeenRemoteIds.ShouldContain("item-a");
         result.SeenRemoteIds.ShouldContain("item-b");
     }
 
     [Fact]
-    public async Task when_item_has_no_known_synced_item_and_no_local_file_then_download_job_is_created()
+    public async Task when_enumeration_returns_items_then_delta_items_contains_all_returned_items()
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt")]));
-        var sut = CreateSut(new MockFileSystem());
+            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
 
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
-        result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].Remote.RemoteItemId.Id.ShouldBe("item-a");
-        result.DownloadJobs[0].ShouldBeOfType<DownloadSyncJob>();
-    }
-
-    [Fact]
-    public async Task when_etag_matches_and_local_file_exists_then_no_download_job_is_created()
-    {
-        const string localFile = $"{BasePath}/Documents/a.txt";
-        var mockFileSystem = new MockFileSystem();
-        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("data"));
-
-        var knownItem = new SyncedItemEntity
-        {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
-            Tags             = VersionInfoFactory.Create("etag-123", null),
-            RemoteModifiedAt = DateTimeOffset.UtcNow.AddDays(-1)
-        };
-        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt", etag: "etag-123")]));
-        var sut = CreateSut(mockFileSystem);
-
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
-
-        result.DownloadJobs.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task when_local_file_is_newer_than_known_remote_by_more_than_5_seconds_then_on_conflict_callback_is_invoked()
-    {
-        const string localFile = $"{BasePath}/Documents/a.txt";
-        var localWriteTime = DateTime.UtcNow;
-        var mockFileSystem = new MockFileSystem();
-        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("modified locally"));
-        mockFileSystem.File.SetLastWriteTime(localFile, localWriteTime);
-
-        var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
-        var knownItem = new SyncedItemEntity
-        {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
-            RemoteModifiedAt = remoteModified
-        };
-        _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem });
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([DeltaItemFactory.Create(new OneDriveItemId("item-a"), new DriveId("drive-1"), null, ItemPathFactory.Create("a.txt", "/Documents/a.txt"), false, false, 100L, remoteModified, null, VersionInfoFactory.Create(null, null))]));
-
-        var conflictsDetected = new List<SyncConflict>();
-        var sut = CreateSut(mockFileSystem);
-
-        await sut.EnumerateAsync(CreateAccount(), "token", conflict =>
-        {
-            conflictsDetected.Add(conflict);
-            return Task.CompletedTask;
-        }, TestContext.Current.CancellationToken);
-
-        conflictsDetected.ShouldHaveSingleItem();
-        conflictsDetected[0].Remote.RemoteItemId.Id.ShouldBe("item-a");
-    }
-
-    [Fact]
-    public async Task when_item_is_a_folder_then_synced_item_repository_upsert_is_called()
-    {
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FolderItem("subfolder-1", "Sub", "/Documents/Sub")]));
-        var sut = CreateSut(new MockFileSystem());
-
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
-
-        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.IsFolder && e.RemoteItemId.Id == "subfolder-1"), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task when_file_exists_locally_without_synced_item_then_phantom_item_is_upserted()
-    {
-        const string localFile = $"{BasePath}/Documents/phantom.txt";
-        var mockFileSystem = new MockFileSystem();
-        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("phantom"));
-
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-phantom", "phantom.txt", "/Documents/phantom.txt")]));
-        var sut = CreateSut(mockFileSystem);
-
-        await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
-
-        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-phantom"), Arg.Any<CancellationToken>());
+        result.DeltaItems.Count.ShouldBe(2);
+        result.DeltaItems.ShouldContain(i => i.Id.Id == "item-a");
+        result.DeltaItems.ShouldContain(i => i.Id.Id == "item-b");
     }
 
     [Fact]
@@ -264,41 +151,10 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
-        var sut = CreateSut(new MockFileSystem());
 
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
 
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");
-    }
-
-    [Fact]
-    public async Task when_remote_file_item_has_nested_relative_path_then_download_job_local_path_starts_with_base_path()
-    {
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]));
-        var sut = CreateSut(new MockFileSystem());
-
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
-
-        result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].Target.LocalPath.ShouldStartWith(BasePath);
-    }
-
-    [Fact]
-    public async Task when_remote_file_item_has_nested_relative_path_then_download_job_local_path_does_not_equal_base_path()
-    {
-        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "report.txt", "/Documents/2024/report.txt")]));
-        var sut = CreateSut(new MockFileSystem());
-
-        var result = await sut.EnumerateAsync(CreateAccount(), "token", _ => Task.CompletedTask, TestContext.Current.CancellationToken);
-
-        result.DownloadJobs.ShouldHaveSingleItem();
-        result.DownloadJobs[0].Target.LocalPath.ShouldNotBe(BasePath);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncPassOrchestrator.cs
@@ -11,13 +11,14 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncPassOrchestrator
 {
-    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
-    private readonly IDriveStateRepository _driveStateRepository = Substitute.For<IDriveStateRepository>();
+    private readonly IAccountRepository     _accountRepository     = Substitute.For<IAccountRepository>();
+    private readonly IDriveStateRepository  _driveStateRepository  = Substitute.For<IDriveStateRepository>();
     private readonly IRemoteFolderEnumerator _remoteFolderEnumerator = Substitute.For<IRemoteFolderEnumerator>();
     private readonly IRemoteDeletionDetector _remoteDeletionDetector = Substitute.For<IRemoteDeletionDetector>();
-    private readonly ILocalDeletionDetector _localDeletionDetector = Substitute.For<ILocalDeletionDetector>();
-    private readonly ILocalChangeDetector _localChangeDetector = Substitute.For<ILocalChangeDetector>();
-    private readonly ISyncJobExecutor _syncJobExecutor = Substitute.For<ISyncJobExecutor>();
+    private readonly ILocalDeletionDetector  _localDeletionDetector  = Substitute.For<ILocalDeletionDetector>();
+    private readonly ILocalChangeDetector    _localChangeDetector    = Substitute.For<ILocalChangeDetector>();
+    private readonly ISyncJobExecutor        _syncJobExecutor        = Substitute.For<ISyncJobExecutor>();
+    private readonly IDownloadJobBuilder     _downloadJobBuilder     = Substitute.For<IDownloadJobBuilder>();
 
     private ISyncPassOrchestrator CreateSut()
     {
@@ -26,7 +27,8 @@ public sealed class GivenASyncPassOrchestrator
             _remoteDeletionDetector,
             _localDeletionDetector,
             _localChangeDetector,
-            _syncJobExecutor);
+            _syncJobExecutor,
+            _downloadJobBuilder);
 
         return new SyncPassOrchestrator(_accountRepository, _driveStateRepository, dependencies);
     }
@@ -45,8 +47,10 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
+        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<SyncJob>)[]);
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
             .Returns([]);
         _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
@@ -58,16 +62,15 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
-        var token = "token";
+        var token   = "token";
 
         await sut.OrchestrateAsync(account, token, _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteFolderEnumerator.Received(1).EnumerateAsync(
             Arg.Is(account),
             Arg.Is(token),
-            Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -76,10 +79,10 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         var result = await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -92,10 +95,10 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -113,7 +116,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         var result = await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -126,7 +129,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -144,7 +147,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -161,7 +164,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -182,8 +185,8 @@ public sealed class GivenASyncPassOrchestrator
         SetupDeepSyncPrerequisites();
 
         var progressMessages = new List<string>();
-        var sut = CreateSut();
-        var account = CreateAccount();
+        var sut              = CreateSut();
+        var account          = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
@@ -196,8 +199,8 @@ public sealed class GivenASyncPassOrchestrator
         SetupDeepSyncPrerequisites();
 
         var progressMessages = new List<string>();
-        var sut = CreateSut();
-        var account = CreateAccount();
+        var sut              = CreateSut();
+        var account          = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
@@ -213,7 +216,7 @@ public sealed class GivenASyncPassOrchestrator
         _accountRepository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.Some(new AccountEntity { Id = new AccountId("user-1") }));
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -226,7 +229,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         SetupDeepSyncPrerequisites();
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
@@ -237,27 +240,30 @@ public sealed class GivenASyncPassOrchestrator
     [Fact]
     public async Task when_conflict_is_detected_then_conflict_callback_is_invoked()
     {
-        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Option.None<DriveStateEntity>());
+        SetupDeepSyncPrerequisites();
 
-        var conflict = new SyncConflict { Id = Guid.NewGuid(), Remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)) };
+        var conflict = new SyncConflict
+        {
+            Id     = Guid.NewGuid(),
+            Remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty))
+        };
         var callbackInvoked = false;
 
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(async args =>
             {
-                var callback = args.ArgAt<Func<SyncConflict, Task>>(2);
+                var callback = args.ArgAt<Func<SyncConflict, Task>>(4);
                 await callback(conflict);
 
-                return new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true);
+                return (IReadOnlyList<SyncJob>)[];
             });
 
-        var sut = CreateSut();
+        var sut     = CreateSut();
         var account = CreateAccount();
 
         await sut.OrchestrateAsync(account, "token", async detectedConflict =>
         {
-            if (detectedConflict.Id == conflict.Id)
+            if(detectedConflict.Id == conflict.Id)
                 callbackInvoked = true;
             await Task.CompletedTask;
         }, ct: TestContext.Current.CancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
@@ -1,0 +1,89 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
+
+public sealed class GivenASyncedItemRegistrar
+{
+    private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
+    private readonly IDirectory _mockDirectory = Substitute.For<IDirectory>();
+    private readonly IFileSystem _fileSystem = Substitute.For<IFileSystem>();
+
+    public GivenASyncedItemRegistrar()
+        => _fileSystem.Directory.Returns(_mockDirectory);
+
+    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileSystem);
+
+    private static DeltaItem FolderItem(string id, string remotePath)
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+
+    private static DeltaItem FileItem(string id, string remotePath)
+        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
+
+    [Fact]
+    public async Task when_register_folder_called_then_directory_is_created()
+    {
+        var sut = CreateSut();
+        var item = FolderItem("folder-1", "/Documents/Sub");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/Documents/Sub", "/sync-root/Documents/Sub", syncedItems, TestContext.Current.CancellationToken);
+
+        _mockDirectory.Received(1).CreateDirectory("/sync-root/Documents/Sub");
+    }
+
+    [Fact]
+    public async Task when_register_folder_called_then_synced_item_repository_upsert_is_called()
+    {
+        var sut = CreateSut();
+        var item = FolderItem("folder-1", "/Documents/Sub");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/Documents/Sub", "/sync-root/Documents/Sub", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.IsFolder && e.RemoteItemId.Id == "folder-1"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_folder_called_then_synced_items_dict_is_updated()
+    {
+        var sut = CreateSut();
+        var item = FolderItem("folder-1", "/Documents/Sub");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/Documents/Sub", "/sync-root/Documents/Sub", syncedItems, TestContext.Current.CancellationToken);
+
+        syncedItems.ShouldContainKey("folder-1");
+        syncedItems["folder-1"].IsFolder.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_then_synced_item_repository_upsert_is_called()
+    {
+        var sut = CreateSut();
+        var item = FileItem("item-phantom", "/Documents/phantom.txt");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/Documents/phantom.txt", "/sync-root/Documents/phantom.txt", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-phantom"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_then_synced_items_dict_is_updated()
+    {
+        var sut = CreateSut();
+        var item = FileItem("item-phantom", "/Documents/phantom.txt");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/Documents/phantom.txt", "/sync-root/Documents/phantom.txt", syncedItems, TestContext.Current.CancellationToken);
+
+        syncedItems.ShouldContainKey("item-phantom");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
@@ -1,0 +1,119 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Conflicts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.Utilities;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar, IFileSystem fileSystem) : IDownloadJobBuilder
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    {
+        List<SyncJob> jobs = [];
+
+        foreach (var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
+        {
+            if (!SyncRuleEvaluator.IsIncluded(item.Path.EffectivePath, rules))
+                continue;
+
+            if (item.IsFolder)
+            {
+                string folderLocalPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
+                await syncedItemRegistrar.RegisterFolderAsync(account.Id, item, item.Path.EffectivePath, folderLocalPath, syncedItems, ct).ConfigureAwait(false);
+                continue;
+            }
+
+            var job = await ProcessFileItemAsync(account, item, syncedItems, onConflict, ct).ConfigureAwait(false);
+            if (job is not null)
+                jobs.Add(job);
+        }
+
+        return jobs;
+    }
+
+    private async Task<SyncJob?> ProcessFileItemAsync(OneDriveAccount account, DeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    {
+        string localPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
+        syncedItems.TryGetValue(item.Id.Id, out var knownItem);
+
+        if (knownItem?.Tags.ETag is not null && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
+        {
+            Serilog.Log.Debug("[DownloadJobBuilder] ETag match — skipping unchanged file {Path}", item.Path.RelativePath);
+            return null;
+        }
+
+        if (knownItem is not null && fileSystem.File.Exists(localPath))
+        {
+            var localModified = new DateTimeOffset(fileSystem.FileInfo.New(localPath).LastWriteTimeUtc, TimeSpan.Zero);
+            bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
+
+            if (isConflict)
+                return await BuildConflictJobAsync(account, item, localPath, localModified, onConflict).ConfigureAwait(false);
+        }
+        else if (knownItem is null && fileSystem.File.Exists(localPath))
+        {
+            await syncedItemRegistrar.RegisterPhantomAsync(account.Id, item, item.Path.EffectivePath, localPath, syncedItems, ct).ConfigureAwait(false);
+            return null;
+        }
+
+        return BuildDownloadJob(account.Id, item, localPath);
+    }
+
+    private async Task<SyncJob?> BuildConflictJobAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, Func<SyncConflict, Task> onConflict)
+    {
+        var conflict = BuildConflict(account, item, localPath, localModified);
+        await onConflict(conflict).ConfigureAwait(false);
+
+        var outcome = ConflictResolver.Resolve(account.SyncConfig!.ConflictPolicy, localModified, item.LastModified ?? DateTimeOffset.MinValue);
+
+        return outcome switch
+        {
+            ConflictOutcome.UseRemote => BuildDownloadJob(account.Id, item, localPath),
+            ConflictOutcome.UseLocal  => BuildUploadJob(account.Id, item, localPath, localModified),
+            ConflictOutcome.KeepBoth  => BuildKeepBothJob(account.Id, item, localPath, localModified),
+            _                         => null
+        };
+    }
+
+    private static DownloadSyncJob BuildDownloadJob(AccountId accountId, DeltaItem item, string localPath)
+    {
+        var remote   = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
+        var target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
+        var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+
+        return SyncJobFactory.CreateDownload(remote, target, metadata, item.DownloadUrl);
+    }
+
+    private UploadSyncJob BuildUploadJob(AccountId accountId, DeltaItem item, string localPath, DateTimeOffset localModified)
+    {
+        var remote   = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
+        var target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
+        var metadata = SyncFileMetadataFactory.Create(fileSystem.FileInfo.New(localPath).Length, localModified);
+
+        return SyncJobFactory.CreateUpload(remote, target, metadata);
+    }
+
+    private DownloadSyncJob BuildKeepBothJob(AccountId accountId, DeltaItem item, string localPath, DateTimeOffset localModified)
+    {
+        string newName = ConflictResolver.MakeKeepBothName(localPath, localModified, fileSystem);
+        fileSystem.File.Move(localPath, newName);
+
+        return BuildDownloadJob(accountId, item, localPath);
+    }
+
+    private SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
+        => new()
+        {
+            Remote   = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
+            Target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
+            Snapshot = ConflictSnapshotFactory.Create(localModified, fileSystem.FileInfo.New(localPath).Length, item.LastModified ?? DateTimeOffset.MinValue, item.Size)
+        };
+
+    private static string BuildLocalPath(string localBasePath, string relativePath)
+        => localBasePath.CombinePath(relativePath.Replace('/', Path.DirectorySeparatorChar));
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IDownloadJobBuilder.cs
@@ -1,0 +1,18 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Builds download and upload sync jobs from a list of remote delta items,
+/// applying conflict detection, rule filtering, and phantom-item registration.
+/// </summary>
+public interface IDownloadJobBuilder
+{
+    /// <summary>
+    /// Processes <paramref name="items"/>, applies sync rule filtering, registers folders and phantom
+    /// files via <see cref="ISyncedItemRegistrar"/>, detects conflicts, and returns the resulting jobs.
+    /// </summary>
+    Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/IRemoteFolderEnumerator.cs
@@ -1,19 +1,16 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <summary>
-/// Loads sync rules and synced items for an account, iterates every root include rule,
-/// resolves folder IDs, enumerates remote items, and classifies each as skipped, folder,
-/// phantom, conflict, or download job.
+/// Loads sync rules for an account, resolves drive and folder IDs, and enumerates
+/// remote delta items — returning raw results for downstream processing.
 /// </summary>
 public interface IRemoteFolderEnumerator
 {
     /// <summary>
-    /// Performs a full remote enumeration pass for <paramref name="account"/>.
-    /// Invokes <paramref name="onConflict"/> for each conflict detected so the caller
-    /// can persist and raise the event without coupling this service to <c>ISyncRepository</c>.
+    /// Performs a full remote enumeration pass for <paramref name="account"/>,
+    /// returning the raw delta-item list alongside seen IDs and rules.
     /// </summary>
-    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Func<SyncConflict, Task> onConflict, CancellationToken ct);
+    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncedItemRegistrar.cs
@@ -1,0 +1,17 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <summary>
+/// Registers synced items in the database for folders and phantom files encountered during enumeration.
+/// </summary>
+public interface ISyncedItemRegistrar
+{
+    /// <summary>Creates the local directory and upserts the folder tracking entity.</summary>
+    Task RegisterFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+
+    /// <summary>Registers a phantom file — exists locally with no tracking record — as already synced.</summary>
+    Task RegisterPhantomAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteEnumerationResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteEnumerationResult.cs
@@ -4,7 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <summary>
-/// Carries the output of a single remote-enumeration pass.
-/// Consumed by deletion detectors and the job executor.
+/// Carries the raw output of a single remote-enumeration pass.
+/// Downstream processors (<see cref="IDownloadJobBuilder"/>, deletion detectors) consume this result.
 /// </summary>
-public sealed record RemoteEnumerationResult(IReadOnlyList<SyncJob> DownloadJobs, IReadOnlySet<string> SeenRemoteIds, Dictionary<string, SyncedItemEntity> SyncedItems, IReadOnlyList<SyncRuleEntity> Rules, bool HadNoRules = false);
+public sealed record RemoteEnumerationResult(IReadOnlyList<DeltaItem> DeltaItems, IReadOnlySet<string> SeenRemoteIds, Dictionary<string, SyncedItemEntity> SyncedItems, IReadOnlyList<SyncRuleEntity> Rules, bool HadNoRules = false);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -1,22 +1,19 @@
-using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
-using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.Utilities;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem) : IRemoteFolderEnumerator
+public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository) : IRemoteFolderEnumerator
 {
     /// <inheritdoc />
-    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct)
     {
         var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
@@ -39,12 +36,13 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
         if(driveId is null)
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: false);
+
         var includeRules = rules.Where(r => r.RuleType == RuleType.Include).ToList();
         var rootIncludeRules = includeRules
             .Where(rule => !includeRules.Any(other => other.RemotePath != rule.RemotePath && rule.RemotePath.StartsWith(other.RemotePath + "/", StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
-        List<SyncJob> downloadJobs = [];
+        List<DeltaItem> allDeltaItems = [];
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach(var rule in rootIncludeRules)
@@ -75,10 +73,13 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
             Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
 
-            await ProcessItemsForRuleAsync(account, items, rules, syncedItems, downloadJobs, onConflict, seenRemoteIds, ct).ConfigureAwait(false);
+            foreach(var item in items)
+                seenRemoteIds.Add(item.Id.Id);
+
+            allDeltaItems.AddRange(items);
         }
 
-        return new RemoteEnumerationResult(downloadJobs, seenRemoteIds, syncedItems, rules);
+        return new RemoteEnumerationResult(allDeltaItems, seenRemoteIds, syncedItems, rules);
     }
 
     private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, string accessToken, DriveId driveId, CancellationToken ct)
@@ -96,129 +97,6 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         return folderId;
     }
 
-    private async Task ProcessItemsForRuleAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict, HashSet<string> seenRemoteIds, CancellationToken ct)
-    {
-        foreach(var item in items.TakeWhile(_ => !ct.IsCancellationRequested))
-        {
-            seenRemoteIds.Add(item.Id.Id);
-
-            if(!SyncRuleEvaluator.IsIncluded(item.Path.EffectivePath, rules))
-                continue;
-
-            if(item.IsFolder)
-            {
-                await HandleFolderAsync(account.Id, item, item.Path.EffectivePath, account.SyncConfig!.LocalSyncPath.Value, syncedItems, ct).ConfigureAwait(false);
-                continue;
-            }
-
-            await ProcessFileItemAsync(account, item, rules, syncedItems, downloadJobs, onConflict, ct).ConfigureAwait(false);
-        }
-    }
-
-    private async Task ProcessFileItemAsync(OneDriveAccount account, DeltaItem item, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict, CancellationToken ct)
-    {
-        string localPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
-
-        syncedItems.TryGetValue(item.Id.Id, out var knownItem);
-
-        if(knownItem?.Tags.ETag is not null && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
-        {
-            Serilog.Log.Debug("[RemoteFolderEnumerator] ETag match — skipping unchanged file {Path}", item.Path.RelativePath);
-
-            return;
-        }
-
-        if(knownItem is not null && fileSystem.File.Exists(localPath))
-        {
-            var localModified = new DateTimeOffset(fileSystem.FileInfo.New(localPath).LastWriteTimeUtc, TimeSpan.Zero);
-            bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
-
-            if(isConflict)
-            {
-                var conflict = BuildConflict(account, item, localPath, localModified);
-                await HandleConflictAsync(account, item, localPath, localModified, conflict, downloadJobs, onConflict).ConfigureAwait(false);
-
-                return;
-            }
-        }
-        else if(knownItem is null && fileSystem.File.Exists(localPath))
-        {
-            Serilog.Log.Debug("[RemoteFolderEnumerator] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
-            var phantomItem = SyncedItemEntityFactory.Create(account.Id, item, item.Path.EffectivePath, localPath);
-            await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
-            syncedItems[item.Id.Id] = phantomItem;
-
-            return;
-        }
-
-        var remote = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id);
-        var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
-        var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
-
-        downloadJobs.Add(SyncJobFactory.CreateDownload(remote, target, metadata, item.DownloadUrl));
-    }
-
-    private async Task HandleFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localBasePath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
-    {
-        string localPath = BuildLocalPath(localBasePath, remotePath.TrimStart('/'));
-        _ = fileSystem.Directory.CreateDirectory(localPath);
-
-        var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
-        await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
-        syncedItems[item.Id.Id] = entity;
-    }
-
-    private async Task HandleConflictAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, SyncConflict conflict, List<SyncJob> downloadJobs, Func<SyncConflict, Task> onConflict)
-    {
-        await onConflict(conflict).ConfigureAwait(false);
-
-        var outcome = ConflictResolver.Resolve(account.SyncConfig!.ConflictPolicy, localModified, item.LastModified ?? DateTimeOffset.MinValue);
-
-        switch(outcome)
-        {
-            case ConflictOutcome.Skip:
-                break;
-
-            case ConflictOutcome.UseRemote:
-                var remoteR = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id);
-                var targetR = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
-                var metadataR = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
-
-                downloadJobs.Add(SyncJobFactory.CreateDownload(remoteR, targetR, metadataR, item.DownloadUrl));
-                break;
-
-            case ConflictOutcome.UseLocal:
-                var remoteL = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id);
-                var targetL = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
-                var metadataL = SyncFileMetadataFactory.Create(fileSystem.FileInfo.New(localPath).Length, localModified);
-
-                downloadJobs.Add(SyncJobFactory.CreateUpload(remoteL, targetL, metadataL));
-                break;
-
-            case ConflictOutcome.KeepBoth:
-                string newName = ConflictResolver.MakeKeepBothName(localPath, localModified, fileSystem);
-                fileSystem.File.Move(localPath, newName);
-
-                var remoteK = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id);
-                var targetK = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
-                var metadataK = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
-
-                downloadJobs.Add(SyncJobFactory.CreateDownload(remoteK, targetK, metadataK, item.DownloadUrl));
-                break;
-        }
-    }
-
     private static string? TryResolveFromSyncedItems(Dictionary<string, SyncedItemEntity> syncedItems, string remotePath)
         => syncedItems.Values.FirstOrDefault(i => i.IsFolder && string.Equals(i.RemotePath, remotePath, StringComparison.OrdinalIgnoreCase))?.RemoteItemId.Id;
-
-    private SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
-        => new()
-        {
-            Remote   = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
-            Target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
-            Snapshot = ConflictSnapshotFactory.Create(localModified, fileSystem.FileInfo.New(localPath).Length, item.LastModified ?? DateTimeOffset.MinValue, item.Size)
-        };
-
-    private static string BuildLocalPath(string localBasePath, string relativePath)
-        => localBasePath.CombinePath(relativePath.Replace('/', Path.DirectorySeparatorChar));
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncPassOrchestrator.cs
@@ -17,13 +17,9 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         driveState.DeltaLink = null;
         await driveStateRepository.UpsertAsync(driveState, ct).ConfigureAwait(false);
 
-        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(
-            account,
-            token,
-            conflictCallback,
-            ct).ConfigureAwait(false);
+        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, ct).ConfigureAwait(false);
 
-        if (enumerationResult.HadNoRules)
+        if(enumerationResult.HadNoRules)
             return false;
 
         var syncedItemsDict = new Dictionary<string, SyncedItemEntity>(enumerationResult.SyncedItems);
@@ -34,24 +30,19 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         RaiseProgress(account.Id.Id, 0, 0, "Detecting local changes...", onProgress);
         await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, token, syncedItemsDict, ct).ConfigureAwait(false);
 
+        var downloadJobs = await dependencies.DownloadJobBuilder.BuildAsync(account, enumerationResult.DeltaItems, enumerationResult.Rules, syncedItemsDict, conflictCallback, ct).ConfigureAwait(false);
+
         var syncedItemsByLocalPath = syncedItemsDict.Values.ToDictionary(i => i.LocalPath, StringComparer.OrdinalIgnoreCase);
         var uploadJobs = dependencies.LocalChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, account.SyncConfig!.LocalSyncPath.Value, enumerationResult.Rules, syncedItemsByLocalPath);
 
-        var allJobs = new List<SyncJob>(enumerationResult.DownloadJobs.Count + uploadJobs.Count);
-        allJobs.AddRange(enumerationResult.DownloadJobs);
+        var allJobs = new List<SyncJob>(downloadJobs.Count + uploadJobs.Count);
+        allJobs.AddRange(downloadJobs);
         allJobs.AddRange(uploadJobs);
 
-        if (allJobs.Count > 0)
+        if(allJobs.Count > 0)
         {
             RaiseProgress(account.Id.Id, 0, allJobs.Count, $"Syncing {allJobs.Count} file(s)...", onProgress);
-            await dependencies.JobExecutor.ExecuteAsync(
-                account,
-                token,
-                allJobs,
-                syncedItemsDict,
-                onProgress ?? (_ => { }),
-                onJobCompleted ?? (_ => { }),
-                ct).ConfigureAwait(false);
+            await dependencies.JobExecutor.ExecuteAsync(account, token, allJobs, syncedItemsDict, onProgress ?? (_ => { }), onJobCompleted ?? (_ => { }), ct).ConfigureAwait(false);
         }
         else
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncServiceDependencies.cs
@@ -1,7 +1,7 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <summary>
-/// Groups the five sync-pass collaborators injected into <see cref="SyncPassOrchestrator"/>
+/// Groups the sync-pass collaborators injected into <see cref="SyncPassOrchestrator"/>
 /// to keep its constructor within the parameter-count guideline.
 /// </summary>
-public sealed record SyncServiceDependencies(IRemoteFolderEnumerator RemoteFolderEnumerator, IRemoteDeletionDetector RemoteDeletionDetector, ILocalDeletionDetector LocalDeletionDetector, ILocalChangeDetector LocalChangeDetector, ISyncJobExecutor JobExecutor);
+public sealed record SyncServiceDependencies(IRemoteFolderEnumerator RemoteFolderEnumerator, IRemoteDeletionDetector RemoteDeletionDetector, ILocalDeletionDetector LocalDeletionDetector, ILocalChangeDetector LocalChangeDetector, ISyncJobExecutor JobExecutor, IDownloadJobBuilder DownloadJobBuilder);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
@@ -1,0 +1,29 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+
+/// <inheritdoc />
+public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem) : ISyncedItemRegistrar
+{
+    /// <inheritdoc />
+    public async Task RegisterFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    {
+        _ = fileSystem.Directory.CreateDirectory(localPath);
+        var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
+        await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
+        syncedItems[item.Id.Id] = entity;
+    }
+
+    /// <inheritdoc />
+    public async Task RegisterPhantomAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    {
+        Serilog.Log.Debug("[SyncedItemRegistrar] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
+        var phantomItem = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
+        await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
+        syncedItems[item.Id.Id] = phantomItem;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -33,6 +33,8 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();
         _ = services.AddSingleton<IUploadService, UploadService>();
         _ = services.AddSingleton<IConflictApplier, ConflictApplier>();
+        _ = services.AddSingleton<ISyncedItemRegistrar, SyncedItemRegistrar>();
+        _ = services.AddSingleton<IDownloadJobBuilder, DownloadJobBuilder>();
         _ = services.AddSingleton<ILocalChangeDetector, LocalChangeDetector>();
         _ = services.AddSingleton<IRemoteFolderEnumerator, RemoteFolderEnumerator>();
         _ = services.AddSingleton<IRemoteDeletionDetector, RemoteDeletionDetector>();


### PR DESCRIPTION
## Summary

- `RemoteFolderEnumerator` stripped to pure remote enumeration — returns `IReadOnlyList<DeltaItem>` instead of pre-built jobs; `EnumerateAsync` no longer takes `onConflict`
- New `DownloadJobBuilder` / `IDownloadJobBuilder` — owns conflict detection, conflict-policy application, and `SyncJob` construction
- New `SyncedItemRegistrar` / `ISyncedItemRegistrar` — owns phantom-item creation and folder registration
- `SyncPassOrchestrator` now orchestrates enumerate → build-jobs two-step, passing the conflict callback to `DownloadJobBuilder`
- `SyncServiceDependencies` gains `IDownloadJobBuilder`; both new services registered in `ShellServiceExtensions`

## Test plan

- [ ] `GivenARemoteFolderEnumerator` — slimmed to enumeration-only behaviour
- [ ] `GivenADownloadJobBuilder` — full coverage: rule filtering, folder registration, ETag skip, new-file download, conflict callback, phantom registration, conflict policies (RemoteWins/LocalWins/Ignore), path construction
- [ ] `GivenASyncedItemRegistrar` — folder creation, phantom upsert, dict update
- [ ] `GivenASyncPassOrchestrator` — updated to wire `IDownloadJobBuilder` mock; conflict callback routed through orchestrator
- [ ] `dotnet build` — zero errors, zero warnings
- [ ] `dotnet test` — 857 pass, 0 new failures (8 pre-existing `GivenAThemeService` failures unrelated to this change)

Closes #292

🤖 Generated with [Claude Code](https://claude.ai/claude-code)