### PR TITLE
refactor(apps/desktop): extract OneDriveAccountFactory.CreateFromWizardResult (#298)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
@@ -1,0 +1,77 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnOneDriveAccountFactory
+{
+    private const string AccountId   = "account-abc";
+    private const string DisplayName = "Test User";
+    private const string Email       = "test@example.com";
+    private const string FolderId1   = "folder-1";
+    private const string FolderName1 = "Documents";
+    private const string FolderId2   = "folder-2";
+    private const string FolderName2 = "Desktop";
+
+    private static AccountProfile Profile => AccountProfileFactory.Create(DisplayName, Email);
+
+    private static IEnumerable<WizardFolderItem> TwoSelectedFolders =>
+    [
+        new WizardFolderItem(FolderId1, FolderName1) { IsSelected = true },
+        new WizardFolderItem(FolderId2, FolderName2) { IsSelected = true }
+    ];
+
+    [Fact]
+    public void when_given_account_id_then_account_id_is_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.Id.ShouldBe(new AccountId(AccountId));
+    }
+
+    [Fact]
+    public void when_given_profile_then_profile_is_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.Profile.DisplayName.ShouldBe(DisplayName);
+        result.Profile.Email.ShouldBe(Email);
+    }
+
+    [Fact]
+    public void when_given_selected_folders_then_selected_folder_ids_are_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.SelectedFolderIds.Count.ShouldBe(2);
+        result.SelectedFolderIds.ShouldContain(new OneDriveFolderId(FolderId1));
+        result.SelectedFolderIds.ShouldContain(new OneDriveFolderId(FolderId2));
+    }
+
+    [Fact]
+    public void when_given_selected_folders_then_folder_names_are_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.FolderNames[new OneDriveFolderId(FolderId1)].ShouldBe(FolderName1);
+        result.FolderNames[new OneDriveFolderId(FolderId2)].ShouldBe(FolderName2);
+    }
+
+    [Fact]
+    public void when_given_no_selected_folders_then_selected_folder_ids_is_empty()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, []);
+
+        result.SelectedFolderIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void when_given_no_selected_folders_then_folder_names_is_empty()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, []);
+
+        result.FolderNames.ShouldBeEmpty();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccountFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccountFactory.cs
@@ -1,0 +1,22 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
+
+public static class OneDriveAccountFactory
+{
+    public static OneDriveAccount CreateFromWizardResult(string accountId, AccountProfile profile, IEnumerable<WizardFolderItem> selectedFolders)
+    {
+        var folders = selectedFolders.ToList();
+
+        return new OneDriveAccount
+        {
+            Id               = new AccountId(accountId),
+            Profile          = profile,
+            SelectedFolderIds = [.. folders.Select(f => new OneDriveFolderId(f.Id))],
+            FolderNames      = folders.ToDictionary(f => new OneDriveFolderId(f.Id), f => f.Name)
+        };
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -7,8 +7,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Onboarding;
 
 public sealed partial class AddAccountWizardViewModel(IAuthService authService, IGraphService graphService) : ObservableObject, IDisposable
@@ -238,15 +236,9 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
 
     private void Finish()
     {
-        var account = new OneDriveAccount
-        {
-            Id = new AccountId(_accountId),
-            Profile = AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
-            SelectedFolderIds = [.. Folders.Where(f => f.IsSelected).Select(f => new OneDriveFolderId(f.Id))],
-            FolderNames = Folders
-                .Where(f => f.IsSelected)
-                .ToDictionary(f => new OneDriveFolderId(f.Id), f => f.Name)
-        };
+        var account = OneDriveAccountFactory.CreateFromWizardResult(
+            _accountId, AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
+            Folders.Where(f => f.IsSelected));
         Completed?.Invoke(this, account);
     }
 


### PR DESCRIPTION
## Summary

- Added `OneDriveAccountFactory.CreateFromWizardResult(string accountId, AccountProfile profile, IEnumerable<WizardFolderItem> selectedFolders)` — domain object construction now belongs to the factory, not the presentation layer
- `AddAccountWizardViewModel.Finish()` reduced from 10 lines of inline object initialisation to a single factory call
- Removed unused `AccountId` alias from the VM's `using` directives
- 6 new unit tests covering id, profile, folder IDs, folder name map, and empty-folder cases

## Test plan

- [ ] `dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — 907 total, 6 new tests pass
- [ ] RED commit `9b4fb93` — `GivenAnOneDriveAccountFactory` fails to compile (factory missing)
- [ ] GREEN commit `4fa8eff` — all 6 factory tests pass, existing wizard VM tests unaffected

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)