### PR TITLE
refactor(apps/desktop): extract IAccountOnboardingService from AccountsViewModel (#295)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -5,8 +5,8 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
-using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
 
@@ -22,51 +22,39 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     private const string FolderName2  = "Desktop";
 
     [Fact]
-    public async Task when_wizard_completes_with_selected_folders_then_sync_rules_are_written_to_sync_rule_repository()
+    public async Task when_wizard_completes_then_account_onboarding_service_is_called()
     {
-        var (authService, graphService, repository, syncRuleRepo) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, syncRuleRepo);
+        var (authService, graphService, repository, onboardingService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService);
 
-        await DriveWizardToCompletionAsync(sut, authService, graphService);
+        await DriveWizardToCompletionAsync(sut);
 
-        await syncRuleRepo.Received().UpsertAsync(Arg.Any<AccountId>(), $"/{FolderName1}", RuleType.Include, FolderId1, Arg.Any<CancellationToken>());
-        await syncRuleRepo.Received().UpsertAsync(Arg.Any<AccountId>(), $"/{FolderName2}", RuleType.Include, FolderId2, Arg.Any<CancellationToken>());
+        await onboardingService.Received(1).CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task when_wizard_completes_with_two_selected_folders_then_two_sync_rules_are_written()
+    public async Task when_wizard_completes_then_account_is_added_to_accounts_collection()
     {
-        var (authService, graphService, repository, syncRuleRepo) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, syncRuleRepo);
+        var (authService, graphService, repository, onboardingService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService);
 
-        await DriveWizardToCompletionAsync(sut, authService, graphService);
+        await DriveWizardToCompletionAsync(sut);
 
-        await syncRuleRepo.Received(2).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        sut.Accounts.Count.ShouldBe(1);
     }
 
     [Fact]
-    public async Task when_wizard_completes_with_no_selected_folders_then_no_sync_rules_are_written()
+    public async Task when_wizard_is_cancelled_then_account_onboarding_service_is_not_called()
     {
-        var (authService, graphService, repository, syncRuleRepo) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, syncRuleRepo);
+        var (authService, graphService, repository, onboardingService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService);
 
-        await DriveWizardToCompletionWithNoFoldersAsync(sut, authService, graphService);
+        await DriveWizardToCancellationAsync(sut);
 
-        await syncRuleRepo.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await onboardingService.DidNotReceive().CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task when_wizard_completes_then_account_is_persisted_to_account_repository()
-    {
-        var (authService, graphService, repository, syncRuleRepo) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, syncRuleRepo);
-
-        await DriveWizardToCompletionAsync(sut, authService, graphService);
-
-        await repository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
-    }
-
-    private static async Task DriveWizardToCompletionAsync(AccountsViewModel sut, IAuthService authService, IGraphService graphService)
+    private static async Task DriveWizardToCompletionAsync(AccountsViewModel sut)
     {
         sut.AddAccount();
         var wizard = sut.Wizard!;
@@ -79,25 +67,23 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         await Task.Delay(200);
     }
 
-    private static async Task DriveWizardToCompletionWithNoFoldersAsync(AccountsViewModel sut, IAuthService authService, IGraphService graphService)
+    private static async Task DriveWizardToCancellationAsync(AccountsViewModel sut)
     {
         sut.AddAccount();
         var wizard = sut.Wizard!;
 
         await wizard.OpenBrowserCommand.ExecuteAsync(null);
-        await wizard.NextCommand.ExecuteAsync(null);
-        wizard.SkipFoldersCommand.Execute(null);
-        await wizard.NextCommand.ExecuteAsync(null);
+        await wizard.CancelCommand.ExecuteAsync(null);
 
-        await Task.Delay(200);
+        await Task.Delay(50);
     }
 
-    private static (IAuthService AuthService, IGraphService GraphService, IAccountRepository Repository, ISyncRuleRepository SyncRuleRepo) BuildMocks()
+    private static (IAuthService AuthService, IGraphService GraphService, IAccountRepository Repository, IAccountOnboardingService OnboardingService) BuildMocks()
     {
-        var authService  = Substitute.For<IAuthService>();
-        var graphService = Substitute.For<IGraphService>();
-        var repository   = Substitute.For<IAccountRepository>();
-        var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
+        var authService       = Substitute.For<IAuthService>();
+        var graphService      = Substitute.For<IGraphService>();
+        var repository        = Substitute.For<IAccountRepository>();
+        var onboardingService = Substitute.For<IAccountOnboardingService>();
 
         authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, AccountProfileFactory.Create(DisplayName, Email)));
@@ -105,9 +91,12 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         graphService.GetRootFoldersAsync(AccessToken, Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId1, FolderName1), new DriveFolder(FolderId2, FolderName2)]));
 
-        return (authService, graphService, repository, syncRuleRepo);
+        onboardingService.CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => callInfo.Arg<OneDriveAccount>());
+
+        return (authService, graphService, repository, onboardingService);
     }
 
-    private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepo)
-        => new(authService, graphService, repository, syncRuleRepo, Substitute.For<ISyncEventAggregator>());
+    private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService onboardingService)
+        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>());
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
@@ -37,7 +38,7 @@ public sealed class GivenAMainWindowViewModel
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _syncEventAggregator);
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
@@ -15,7 +16,7 @@ public sealed class GivenAStatusBarViewModel
     private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
     private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _syncEventAggregator);
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
 
     private static AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) });
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Onboarding/GivenAnAccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Onboarding/GivenAnAccountOnboardingService.cs
@@ -1,0 +1,151 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Onboarding;
+
+public sealed class GivenAnAccountOnboardingService
+{
+    private const string AccountIdStr = "account-1";
+    private const string DisplayName  = "Test User";
+    private const string Email        = "test@outlook.com";
+    private const string FolderId1    = "f1";
+    private const string FolderName1  = "Documents";
+    private const string FolderId2    = "f2";
+    private const string FolderName2  = "Desktop";
+
+    private readonly IAccountRepository  _accountRepository  = Substitute.For<IAccountRepository>();
+    private readonly ISyncRuleRepository _syncRuleRepository = Substitute.For<ISyncRuleRepository>();
+
+    private AccountOnboardingService BuildSut() => new(_accountRepository, _syncRuleRepository);
+
+    private static OneDriveAccount BuildAccountWithFolders()
+        => new()
+        {
+            Id        = new AccountId(AccountIdStr),
+            Profile   = AccountProfileFactory.Create(DisplayName, Email),
+            IsActive  = true,
+            FolderNames = new Dictionary<OneDriveFolderId, string>
+            {
+                { new OneDriveFolderId(FolderId1), FolderName1 },
+                { new OneDriveFolderId(FolderId2), FolderName2 }
+            }
+        };
+
+    private static OneDriveAccount BuildAccountWithNoFolders()
+        => new()
+        {
+            Id        = new AccountId(AccountIdStr),
+            Profile   = AccountProfileFactory.Create(DisplayName, Email),
+            IsActive  = false,
+            FolderNames = []
+        };
+
+    [Fact]
+    public void when_constructed_then_instance_is_not_null()
+    {
+        var sut = BuildSut();
+
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task when_completing_onboarding_then_account_is_upserted_to_repository()
+    {
+        var account = BuildAccountWithFolders();
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _accountRepository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_completing_onboarding_with_folders_then_sync_rules_are_written_for_each_folder()
+    {
+        var account = BuildAccountWithFolders();
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _syncRuleRepository.Received().UpsertAsync(Arg.Any<AccountId>(), $"/{FolderName1}", RuleType.Include, FolderId1, Arg.Any<CancellationToken>());
+        await _syncRuleRepository.Received().UpsertAsync(Arg.Any<AccountId>(), $"/{FolderName2}", RuleType.Include, FolderId2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_completing_onboarding_with_two_folders_then_exactly_two_sync_rules_are_written()
+    {
+        var account = BuildAccountWithFolders();
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _syncRuleRepository.Received(2).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_completing_onboarding_with_no_folders_then_no_sync_rules_are_written()
+    {
+        var account = BuildAccountWithNoFolders();
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_account_is_active_then_set_active_account_is_called()
+    {
+        var account = BuildAccountWithFolders();
+        account.IsActive = true;
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _accountRepository.Received(1).SetActiveAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_account_is_not_active_then_set_active_account_is_not_called()
+    {
+        var account = BuildAccountWithFolders();
+        account.IsActive = false;
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        await _accountRepository.DidNotReceive().SetActiveAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_account_has_no_sync_config_then_sync_config_is_resolved_from_email()
+    {
+        var account = BuildAccountWithFolders();
+        account.SyncConfig = null;
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        account.SyncConfig.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task when_account_has_existing_sync_config_then_sync_config_is_not_overwritten()
+    {
+        var account      = BuildAccountWithFolders();
+        var existingPath = LocalSyncPathFactory.Create("/custom/path").Match<LocalSyncPath>(p => p, _ => throw new InvalidOperationException());
+        var existingConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, existingPath);
+        account.SyncConfig = existingConfig;
+
+        await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        account.SyncConfig.ShouldBeSameAs(existingConfig);
+    }
+
+    [Fact]
+    public async Task when_completing_onboarding_then_same_account_instance_is_returned()
+    {
+        var account = BuildAccountWithFolders();
+
+        var result = await BuildSut().CompleteOnboardingAsync(account, CancellationToken.None);
+
+        result.ShouldBeSameAs(account);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
@@ -62,7 +63,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
 
     private MainWindowViewModel CreateMainWindowViewModel()
     {
-        var accounts = new AccountsViewModel(authService, graphService, accountRepository, syncRuleRepository, syncEventAggregator);
+        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator);
         var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem);
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
         var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
@@ -37,7 +38,7 @@ public sealed class GivenAnApplicationInitializer
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _syncEventAggregator);
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -4,19 +4,17 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
-
-using AStar.Dev.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, ISyncEventAggregator syncEventAggregator) : ObservableObject
+public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator) : ObservableObject
 {
     public ObservableCollection<AccountCardViewModel> Accounts { get; } = [];
 
@@ -97,32 +95,18 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
                     CloseWizard();
 
                     account.AccentIndex = Accounts.Count % 6;
-                    account.IsActive = Accounts.Count == 0;
-                    if(account.SyncConfig is null)
-                    {
-                        var defaultPath = ApplicationMetadata.ApplicationNameLowered.UserDirectory().CombinePath(account.Profile.Email);
-                        var resolvedPath = LocalSyncPathFactory.Create(defaultPath).Match<LocalSyncPath?>(p => p, _ => null);
-                        if(resolvedPath is not null)
-                            account.SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, resolvedPath);
-                    }
+                    account.IsActive    = Accounts.Count == 0;
 
-                    var entity = ToEntity(account);
-                    await repository.UpsertAsync(entity, CancellationToken.None);
+                    var finalisedAccount = await accountOnboardingService.CompleteOnboardingAsync(account, CancellationToken.None);
 
-                    foreach(var (folderId, folderName) in account.FolderNames)
-                        await syncRuleRepository.UpsertAsync(account.Id, $"/{folderName}", RuleType.Include, folderId.Id, CancellationToken.None);
-
-                    if(account.IsActive)
-                        await repository.SetActiveAccountAsync(account.Id, CancellationToken.None);
-
-                    var card = BuildCard(account);
+                    var card = BuildCard(finalisedAccount);
                     Accounts.Add(card);
                     OnPropertyChanged(nameof(HasAccounts));
 
-                    if(account.IsActive)
+                    if(finalisedAccount.IsActive)
                         ActiveAccount = card;
 
-                    AccountAdded?.Invoke(this, account);
+                    AccountAdded?.Invoke(this, finalisedAccount);
 
                     return Unit.Default;
                 })
@@ -210,15 +194,4 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
         return card;
     }
 
-    private static AccountEntity ToEntity(OneDriveAccount a)
-        => new()
-        {
-            Id           = a.Id,
-            Profile      = a.Profile,
-            AccentIndex  = a.AccentIndex,
-            IsActive     = a.IsActive,
-            LastSyncedAt = a.LastSyncedAt,
-            Quota        = a.Quota,
-            SyncConfig   = a.SyncConfig ?? AccountSyncConfigFactory.Default
-        };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
@@ -1,0 +1,49 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.Utilities;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
+
+/// <inheritdoc />
+public sealed class AccountOnboardingService(IAccountRepository accountRepository, ISyncRuleRepository syncRuleRepository) : IAccountOnboardingService
+{
+    /// <inheritdoc />
+    public async Task<OneDriveAccount> CompleteOnboardingAsync(OneDriveAccount account, CancellationToken ct)
+    {
+        if(account.SyncConfig is null)
+            account.SyncConfig = ResolveDefaultSyncConfig(account.Profile.Email);
+
+        await accountRepository.UpsertAsync(ToEntity(account), ct);
+
+        foreach(var (folderId, folderName) in account.FolderNames)
+            await syncRuleRepository.UpsertAsync(account.Id, $"/{folderName}", RuleType.Include, folderId.Id, ct);
+
+        if(account.IsActive)
+            await accountRepository.SetActiveAccountAsync(account.Id, ct);
+
+        return account;
+    }
+
+    private static AccountSyncConfig? ResolveDefaultSyncConfig(string email)
+    {
+        var defaultPath = ApplicationMetadata.ApplicationNameLowered.UserDirectory().CombinePath(email);
+
+        return LocalSyncPathFactory.Create(defaultPath)
+            .Match<AccountSyncConfig?>(p => AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, p), _ => null);
+    }
+
+    private static AccountEntity ToEntity(OneDriveAccount account)
+        => new()
+        {
+            Id           = account.Id,
+            Profile      = account.Profile,
+            AccentIndex  = account.AccentIndex,
+            IsActive     = account.IsActive,
+            LastSyncedAt = account.LastSyncedAt,
+            Quota        = account.Quota,
+            SyncConfig   = account.SyncConfig ?? AccountSyncConfigFactory.Default
+        };
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/IAccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/IAccountOnboardingService.cs
@@ -1,0 +1,14 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
+
+/// <summary>Handles persistence and configuration during account onboarding.</summary>
+public interface IAccountOnboardingService
+{
+    /// <summary>
+    /// Persists the new account, resolves a default sync path when none is configured,
+    /// writes sync rules for each selected folder, and marks the account active when appropriate.
+    /// Returns the finalised <see cref="OneDriveAccount"/>.
+    /// </summary>
+    Task<OneDriveAccount> CompleteOnboardingAsync(OneDriveAccount account, CancellationToken ct);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -2,6 +2,7 @@ using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.OneDrive;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
@@ -26,6 +27,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ILogEntryProvider>(inMemoryLogSink);
         _ = services.AddSingleton<IFileSystem, RealFileSystem>();
         _ = services.AddSingleton<ITokenCacheService, TokenCacheService>();
+        _ = services.AddSingleton<IAccountOnboardingService, AccountOnboardingService>();
         _ = services.AddSingleton<IAuthService, AuthService>();
         _ = services.AddSingleton<IGraphClientFactory, GraphClientFactory>();
         _ = services.AddSingleton<IGraphService, GraphService>();


### PR DESCRIPTION
## Summary

- Introduces `IAccountOnboardingService` / `AccountOnboardingService` in `Infrastructure/Onboarding/`
- Moves default sync-path resolution, `AccountEntity` persistence, sync-rule writing, and `SetActiveAccountAsync` out of `AccountsViewModel.OnWizardCompletedAsync` into the new service
- `AccountsViewModel` now receives `IAccountOnboardingService` (replaces `ISyncRuleRepository` in its constructor) and expresses UI intent only: sets `AccentIndex`/`IsActive`, delegates to the service, then builds/adds the card
- Registers `IAccountOnboardingService` as a singleton in `ShellServiceExtensions`
- Adds `GivenAnAccountOnboardingService` with 9 unit tests covering persistence, sync-rule writing, active-account promotion, and default-path resolution
- Updates `GivenAnAccountsViewModelWithACompletingWizard` to assert the VM calls the service; persistence tests move to the service test class

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test` — 897 passed, 0 failed
- [x] `GivenAnAccountOnboardingService` — 9 new tests green
- [x] `GivenAnAccountsViewModelWithACompletingWizard` — updated tests pass

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)