### PR TITLE
Refactor logging in AStar.Dev.OneDrive.Sync.Client to use ILogger + LogMessage

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
@@ -75,6 +76,6 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManager
             Profile = AccountProfileFactory.Create("Test User", "test@test.com")
         };
 
-        return new AccountFilesViewModel(account, authService, graphService, repository, syncRuleRepo, fileSystem, fileManagerService);
+        return new AccountFilesViewModel(account, authService, graphService, repository, syncRuleRepo, fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
@@ -43,7 +44,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.LastWriteWins), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.LastWriteWins), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         sut.RootFolders[0].ToggleIncludeCommand.Execute(null);
@@ -63,7 +64,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -86,7 +87,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -109,7 +110,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -132,7 +133,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -154,7 +155,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -176,7 +177,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -238,6 +239,6 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        return new(account, authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        return new(account, authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
@@ -26,7 +27,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
     {
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
 
-        return new AccountFilesViewModel(BuildAccount(), authService, Substitute.For<IGraphService>(), Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        return new AccountFilesViewModel(BuildAccount(), authService, Substitute.For<IGraphService>(), Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     }
 
     [Fact]
@@ -119,7 +120,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        var sut = new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
 
         await sut.LoadCommand.ExecuteAsync(null);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
@@ -70,7 +71,7 @@ public sealed class GivenAnAccountFilesViewModelWithDriveIdFetchFailure
         graphService.GetDriveIdAsync(AccountIdString, AccessToken, Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Error(DriveIdErrorMessage));
 
-        return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>());
+        return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     }
 
     private static OneDriveAccount BuildAccount() => new()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
 
@@ -98,5 +99,5 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     }
 
     private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService onboardingService)
-        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>());
+        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>(), Substitute.For<ILogger<AccountsViewModel>>());
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
@@ -1,0 +1,77 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnOneDriveAccountFactory
+{
+    private const string AccountId   = "account-abc";
+    private const string DisplayName = "Test User";
+    private const string Email       = "test@example.com";
+    private const string FolderId1   = "folder-1";
+    private const string FolderName1 = "Documents";
+    private const string FolderId2   = "folder-2";
+    private const string FolderName2 = "Desktop";
+
+    private static AccountProfile Profile => AccountProfileFactory.Create(DisplayName, Email);
+
+    private static IEnumerable<WizardFolderItem> TwoSelectedFolders =>
+    [
+        new WizardFolderItem(FolderId1, FolderName1) { IsSelected = true },
+        new WizardFolderItem(FolderId2, FolderName2) { IsSelected = true }
+    ];
+
+    [Fact]
+    public void when_given_account_id_then_account_id_is_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.Id.ShouldBe(new AccountId(AccountId));
+    }
+
+    [Fact]
+    public void when_given_profile_then_profile_is_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.Profile.DisplayName.ShouldBe(DisplayName);
+        result.Profile.Email.ShouldBe(Email);
+    }
+
+    [Fact]
+    public void when_given_selected_folders_then_selected_folder_ids_are_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.SelectedFolderIds.Count.ShouldBe(2);
+        result.SelectedFolderIds.ShouldContain(new OneDriveFolderId(FolderId1));
+        result.SelectedFolderIds.ShouldContain(new OneDriveFolderId(FolderId2));
+    }
+
+    [Fact]
+    public void when_given_selected_folders_then_folder_names_are_set()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, TwoSelectedFolders);
+
+        result.FolderNames[new OneDriveFolderId(FolderId1)].ShouldBe(FolderName1);
+        result.FolderNames[new OneDriveFolderId(FolderId2)].ShouldBe(FolderName2);
+    }
+
+    [Fact]
+    public void when_given_no_selected_folders_then_selected_folder_ids_is_empty()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, []);
+
+        result.SelectedFolderIds.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void when_given_no_selected_folders_then_folder_names_is_empty()
+    {
+        var result = OneDriveAccountFactory.CreateFromWizardResult(AccountId, Profile, []);
+
+        result.FolderNames.ShouldBeEmpty();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
@@ -5,7 +5,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Conflicts;
 
 public sealed class GivenAConflictResolver
 {
-    private static readonly MockFileSystem MockFs = new();
+    private static readonly MockFileSystem mockFileSystem = new();
 
     [Fact]
     public void when_resolving_with_ignore_policy_then_skip_is_returned()
@@ -143,7 +143,7 @@ public sealed class GivenAConflictResolver
         string localPath = "/home/jason/Documents/report.docx";
         var localModified = new DateTimeOffset(2024, 1, 15, 14, 32, 0, TimeSpan.Zero);
 
-        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, MockFs);
+        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, mockFileSystem);
 
         result.ShouldContain("report");
         result.ShouldContain("docx");
@@ -158,7 +158,7 @@ public sealed class GivenAConflictResolver
         string localPath = "/home/jason/My Documents/My Report.docx";
         var localModified = DateTimeOffset.UtcNow;
 
-        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, MockFs);
+        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, mockFileSystem);
 
         result.ShouldContain("My Report");
         result.ShouldEndWith(".docx");
@@ -170,7 +170,7 @@ public sealed class GivenAConflictResolver
         string localPath = "/home/jason/Documents/README";
         var localModified = DateTimeOffset.UtcNow;
 
-        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, MockFs);
+        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, mockFileSystem);
 
         result.ShouldContain("README");
         result.ShouldContain("local");
@@ -182,7 +182,7 @@ public sealed class GivenAConflictResolver
         string localPath = "/home/jason/file.tar.gz";
         var localModified = DateTimeOffset.UtcNow;
 
-        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, MockFs);
+        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, mockFileSystem);
 
         result.ShouldContain("file.tar");
         result.ShouldEndWith(".gz");
@@ -195,8 +195,8 @@ public sealed class GivenAConflictResolver
         var time1 = new DateTimeOffset(2024, 1, 15, 14, 32, 0, TimeSpan.Zero);
         var time2 = new DateTimeOffset(2024, 1, 16, 14, 32, 0, TimeSpan.Zero);
 
-        string result1 = ConflictResolver.MakeKeepBothName(localPath, time1, MockFs);
-        string result2 = ConflictResolver.MakeKeepBothName(localPath, time2, MockFs);
+        string result1 = ConflictResolver.MakeKeepBothName(localPath, time1, mockFileSystem);
+        string result2 = ConflictResolver.MakeKeepBothName(localPath, time2, mockFileSystem);
 
         result1.ShouldNotBe(result2);
         result1.ShouldContain("2024-01-15");
@@ -209,7 +209,7 @@ public sealed class GivenAConflictResolver
         string localPath = "/home/jason/Documents/report.docx";
         var localModified = DateTimeOffset.UtcNow;
 
-        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, MockFs);
+        string result = ConflictResolver.MakeKeepBothName(localPath, localModified, mockFileSystem);
 
         string? resultDir = Path.GetDirectoryName(result);
         string? originalDir = Path.GetDirectoryName(localPath);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
@@ -2,6 +2,7 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
 
@@ -148,6 +149,6 @@ public sealed class GivenAFolderTreeNodeViewModel
             SyncState:   syncState,
             HasChildren: true);
 
-        return new FolderTreeNodeViewModel(node, graphService, AccessToken, new DriveId(DriveIdString));
+        return new FolderTreeNodeViewModel(node, graphService, AccessToken, new DriveId(DriveIdString), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -13,6 +13,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
@@ -38,8 +39,8 @@ public sealed class GivenAMainWindowViewModel
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
-    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository);
@@ -48,7 +49,7 @@ public sealed class GivenAMainWindowViewModel
     {
         var accountsVm = CreateAccountsViewModel();
 
-        return new(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
+        return new(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm), Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     [Fact]
@@ -106,7 +107,7 @@ public sealed class GivenAMainWindowViewModel
         const string accountIdStr = "active-account-123";
         var accountsVm = CreateAccountsViewModel();
         accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test User", "test@example.com") });
-        var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm));
+        var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), new StatusBarViewModel(accountsVm), Substitute.For<ILogger<MainWindowViewModel>>());
 
         await sut.SyncNowCommand.ExecuteAsync(null);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
 
@@ -16,7 +17,7 @@ public sealed class GivenAStatusBarViewModel
     private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
     private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
 
     private static AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) });
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
@@ -1,5 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
+using NSubstitute;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;
@@ -11,7 +13,7 @@ public sealed class GivenATokenCacheService
     {
         _ = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         _ = service.ShouldNotBeNull();
         service.CacheDirectory.ShouldNotBeNullOrEmpty();
@@ -20,7 +22,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_constructed_then_cache_directory_property_is_not_null()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         _ = service.CacheDirectory.ShouldNotBeNull();
     }
@@ -28,7 +30,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_is_not_empty()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         service.CacheDirectory.Length.ShouldBeGreaterThan(0);
     }
@@ -36,7 +38,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_contains_app_name()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         service.CacheDirectory.ShouldContain("astar-dev-onedrive-sync");
     }
@@ -47,7 +49,7 @@ public sealed class GivenATokenCacheService
         var mockApp = Substitute.For<IPublicClientApplication>();
         var mockCache = Substitute.For<ITokenCache>();
         _ = mockApp.UserTokenCache.Returns(mockCache);
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
         try
         {
             await service.RegisterAsync(mockApp);
@@ -64,7 +66,7 @@ public sealed class GivenATokenCacheService
         var mockApp = Substitute.For<IPublicClientApplication>();
         var mockCache = Substitute.For<ITokenCache>();
         _ = mockApp.UserTokenCache.Returns(mockCache);
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         try
         {
@@ -81,8 +83,8 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_two_instances_are_created_then_they_share_the_same_cache_directory()
     {
-        var service1 = new TokenCacheService(new MockFileSystem());
-        var service2 = new TokenCacheService(new MockFileSystem());
+        var service1 = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
+        var service2 = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         _ = service1.ShouldNotBeNull();
         _ = service2.ShouldNotBeNull();
@@ -95,7 +97,7 @@ public sealed class GivenATokenCacheService
     [InlineData("different/path")]
     public void when_cache_directory_is_read_then_it_is_platform_specific(string _)
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         string cacheDir = service.CacheDirectory;
         cacheDir.ShouldNotBeNullOrEmpty();
@@ -105,7 +107,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_twice_then_same_value_is_returned()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
         string cachedDir = service.CacheDirectory;
         service.CacheDirectory.ShouldBe(cachedDir);
     }
@@ -113,7 +115,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_is_an_absolute_path()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         bool isAbsolute = Path.IsPathRooted(service.CacheDirectory);
         isAbsolute.ShouldBeTrue();
@@ -122,7 +124,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_property_is_inspected_then_it_has_no_setter()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         _ = service.CacheDirectory;
         var property = typeof(TokenCacheService).GetProperty("CacheDirectory");
@@ -133,7 +135,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public async Task when_register_async_called_with_null_then_null_reference_exception_is_thrown()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
         try
         {
             await service.RegisterAsync(null!);
@@ -155,7 +157,7 @@ public sealed class GivenATokenCacheService
         {
             var task = Task.Run(() =>
             {
-                var service = new TokenCacheService(new MockFileSystem());
+                var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
                 lock (lockObj)
                 {
                     services.Add(service);
@@ -177,7 +179,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_path_is_rooted()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
 
         service.CacheDirectory.ShouldNotBeNullOrEmpty();
         Path.IsPathRooted(service.CacheDirectory).ShouldBeTrue();
@@ -186,7 +188,7 @@ public sealed class GivenATokenCacheService
     [Fact]
     public void when_cache_directory_is_read_then_it_matches_platform_convention()
     {
-        var service = new TokenCacheService(new MockFileSystem());
+        var service = new TokenCacheService(new MockFileSystem(), Substitute.For<ILogger<TokenCacheService>>());
         string cacheDir = service.CacheDirectory;
         if (OperatingSystem.IsWindows())
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
@@ -16,14 +17,17 @@ public sealed class GivenASettingsService
         return mockFileSystem;
     }
 
+    private static SettingsService CreateService(string? path = SettingsPath)
+        => new(CreateMockFileSystem(), Substitute.For<ILogger<SettingsService>>(), path);
+
     [Fact]
     public void when_constructed_then_service_implements_isettings_service() =>
-        new SettingsService(CreateMockFileSystem(), SettingsPath).ShouldBeAssignableTo<ISettingsService>();
+        CreateService().ShouldBeAssignableTo<ISettingsService>();
 
     [Fact]
     public async Task when_load_async_is_called_then_service_still_implements_isettings_service()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         await service.LoadAsync();
 
@@ -33,7 +37,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_save_async_is_called_without_subscribers_then_no_exception_is_thrown()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         await Should.NotThrowAsync(() => service.SaveAsync());
     }
@@ -41,7 +45,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_save_async_is_called_multiple_times_then_settings_changed_is_raised_each_time()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
         int raiseCount = 0;
         service.SettingsChanged += (_, _) => raiseCount++;
 
@@ -54,7 +58,7 @@ public sealed class GivenASettingsService
     [Fact]
     public async Task when_settings_changed_event_is_raised_then_sender_is_the_service_instance()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
         object? capturedSender = null;
         service.SettingsChanged += (sender, _) => capturedSender = sender;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
@@ -27,10 +28,13 @@ public sealed class GivenASettingsServiceLoadAsync
         return mockFileSystem;
     }
 
+    private static SettingsService CreateService(MockFileSystem fileSystem)
+        => new(fileSystem, Substitute.For<ILogger<SettingsService>>(), SettingsPath);
+
     [Fact]
     public async Task when_settings_file_does_not_exist_then_current_uses_defaults_after_load()
     {
-        var sut = new SettingsService(CreateEmptyMockileSystem(), SettingsPath);
+        var sut = CreateService(CreateEmptyMockileSystem());
 
         await sut.LoadAsync();
 
@@ -42,7 +46,7 @@ public sealed class GivenASettingsServiceLoadAsync
     public async Task when_valid_json_file_exists_then_current_is_populated_after_load()
     {
         var expected = new AppSettings { Theme = AppTheme.Dark, SyncIntervalMinutes = 15, Locale = "fr-FR" };
-        var sut = new SettingsService(CreateMockFileSystemWithSettings(expected), SettingsPath);
+        var sut = CreateService(CreateMockFileSystemWithSettings(expected));
 
         await sut.LoadAsync();
 
@@ -56,7 +60,7 @@ public sealed class GivenASettingsServiceLoadAsync
     {
         var mockFileSystem = CreateEmptyMockileSystem();
         mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("{ this is not valid json }}}"));
-        var sut = new SettingsService(mockFileSystem, SettingsPath);
+        var sut = CreateService(mockFileSystem);
 
         await sut.LoadAsync();
 
@@ -69,7 +73,7 @@ public sealed class GivenASettingsServiceLoadAsync
     {
         var mockFileSystem = CreateEmptyMockileSystem();
         mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("not json at all"));
-        var sut = new SettingsService(mockFileSystem, SettingsPath);
+        var sut = CreateService(mockFileSystem);
 
         await Should.NotThrowAsync(() => sut.LoadAsync());
     }
@@ -79,7 +83,7 @@ public sealed class GivenASettingsServiceLoadAsync
     {
         var mockFileSystem = CreateEmptyMockileSystem();
         mockFileSystem.Initialize().WithFile(SettingsPath).Which(m => m.HasStringContent("null"));
-        var sut = new SettingsService(mockFileSystem, SettingsPath);
+        var sut = CreateService(mockFileSystem);
 
         await sut.LoadAsync();
 
@@ -90,7 +94,7 @@ public sealed class GivenASettingsServiceLoadAsync
     public async Task when_load_async_is_called_multiple_times_then_current_reflects_latest_file_content()
     {
         var mockFileSystem = CreateMockFileSystemWithSettings(new AppSettings { Theme = AppTheme.Light });
-        var sut = new SettingsService(mockFileSystem, SettingsPath);
+        var sut = CreateService(mockFileSystem);
         await sut.LoadAsync();
         sut.Current.Theme.ShouldBe(AppTheme.Light);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
@@ -18,10 +19,13 @@ public sealed class GivenASettingsServiceWithDefaults
         return mockFileSystem;
     }
 
+    private static SettingsService CreateService()
+        => new(CreateMockFileSystem(), Substitute.For<ILogger<SettingsService>>(), SettingsPath);
+
     [Fact]
     public void when_constructed_then_settings_have_default_values()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         _ = service.Current.ShouldNotBeNull();
         service.Current.Theme.ShouldBe(AppTheme.System);
@@ -33,7 +37,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_current_is_read_then_it_is_app_settings()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         var settings = service.Current;
 
@@ -44,7 +48,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_theme_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.Theme = AppTheme.Dark;
 
@@ -54,7 +58,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_locale_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.Locale = "fr-FR";
 
@@ -64,7 +68,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_default_conflict_policy_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.DefaultConflictPolicy = ConflictPolicy.LastWriteWins;
 
@@ -74,7 +78,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_sync_interval_minutes_is_set_then_it_is_preserved()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.SyncIntervalMinutes = 30;
 
@@ -84,7 +88,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_save_async_called_then_settingschanged_event_is_raised()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
         bool eventRaised = false;
         AppSettings? changedSettings = null;
         service.SettingsChanged += (s, settings) =>
@@ -104,7 +108,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_save_async_called_then_settings_are_persisted()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
         service.Current.Locale = "de-DE";
         service.Current.SyncIntervalMinutes = 45;
 
@@ -117,7 +121,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_load_async_called_then_no_exception_is_thrown()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         await Should.NotThrowAsync(() => service.LoadAsync());
     }
@@ -125,7 +129,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_load_async_called_then_current_settings_is_not_null()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         await service.LoadAsync();
 
@@ -138,7 +142,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(AppTheme.Dark)]
     public void when_any_theme_is_set_then_it_is_preserved(AppTheme theme)
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.Theme = theme;
 
@@ -152,7 +156,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData("es-ES")]
     public void when_any_locale_is_set_then_it_is_preserved(string locale)
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.Locale = locale;
 
@@ -166,7 +170,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(ConflictPolicy.LocalWins)]
     public void when_any_conflict_policy_is_set_then_it_is_preserved(ConflictPolicy policy)
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.DefaultConflictPolicy = policy;
 
@@ -180,7 +184,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [InlineData(120)]
     public void when_any_sync_interval_is_set_then_it_is_preserved(int minutes)
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.SyncIntervalMinutes = minutes;
 
@@ -190,7 +194,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public void when_multiple_settings_are_changed_then_all_are_maintained()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
 
         service.Current.Theme = AppTheme.Dark;
         service.Current.Locale = "fr-FR";
@@ -206,7 +210,7 @@ public sealed class GivenASettingsServiceWithDefaults
     [Fact]
     public async Task when_save_async_called_after_multiple_changes_then_event_includes_all_changes()
     {
-        var service = new SettingsService(CreateMockFileSystem(), SettingsPath);
+        var service = CreateService();
         bool eventRaised = false;
         AppSettings? changedSettings = null;
         service.SettingsChanged += (s, settings) =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -15,6 +15,7 @@ using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Shell;
@@ -63,17 +64,17 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
 
     private MainWindowViewModel CreateMainWindowViewModel()
     {
-        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator);
-        var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>());
+        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+        var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
         var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator);
         var settings = new SettingsViewModel(settingsServiceForViewModel, themeServiceForViewModel, schedulerForViewModel, accountRepository);
         var statusBar = new StatusBarViewModel(accounts);
 
-        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, statusBar);
+        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, statusBar, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
-    private AppBootstrapper CreateSut() => new(dbContextFactory, settingsService, themeService, syncScheduler, CreateMainWindowViewModel());
+    private AppBootstrapper CreateSut() => new(dbContextFactory, settingsService, themeService, syncScheduler, CreateMainWindowViewModel(), Substitute.For<ILogger<AppBootstrapper>>());
 
     [Fact]
     public async Task when_bootstrap_async_is_called_then_settings_load_async_is_called()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -13,6 +13,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Shell;
@@ -38,14 +39,14 @@ public sealed class GivenAnApplicationInitializer
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator);
-    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository);
 
     private ApplicationInitializer CreateSut(AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings)
-        => new(_startupService, accounts, files, dashboard, activity, settings);
+        => new(_startupService, accounts, files, dashboard, activity, settings, Substitute.For<ILogger<ApplicationInitializer>>());
 
     private static OneDriveAccount BuildAccount(string id = "acc-1", string email = "user@test.com", bool isActive = false)
         => new() { Id = new AccountId(id), Profile = AccountProfileFactory.Create("Test User", email), IsActive = isActive, SelectedFolderIds = [] };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAConflictApplier.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 using ReactiveUnit = global::System.Reactive.Unit;
@@ -17,7 +18,7 @@ public sealed class GivenAConflictApplier
     private readonly IHttpDownloader _httpDownloader = Substitute.For<IHttpDownloader>();
     private readonly IFileSystem     _fileSystem     = Substitute.For<IFileSystem>();
 
-    private ConflictApplier CreateSut() => new(_httpDownloader, _graphService, _fileSystem);
+    private ConflictApplier CreateSut() => new(_httpDownloader, _graphService, _fileSystem, Substitute.For<ILogger<ConflictApplier>>());
 
     private static SyncConflict CreateUseRemoteConflict() => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
@@ -15,13 +16,13 @@ public sealed class GivenADownloadJobBuilder
 
     private readonly ISyncedItemRegistrar _syncedItemRegistrar = Substitute.For<ISyncedItemRegistrar>();
 
-    private DownloadJobBuilder CreateSut(MockFileSystem mockFs) => new(_syncedItemRegistrar, mockFs);
+    private DownloadJobBuilder CreateSut(MockFileSystem mockFileSystem) => new(_syncedItemRegistrar, mockFileSystem, Substitute.For<ILogger<DownloadJobBuilder>>());
 
     private static OneDriveAccount CreateAccount(ConflictPolicy policy = ConflictPolicy.Ignore) => new()
     {
-        Id                = new AccountId("user-1"),
-        Profile           = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
-        SyncConfig        = AccountSyncConfigFactory.Create(policy, LocalSyncPath.Restore(BasePath)),
+        Id = new AccountId("user-1"),
+        Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com"),
+        SyncConfig = AccountSyncConfigFactory.Create(policy, LocalSyncPath.Restore(BasePath)),
         SelectedFolderIds = []
     };
 
@@ -93,11 +94,11 @@ public sealed class GivenADownloadJobBuilder
 
         var knownItem = new SyncedItemEntity
         {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
-            Tags             = VersionInfoFactory.Create("etag-123", null),
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
+            Tags = VersionInfoFactory.Create("etag-123", null),
             RemoteModifiedAt = DateTimeOffset.UtcNow.AddDays(-1)
         };
         var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
@@ -122,10 +123,10 @@ public sealed class GivenADownloadJobBuilder
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var knownItem = new SyncedItemEntity
         {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
             RemoteModifiedAt = remoteModified
         };
         var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
@@ -214,10 +215,10 @@ public sealed class GivenADownloadJobBuilder
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var knownItem = new SyncedItemEntity
         {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
             RemoteModifiedAt = remoteModified
         };
         var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
@@ -243,10 +244,10 @@ public sealed class GivenADownloadJobBuilder
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var knownItem = new SyncedItemEntity
         {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
             RemoteModifiedAt = remoteModified
         };
         var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
@@ -272,10 +273,10 @@ public sealed class GivenADownloadJobBuilder
         var remoteModified = DateTimeOffset.UtcNow.AddMinutes(-10);
         var knownItem = new SyncedItemEntity
         {
-            AccountId        = new AccountId("user-1"),
-            RemoteItemId     = new OneDriveItemId("item-a"),
-            RemotePath       = "/Documents/a.txt",
-            LocalPath        = localFile,
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
             RemoteModifiedAt = remoteModified
         };
         var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobHandler.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -21,7 +22,7 @@ public sealed class GivenADownloadJobHandler
             .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
     }
 
-    private DownloadJobHandler CreateSut() => new(_downloader, _graphService);
+    private DownloadJobHandler CreateSut() => new(_downloader, _graphService, Substitute.For<ILogger<DownloadJobHandler>>());
 
     private static DownloadSyncJob MakeDownloadJob(string? downloadUrl = "https://example.com/file")
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -9,9 +10,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 public sealed class GivenALocalChangeDetector
 {
     private const string AccountId = "acc-test-1";
-    private const string BasePath  = "/sync-root";
+    private const string BasePath = "/sync-root";
 
-    private static LocalChangeDetector CreateSut(MockFileSystem mockFs) => new(mockFs);
+    private static LocalChangeDetector CreateSut(MockFileSystem mockFileSystem) => new(mockFileSystem, Substitute.For<ILogger<LocalChangeDetector>>());
 
     private static SyncRuleEntity Rule(string remotePath, RuleType type) => new() { RemotePath = remotePath, RuleType = type };
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalDeletionDetector.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging.Abstractions;
 using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
@@ -11,18 +12,18 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenALocalDeletionDetector
 {
-    private const string BaseDir   = "/sync-root";
+    private const string BaseDir = "/sync-root";
     private const string LocalFile = $"{BaseDir}/file.txt";
 
-    private readonly IGraphService         _graphService         = Substitute.For<IGraphService>();
+    private readonly IGraphService _graphService = Substitute.For<IGraphService>();
     private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
-    private readonly AccountId             _accountId            = new("user-1");
+    private readonly AccountId _accountId = new("user-1");
 
     public GivenALocalDeletionDetector()
         => _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
 
-    private LocalDeletionDetector CreateSut(MockFileSystem mockFs) => new(_graphService, _syncedItemRepository, mockFs);
+    private LocalDeletionDetector CreateSut(MockFileSystem mockFileSystem) => new(_graphService, _syncedItemRepository, mockFileSystem, NullLogger<LocalDeletionDetector>.Instance);
 
     [Fact]
     public async Task when_local_file_still_exists_then_graph_delete_is_not_called()
@@ -94,7 +95,7 @@ public sealed class GivenALocalDeletionDetector
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
             ["item-fail"] = new() { RemoteItemId = new OneDriveItemId("item-fail"), RemotePath = "/fail.txt", LocalPath = $"{BaseDir}/fail.txt", IsFolder = false },
-            ["item-ok"]   = new() { RemoteItemId = new OneDriveItemId("item-ok"),   RemotePath = "/ok.txt",   LocalPath = $"{BaseDir}/ok.txt",   IsFolder = false }
+            ["item-ok"] = new() { RemoteItemId = new OneDriveItemId("item-ok"), RemotePath = "/ok.txt", LocalPath = $"{BaseDir}/ok.txt", IsFolder = false }
         };
         var sut = CreateSut(mockFileSystem);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAParallelSyncPipeline.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -22,7 +23,7 @@ public sealed class GivenAParallelSyncPipeline
         _workerFactory.Create(Arg.Any<int>()).Returns(_ => new SucceedingDownloadWorker());
     }
 
-    private ParallelSyncPipeline CreateSut() => new(_workerFactory, _syncRepository);
+    private ParallelSyncPipeline CreateSut() => new(_workerFactory, _syncRepository, Substitute.For<ILogger<ParallelSyncPipeline>>());
 
     private static DownloadSyncJob MakeDownloadJob(string relativePath = "folder/file.txt")
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteDeletionDetector.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
@@ -9,13 +10,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenARemoteDeletionDetector
 {
-    private const string BaseDir   = "/sync-root";
+    private const string BaseDir = "/sync-root";
     private const string LocalFile = $"{BaseDir}/file.txt";
 
     private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
-    private readonly AccountId             _accountId            = new("user-1");
+    private readonly AccountId _accountId = new("user-1");
 
-    private RemoteDeletionDetector CreateSut(MockFileSystem mockFs) => new(_syncedItemRepository, mockFs);
+    private RemoteDeletionDetector CreateSut(MockFileSystem mockFileSystem) => new(_syncedItemRepository, mockFileSystem, Substitute.For<ILogger<RemoteDeletionDetector>>());
 
     private static List<SyncRuleEntity> IncludeRules(params string[] paths)
         => paths.Select(p => new SyncRuleEntity { RemotePath = p, RuleType = RuleType.Include }).ToList();
@@ -120,7 +121,7 @@ public sealed class GivenARemoteDeletionDetector
 
         await sut.DetectAndApplyAsync(_accountId, syncedItems, seenRemoteIds, IncludeRules("/Documents"), TestContext.Current.CancellationToken);
 
-        mockFileSystem  .File.Exists(LocalFile).ShouldBeTrue();
+        mockFileSystem.File.Exists(LocalFile).ShouldBeTrue();
         await _syncedItemRepository.DidNotReceive().DeleteByRemoteIdAsync(Arg.Any<AccountId>(), Arg.Any<OneDriveItemId>(), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -25,7 +26,7 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
     }
 
-    private RemoteFolderEnumerator CreateSut() => new(_graphService, _syncRuleRepository, _syncedItemRepository);
+    private RemoteFolderEnumerator CreateSut() => new(_graphService, _syncRuleRepository, _syncedItemRepository, Substitute.For<ILogger<RemoteFolderEnumerator>>());
 
     private static OneDriveAccount CreateAccount() => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncJobExecutor.cs
@@ -13,17 +13,17 @@ public sealed class GivenASyncJobExecutor
 {
     private const string UploadFilePath = "/sync-root/Documents/file.txt";
 
-    private readonly ISyncRepository         _syncRepository         = Substitute.For<ISyncRepository>();
-    private readonly ISyncedItemRepository   _syncedItemRepository   = Substitute.For<ISyncedItemRepository>();
-    private readonly ISyncPipeline _pipeline             = Substitute.For<ISyncPipeline>();
+    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
+    private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
+    private readonly ISyncPipeline _pipeline = Substitute.For<ISyncPipeline>();
 
     private readonly OneDriveAccount _account = new()
     {
-        Id    = new AccountId("user-1"),
+        Id = new AccountId("user-1"),
         Profile = AccountProfileFactory.Create(string.Empty, "user@outlook.com")
     };
 
-    private SyncJobExecutor CreateSut(MockFileSystem mockFs) => new(_syncRepository, _syncedItemRepository, _pipeline, mockFs);
+    private SyncJobExecutor CreateSut(MockFileSystem mockFileSystem) => new(_syncRepository, _syncedItemRepository, _pipeline, mockFileSystem);
 
     private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
     {
@@ -34,9 +34,9 @@ public sealed class GivenASyncJobExecutor
         return direction switch
         {
             SyncDirection.Download => SyncJobFactory.CreateDownload(remote, target, metadata),
-            SyncDirection.Upload   => SyncJobFactory.CreateUpload(remote, target, metadata),
-            SyncDirection.Delete   => SyncJobFactory.CreateDelete(remote, target, metadata),
-            _                      => SyncJobFactory.CreateDownload(remote, target, metadata)
+            SyncDirection.Upload => SyncJobFactory.CreateUpload(remote, target, metadata),
+            SyncDirection.Delete => SyncJobFactory.CreateDelete(remote, target, metadata),
+            _ => SyncJobFactory.CreateDownload(remote, target, metadata)
         };
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -4,19 +4,23 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenASyncScheduler
 {
+    private static SyncScheduler CreateScheduler(ISyncService syncService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository)
+        => new(syncService, repository, syncRuleRepository, Substitute.For<ILogger<SyncScheduler>>());
+
     [Fact]
     public void when_constructed_then_scheduler_is_not_null()
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
 
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
 
         _ = scheduler.ShouldNotBeNull();
     }
@@ -30,7 +34,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
 
         scheduler.StartSync();
 
@@ -42,7 +46,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
 
         scheduler.StartSync();
 
@@ -54,7 +58,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var customInterval = TimeSpan.FromMinutes(30);
 
         scheduler.StartSync(customInterval);
@@ -67,7 +71,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         scheduler.StartSync();
 
         scheduler.StopSync();
@@ -80,7 +84,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         scheduler.StartSync();
         var newInterval = TimeSpan.FromMinutes(30);
 
@@ -96,7 +100,7 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Profile = AccountProfileFactory.Create("test", "test@example.com") }]);
 
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
 
@@ -110,7 +114,7 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns([new() { Profile = AccountProfileFactory.Create("test", "test@example.com") }]);
 
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
 
@@ -122,7 +126,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var account = new OneDriveAccount { Id = new AccountId("test-account") };
 
         await scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
@@ -135,7 +139,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var account = new OneDriveAccount { Id = new AccountId("test-account") };
         bool eventRaised = false;
         string? raisedAccountId = null;
@@ -157,7 +161,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var account = new OneDriveAccount { Id = new AccountId("test-account") };
         bool eventRaised = false;
         string? raisedAccountId = null;
@@ -179,7 +183,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var account = new OneDriveAccount { Id = new AccountId("test-account") };
 
         _ = mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
@@ -199,7 +203,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
 
         _ = scheduler.ShouldBeAssignableTo<IAsyncDisposable>();
     }
@@ -213,7 +217,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var interval = TimeSpan.FromMinutes(minutes);
 
         scheduler.StartSync(interval);
@@ -226,7 +230,7 @@ public sealed class GivenASyncScheduler
     {
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
         var account = new OneDriveAccount
         {
             Id = new AccountId("account-123"),
@@ -252,7 +256,7 @@ public sealed class GivenASyncScheduler
             Profile    = AccountProfileFactory.Create("Test User", "test@outlook.com"),
             SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/some/path")),
         }));
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
 
@@ -268,7 +272,7 @@ public sealed class GivenASyncScheduler
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.None<AccountEntity>());
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
 
         await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
 
@@ -282,7 +286,7 @@ public sealed class GivenASyncScheduler
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test", "test@test.com") }));
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
         string? raisedId = null;
         scheduler.SyncStarted += (_, id) => raisedId = id;
 
@@ -298,7 +302,7 @@ public sealed class GivenASyncScheduler
         var mockSyncService = Substitute.For<ISyncService>();
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test", "test@test.com") }));
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
         string? raisedId = null;
         scheduler.SyncCompleted += (_, id) => raisedId = id;
 
@@ -323,7 +327,7 @@ public sealed class GivenASyncScheduler
             LastSyncedAt = lastSyncedAt,
             SyncConfig   = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/sync/path")),
         }));
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
 
@@ -352,7 +356,7 @@ public sealed class GivenASyncScheduler
             Profile    = AccountProfileFactory.Create("No Path User", "nopath@outlook.com"),
             SyncConfig = AccountSyncConfigFactory.Default,
         }));
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
 
@@ -381,7 +385,7 @@ public sealed class GivenASyncScheduler
                 new() { RuleType = RuleType.Exclude, RemoteItemId = "folder-3" },
                 new() { RuleType = RuleType.Include, RemoteItemId = null },
             ]);
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, rulesRepo);
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, rulesRepo);
 
         await scheduler.TriggerAccountAsync(accountIdStr, TestContext.Current.CancellationToken);
 
@@ -403,7 +407,7 @@ public sealed class GivenASyncScheduler
             AccentIndex = 5,
             IsActive    = true,
         }]);
-        var scheduler = new SyncScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
         await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -19,7 +20,7 @@ public sealed class GivenASyncService
     private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService BuildSut()
-        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier, Substitute.For<ILogger<SyncService>>());
 
     [Fact]
     public void when_constructed_then_instance_is_not_null()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -20,7 +21,7 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, Substitute.For<ISyncPassOrchestrator>(), _conflictApplier);
+        => new(_authService, _syncRepository, Substitute.For<ISyncPassOrchestrator>(), _conflictApplier, Substitute.For<ILogger<SyncService>>());
 
     private static SyncConflict CreateConflict() => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -17,7 +18,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier, Substitute.For<ILogger<SyncService>>());
 
     private static SyncConflict CreateConflict() => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -17,7 +18,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     private readonly IConflictApplier      _conflictApplier      = Substitute.For<IConflictApplier>();
 
     private SyncService CreateSut()
-        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier);
+        => new(_authService, _syncRepository, _syncPassOrchestrator, _conflictApplier, Substitute.For<ILogger<SyncService>>());
 
     private static OneDriveAccount CreateAccount(string localSyncPath = "/path/to/sync") => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncWorker.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -16,7 +17,7 @@ public sealed class GivenASyncWorker
     private readonly IJobHandler _handler = Substitute.For<IJobHandler>();
     private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
 
-    private SyncWorker CreateSut() => new(1, [_handler], _syncRepository);
+    private SyncWorker CreateSut() => new(1, [_handler], _syncRepository, Substitute.For<ILogger<SyncWorker>>());
 
     private static DownloadSyncJob MakeDownloadJob()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncWorkerFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncWorkerFactory.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -8,7 +9,7 @@ public sealed class GivenASyncWorkerFactory
     private readonly IJobHandler _handler = Substitute.For<IJobHandler>();
     private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
 
-    private SyncWorkerFactory CreateSut() => new([_handler], _syncRepository);
+    private SyncWorkerFactory CreateSut() => new([_handler], _syncRepository, Substitute.For<ILogger<SyncWorker>>());
 
     [Fact]
     public void when_create_is_called_then_returns_non_null_worker()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -18,7 +19,7 @@ public sealed class GivenASyncedItemRegistrar
     public GivenASyncedItemRegistrar()
         => _fileSystem.Directory.Returns(_mockDirectory);
 
-    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileSystem);
+    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
 
     private static DeltaItem FolderItem(string id, string remotePath)
         => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnHttpDownloader.cs
@@ -2,14 +2,15 @@ using System.Net;
 using System.Text;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
 public sealed class GivenAnHttpDownloader
 {
-    private const string DownloadUrl   = "https://example.com/file.txt";
-    private const string FileContent   = "hello world";
-    private const string LocalPath     = "/tmp/downloaded-file.txt";
+    private const string DownloadUrl = "https://example.com/file.txt";
+    private const string FileContent = "hello world";
+    private const string LocalPath = "/tmp/downloaded-file.txt";
     private static readonly DateTimeOffset RemoteModified = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
 
     private static IHttpClientFactory CreateFactoryReturning(HttpResponseMessage response)
@@ -30,16 +31,18 @@ public sealed class GivenAnHttpDownloader
         return CreateFactoryReturning(response);
     }
 
+    private static HttpDownloader CreateSut(IHttpClientFactory factory, MockFileSystem fileSystem) => new(factory, fileSystem, Substitute.For<ILogger<HttpDownloader>>());
+
     [Fact]
     public void when_constructed_then_service_implements_ihttp_downloader() =>
-        new HttpDownloader(Substitute.For<IHttpClientFactory>(), new MockFileSystem()).ShouldBeAssignableTo<IHttpDownloader>();
+        CreateSut(Substitute.For<IHttpClientFactory>(), new MockFileSystem()).ShouldBeAssignableTo<IHttpDownloader>();
 
     [Fact]
     public async Task when_download_async_is_called_with_pre_cancelled_token_then_operation_is_cancelled()
     {
         var cts = new CancellationTokenSource();
         cts.Cancel();
-        var sut = new HttpDownloader(CreateOkFactory(), new MockFileSystem());
+        var sut = CreateSut(CreateOkFactory(), new MockFileSystem());
 
         await Should.ThrowAsync<OperationCanceledException>(
             () => sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: cts.Token));
@@ -48,34 +51,34 @@ public sealed class GivenAnHttpDownloader
     [Fact]
     public async Task when_download_async_succeeds_then_file_is_written_with_correct_content()
     {
-        var mockFs = new MockFileSystem();
-        var sut = new HttpDownloader(CreateOkFactory(), mockFs);
+        var mockFileSystem = new MockFileSystem();
+        var sut = CreateSut(CreateOkFactory(), mockFileSystem);
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
-        mockFs.File.Exists(LocalPath).ShouldBeTrue();
-        string writtenContent = mockFs.File.ReadAllText(LocalPath);
+        mockFileSystem.File.Exists(LocalPath).ShouldBeTrue();
+        string writtenContent = mockFileSystem.File.ReadAllText(LocalPath);
         writtenContent.ShouldBe(FileContent);
     }
 
     [Fact]
     public async Task when_download_async_succeeds_then_file_last_write_time_matches_remote_modified()
     {
-        var mockFs = new MockFileSystem();
-        var sut = new HttpDownloader(CreateOkFactory(), mockFs);
+        var mockFileSystem = new MockFileSystem();
+        var sut = CreateSut(CreateOkFactory(), mockFileSystem);
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
-        mockFs.File.GetLastWriteTimeUtc(LocalPath).ShouldBe(RemoteModified.UtcDateTime);
+        mockFileSystem.File.GetLastWriteTimeUtc(LocalPath).ShouldBe(RemoteModified.UtcDateTime);
     }
 
     [Fact]
     public async Task when_download_async_succeeds_with_progress_then_progress_is_reported()
     {
-        var mockFs = new MockFileSystem();
+        var mockFileSystem = new MockFileSystem();
         var reportedValues = new List<long>();
         var progress = new Progress<long>(reportedValues.Add);
-        var sut = new HttpDownloader(CreateOkFactory(), mockFs);
+        var sut = CreateSut(CreateOkFactory(), mockFileSystem);
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, progress, TestContext.Current.CancellationToken);
 
@@ -89,7 +92,7 @@ public sealed class GivenAnHttpDownloader
     public async Task when_download_is_rate_limited_beyond_max_retries_then_result_is_error()
     {
         var factory = CreateAlways429Factory();
-        var sut = new HttpDownloader(factory, new MockFileSystem());
+        var sut = CreateSut(factory, new MockFileSystem());
 
         var result = await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadJobHandler.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
 
@@ -14,7 +15,7 @@ public sealed class GivenAnUploadJobHandler
 
     private readonly IGraphService _graphService = Substitute.For<IGraphService>();
 
-    private UploadJobHandler CreateSut() => new(_graphService);
+    private UploadJobHandler CreateSut() => new(_graphService, NullLogger<UploadJobHandler>.Instance);
 
     private static UploadSyncJob MakeUploadJob(string folderId = "folder-1")
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenAnUploadService.cs
@@ -11,6 +11,7 @@ using WireMockRequest = WireMock.RequestBuilders.Request;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.Functional.Extensions;
+using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -45,7 +46,7 @@ public sealed class GivenAnUploadService
 
     [Fact]
     public void when_constructed_then_service_implements_IUploadService() =>
-        new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem()).ShouldBeAssignableTo<IUploadService>();
+        new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem(), Substitute.For<ILogger<UploadService>>()).ShouldBeAssignableTo<IUploadService>();
 
     [Fact]
     public async Task when_upload_async_is_called_with_pre_cancelled_token_then_operation_is_cancelled()
@@ -55,7 +56,7 @@ public sealed class GivenAnUploadService
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), mockFileSystem);
+        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         await Should.ThrowAsync<OperationCanceledException>(() =>
             sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: cts.Token));
@@ -74,7 +75,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithCallback(_ => Created201Response()));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
         string itemId = uploadResult.Match(id => id, _ => string.Empty);
@@ -95,7 +96,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithCallback(_ => Ok200Response()));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
         string itemId = uploadResult.Match(id => id, _ => string.Empty);
@@ -124,7 +125,7 @@ public sealed class GivenAnUploadService
                       return callIndex == 0 ? Accepted202Response() : Created201Response();
                   }));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var uploadResult = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
         string itemId = uploadResult.Match(id => id, _ => string.Empty);
@@ -149,7 +150,7 @@ public sealed class GivenAnUploadService
 
         var reportedValues = new List<long>();
         var progress = new Progress<long>(reportedValues.Add);
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, progress, TestContext.Current.CancellationToken);
 
@@ -162,7 +163,7 @@ public sealed class GivenAnUploadService
     [Fact]
     public async Task when_upload_async_is_called_with_nonexistent_local_path_then_result_is_error()
     {
-        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem());
+        var sut = new UploadService(Substitute.For<IHttpClientFactory>(), new MockFileSystem(), Substitute.For<ILogger<UploadService>>());
 
         var result = await sut.UploadAsync(BuildAnonymousGraphClient(), new DriveId(DriveIdValue), ParentFolderId, "/nonexistent/path/file.bin", RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -180,7 +181,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPost())
               .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"uploadUrl\":null}").WithHeader("Content-Type", "application/json"));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -201,7 +202,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithStatusCode(429));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 
@@ -221,7 +222,7 @@ public sealed class GivenAnUploadService
         server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
               .RespondWith(Response.Create().WithStatusCode(201).WithHeader("Content-Type", "application/json").WithBody("{}"));
 
-        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem);
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, Substitute.For<ILogger<UploadService>>());
 
         var result = await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -12,11 +12,13 @@ using AStar.Dev.Utilities;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using FolderTreeNodeViewModel = AStar.Dev.OneDrive.Sync.Client.Home.FolderTreeNodeViewModel;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService) : ObservableObject
+public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> logger, ILogger<FolderTreeNodeViewModel> folderTreeLogger) : ObservableObject
 {
     private readonly OneDriveAccount _account = account;
     private readonly IAuthService _authService = authService;
@@ -24,6 +26,8 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     private readonly IAccountRepository _repository = repository;
     private readonly ISyncRuleRepository _syncRuleRepository = syncRuleRepository;
     private readonly IFileManagerService _fileManagerService = fileManagerService;
+    private readonly ILogger<AccountFilesViewModel> _logger = logger;
+    private readonly ILogger<FolderTreeNodeViewModel> _folderTreeLogger = folderTreeLogger;
     private string? _accessToken;
     private Option<DriveId> _driveId = DriveIdFactory.Empty;
 
@@ -59,7 +63,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     [RelayCommand]
     public async Task LoadAsync()
     {
-        if(IsLoading)
+        if (IsLoading)
             return;
 
         IsLoading = true;
@@ -79,7 +83,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                         return null;
                     });
 
-            if(_accessToken is null)
+            if (_accessToken is null)
                 return;
 
             var driveId = await _graphService.GetDriveIdAsync(_account.Id.Id, _accessToken)
@@ -92,7 +96,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                         return null;
                     });
 
-            if(driveId is null)
+            if (driveId is null)
                 return;
 
             _driveId = new Option<DriveId>.Some(driveId.Value);
@@ -100,7 +104,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
             var includedPaths = await LoadRulesAsync();
             await BuildRootFoldersAsync(includedPaths);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             LoadError = $"Failed to load folders: {ex.Message}";
             HasLoadError = true;
@@ -128,27 +132,27 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                 f => f,
                 error =>
                 {
-                    Serilog.Log.Warning("[AccountFilesViewModel] Failed to load root folders for account {AccountId}: {Error}", _account.Id.Id, error);
+                    OneDriveSyncClientMessages.RootFoldersLoadFailed(_logger, _account.Id.Id, error);
                     LoadError = error;
                     HasLoadError = true;
                     return null;
                 });
 
-        if(folders is null)
+        if (folders is null)
             return;
 
         var driveId = _driveId.Match<DriveId?>(
             id => id,
             () =>
             {
-                Serilog.Log.Warning("[AccountFilesViewModel] Drive ID not available when building folder tree for account {AccountId}", _account.Id.Id);
+                OneDriveSyncClientMessages.DriveIdNotAvailable(_logger, _account.Id.Id);
                 return null;
             });
 
-        if(driveId is null)
+        if (driveId is null)
             return;
 
-        foreach(var f in folders)
+        foreach (var f in folders)
         {
             string remotePath = $"/{f.Name}";
             var syncState = includedPaths.Contains(remotePath)
@@ -156,7 +160,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                 : FolderSyncState.Excluded;
 
             var node = new FolderTreeNode(Id: f.Id, Name: f.Name, ParentId: f.ParentId, AccountId: _account.Id.Id, RemotePath: remotePath, SyncState: syncState, HasChildren: true);
-            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveId.Value);
+            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveId.Value, _folderTreeLogger);
 
             vm.IncludeToggled += OnIncludeToggledAsync;
             vm.ViewActivityRequested += OnViewActivityRequested;
@@ -171,8 +175,9 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         try
         {
             var ruleType = node.IsIncluded ? RuleType.Include : RuleType.Exclude;
+            string ruleTypeName = ruleType.ToString();
 
-            Serilog.Log.Debug("[AccountFilesViewModel] Persisting {RuleType} rule for {Path} (account {AccountId})", ruleType, node.RemotePath, _account.Id.Id);
+            OneDriveSyncClientMessages.RulePersisting(_logger, ruleTypeName, node.RemotePath, _account.Id.Id);
 
             await _syncRuleRepository.DeleteChildRulesAsync(_account.Id, node.RemotePath, CancellationToken.None);
 
@@ -180,12 +185,12 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                 ? CollectAllVisible([node])
                 : [node];
 
-            foreach(var item in affected)
+            foreach (var item in affected)
                 await _syncRuleRepository.UpsertAsync(_account.Id, item.RemotePath, ruleType, item.Id, CancellationToken.None);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[AccountFilesViewModel] Failed to persist folder selection for account {AccountId} — {Error}", _account.Id.Id, ex.Message);
+            OneDriveSyncClientMessages.FolderSelectionPersistFailed(_logger, _account.Id.Id, ex.Message, ex);
         }
     }
 
@@ -196,7 +201,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
     {
         string path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).CombinePath("OneDrive", node.Name);
 
-        if(!fileSystem.Directory.Exists(path))
+        if (!fileSystem.Directory.Exists(path))
             return;
 
         _fileManagerService.OpenFolder(path);
@@ -204,11 +209,11 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private static IEnumerable<FolderTreeNodeViewModel> CollectAllVisible(IEnumerable<FolderTreeNodeViewModel> nodes)
     {
-        foreach(var node in nodes)
+        foreach (var node in nodes)
         {
             yield return node;
 
-            foreach(var descendant in CollectAllVisible(node.Children))
+            foreach (var descendant in CollectAllVisible(node.Children))
                 yield return descendant;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -6,16 +6,20 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator) : ObservableObject
+public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator, ILogger<AccountsViewModel> logger) : ObservableObject
 {
+    private readonly ILogger<AccountsViewModel> _logger = logger;
+
     public ObservableCollection<AccountCardViewModel> Accounts { get; } = [];
 
     [ObservableProperty]
@@ -59,12 +63,12 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     public void RestoreAccounts(IEnumerable<OneDriveAccount> accounts)
     {
-        foreach(var account in accounts)
+        foreach (var account in accounts)
         {
             var card = BuildCard(account);
             Accounts.Add(card);
 
-            if(account.IsActive)
+            if (account.IsActive)
                 ActiveAccount = card;
         }
 
@@ -80,7 +84,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
         _ = Accounts.Remove(card);
 
-        if(ActiveAccount == card)
+        if (ActiveAccount == card)
             ActiveAccount = Accounts.FirstOrDefault();
 
         OnPropertyChanged(nameof(HasAccounts));
@@ -96,7 +100,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
                     CloseWizard();
 
                     account.AccentIndex = Accounts.Count % 6;
-                    account.IsActive    = Accounts.Count == 0;
+                    account.IsActive = Accounts.Count == 0;
 
                     var finalisedAccount = await accountOnboardingService.CompleteOnboardingAsync(account, CancellationToken.None);
 
@@ -104,18 +108,18 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
                     Accounts.Add(card);
                     OnPropertyChanged(nameof(HasAccounts));
 
-                    if(finalisedAccount.IsActive)
+                    if (finalisedAccount.IsActive)
                         ActiveAccount = card;
 
                     AccountAdded?.Invoke(this, finalisedAccount);
 
                     return Unit.Default;
                 })
-                .TapErrorAsync(error => Serilog.Log.Error(error, "Error completing account onboarding wizard"));
+                .TapErrorAsync(error => OneDriveSyncClientMessages.AccountOnboardingWizardError(_logger, error));
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[AccountsViewModel.OnWizardCompletedAsync] Unhandled exception: {Error}", ex.Message);
+            OneDriveSyncClientMessages.AccountsViewModelWizardError(_logger, ex.Message, ex);
         }
     }
 
@@ -123,7 +127,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     private void CloseWizard()
     {
-        if(Wizard is not null)
+        if (Wizard is not null)
         {
             Wizard.Completed -= OnWizardCompletedAsync;
             Wizard.Cancelled -= OnWizardCancelled;
@@ -136,7 +140,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
     {
         try
         {
-            foreach(var accountCard in Accounts)
+            foreach (var accountCard in Accounts)
                 accountCard.IsActive = accountCard == card;
 
             ActiveAccount = card;
@@ -146,43 +150,43 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[AccountsViewModel.OnCardSelected] Failed to set active account: {Error}", ex.Message);
+            OneDriveSyncClientMessages.AccountSetActiveFailed(_logger, ex.Message, ex);
         }
     }
 
     private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs args)
     {
         var card = Accounts.FirstOrDefault(a => a.Id == args.AccountId);
-        if(card is null)
+        if (card is null)
             return;
 
         card.SyncState = args.SyncState;
 
-        if(card.Id == ActiveAccount?.Id)
+        if (card.Id == ActiveAccount?.Id)
             ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnSyncCompleted(object? sender, string accountId)
     {
         var card = Accounts.FirstOrDefault(a => a.Id == accountId);
-        if(card is null)
+        if (card is null)
             return;
 
         card.SyncState = SyncState.Completed;
 
-        if(card.Id == ActiveAccount?.Id)
+        if (card.Id == ActiveAccount?.Id)
             ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private void OnConflictDetected(object? sender, SyncConflict conflict)
     {
         var card = Accounts.FirstOrDefault(a => a.Id == conflict.Remote.AccountId.Id);
-        if(card is null)
+        if (card is null)
             return;
 
         card.ConflictCount++;
 
-        if(card.Id == ActiveAccount?.Id)
+        if (card.Id == ActiveAccount?.Id)
             ActiveAccountStateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -194,5 +198,4 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
         return card;
     }
-
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccountFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/OneDriveAccountFactory.cs
@@ -1,0 +1,22 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
+
+public static class OneDriveAccountFactory
+{
+    public static OneDriveAccount CreateFromWizardResult(string accountId, AccountProfile profile, IEnumerable<WizardFolderItem> selectedFolders)
+    {
+        var folders = selectedFolders.ToList();
+
+        return new OneDriveAccount
+        {
+            Id               = new AccountId(accountId),
+            Profile          = profile,
+            SelectedFolderIds = [.. folders.Select(f => new OneDriveFolderId(f.Id))],
+            FolderNames      = folders.ToDictionary(f => new OneDriveFolderId(f.Id), f => f.Name)
+        };
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FilesViewModel.cs
@@ -7,17 +7,18 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
-public sealed partial class FilesViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService) : ObservableObject
+public sealed partial class FilesViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> accountFilesLogger, ILogger<FolderTreeNodeViewModel> folderTreeLogger) : ObservableObject
 {
-    public ObservableCollection<Accounts.AccountFilesViewModel> Tabs { get; } = [];
+    public ObservableCollection<AccountFilesViewModel> Tabs { get; } = [];
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasTabs))]
     [NotifyPropertyChangedFor(nameof(HasNoAccounts))]
-    public partial Accounts.AccountFilesViewModel? ActiveTab { get; set; }
+    public partial AccountFilesViewModel? ActiveTab { get; set; }
 
     public bool HasTabs => Tabs.Count > 0;
     public bool HasNoAccounts => Tabs.Count == 0;
@@ -33,8 +34,8 @@ public sealed partial class FilesViewModel(IAuthService authService, IGraphServi
         if(Tabs.Any(t => t.AccountId == account.Id.Id))
             return;
 
-        var tab = new Accounts.AccountFilesViewModel(
-            account, authService, graphService, repository, syncRuleRepository, fileSystem, fileManagerService);
+        var tab = new AccountFilesViewModel(
+            account, authService, graphService, repository, syncRuleRepository, fileSystem, fileManagerService, accountFilesLogger, folderTreeLogger);
 
         tab.ViewActivityRequested += (_, node) =>
             ViewActivityRequested?.Invoke(this,
@@ -72,7 +73,7 @@ public sealed partial class FilesViewModel(IAuthService authService, IGraphServi
         await tab.LoadCommand.ExecuteAsync(null);
     }
 
-    private void ActivateTab(Accounts.AccountFilesViewModel? tab)
+    private void ActivateTab(AccountFilesViewModel? tab)
     {
         foreach(var t in Tabs)
             t.IsActiveTab = t == tab;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -4,15 +4,18 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
 public sealed partial class FolderTreeNodeViewModel : ObservableObject
 {
     private readonly IGraphService _graphService;
-    private readonly string        _accessToken;
-    private readonly DriveId       _driveId;
-    private          bool          _childrenLoaded;
+    private readonly string _accessToken;
+    private readonly DriveId _driveId;
+    private readonly ILogger<FolderTreeNodeViewModel> _logger;
+    private bool _childrenLoaded;
 
     public string Id { get; }
     public string Name { get; }
@@ -58,7 +61,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     public event EventHandler<FolderTreeNodeViewModel>? OpenInFileManagerRequested;
     public event EventHandler<FolderTreeNodeViewModel>? ViewActivityRequested;
 
-    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, string accessToken, DriveId driveId, int depth = 0)
+    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, string accessToken, DriveId driveId, ILogger<FolderTreeNodeViewModel> logger, int depth = 0)
     {
         Id = node.Id;
         Name = node.Name;
@@ -70,15 +73,16 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         _graphService = graphService;
         _accessToken = accessToken;
         _driveId = driveId;
+        _logger = logger;
     }
 
     [RelayCommand]
     private async Task ToggleExpandAsync()
     {
-        if(!HasChildren)
+        if (!HasChildren)
             return;
 
-        if(!IsExpanded)
+        if (!IsExpanded)
         {
             await EnsureChildrenLoadedAsync();
             IsExpanded = true;
@@ -104,7 +108,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     {
         SyncState = state;
 
-        foreach(var child in Children)
+        foreach (var child in Children)
             child.ApplySyncStateRecursively(state);
     }
 
@@ -118,7 +122,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
 
     private async Task EnsureChildrenLoadedAsync()
     {
-        if(_childrenLoaded) return;
+        if (_childrenLoaded) return;
 
         IsLoadingChildren = true;
         try
@@ -128,23 +132,23 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
                     f => f,
                     error =>
                     {
-                        Serilog.Log.Warning("[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}", RemotePath, error);
+                        OneDriveSyncClientMessages.FolderChildrenLoadFailed(_logger, RemotePath, error);
                         HasChildren = false;
                         return null;
                     });
 
-            if(folders is null)
+            if (folders is null)
                 return;
 
             Children.Clear();
-            foreach(var f in folders)
+            foreach (var f in folders)
             {
                 var childVm = CreateChildFolderTreeViewModel(f);
 
                 Children.Add(childVm);
             }
 
-            if(Children.Count == 0) HasChildren = false;
+            if (Children.Count == 0) HasChildren = false;
 
             _childrenLoaded = true;
         }
@@ -164,7 +168,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
 
     private FolderTreeNodeViewModel CreateChildFolderTreeViewModel(FolderTreeNode childNode)
     {
-        var childVm = new FolderTreeNodeViewModel(childNode, _graphService, _accessToken, _driveId, Depth + 1);
+        var childVm = new FolderTreeNodeViewModel(childNode, _graphService, _accessToken, _driveId, _logger, Depth + 1);
 
         childVm.IncludeToggled += (s, e) => IncludeToggled?.Invoke(s, e);
         childVm.OpenInFileManagerRequested += (s, e) => OpenInFileManagerRequested?.Invoke(s, e);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
@@ -2,11 +2,13 @@ using System.Reactive;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using AccountCardViewModel = AStar.Dev.OneDrive.Sync.Client.Accounts.AccountCardViewModel;
 using AccountsViewModel = AStar.Dev.OneDrive.Sync.Client.Accounts.AccountsViewModel;
 using ActivityViewModel = AStar.Dev.OneDrive.Sync.Client.Activity.ActivityViewModel;
@@ -15,8 +17,10 @@ using SettingsViewModel = AStar.Dev.OneDrive.Sync.Client.Settings.SettingsViewMo
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
-public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, StatusBarViewModel statusBar) : ObservableObject
+public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, StatusBarViewModel statusBar, ILogger<MainWindowViewModel> logger) : ObservableObject
 {
+    private readonly ILogger<MainWindowViewModel> _logger = logger;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDashboardActive))]
     [NotifyPropertyChangedFor(nameof(IsFilesActive))]
@@ -36,14 +40,14 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
     private void Navigate(NavSection section) => ActiveSection = section;
 
     public object? ActiveView => ActiveSection switch
-            {
-                NavSection.Dashboard => DashboardViewInstance,
-                NavSection.Files     => FilesViewInstance,
-                NavSection.Activity  => ActivityViewInstance,
-                NavSection.Accounts  => AccountsViewInstance,
-                NavSection.Settings  => SettingsViewInstance,
-                _                    => null
-            };
+    {
+        NavSection.Dashboard => DashboardViewInstance,
+        NavSection.Files => FilesViewInstance,
+        NavSection.Activity => ActivityViewInstance,
+        NavSection.Accounts => AccountsViewInstance,
+        NavSection.Settings => SettingsViewInstance,
+        _ => null
+    };
 
     private DashboardView DashboardViewInstance
     {
@@ -116,13 +120,13 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
                 await initializer.InitializeAsync();
                 return Unit.Default;
             })
-            .TapErrorAsync(e => Serilog.Log.Fatal(e, "[MainWindowViewModel.InitialiseAsync] FATAL ERROR: {Error}", e));
+            .TapErrorAsync(e => OneDriveSyncClientMessages.MainWindowInitializeFatal(_logger, e.Message, e));
 
     [RelayCommand]
     private async Task SyncNowAsync()
     {
         var active = accounts.ActiveAccount;
-        if(active is null)
+        if (active is null)
             return;
 
         await scheduler.TriggerAccountAsync(active.Id).ConfigureAwait(false);
@@ -146,11 +150,11 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
                     await activity.SetActiveAccountAsync(card.Id, card.Email);
                     return Unit.Default;
                 })
-                .TapErrorAsync(e => Serilog.Log.Error(e, "[MainWindowViewModel.OnAccountSelectedAsync] Error: {Error}", e));
+                .TapErrorAsync(e => OneDriveSyncClientMessages.AccountSelectError(_logger, e.Message, e));
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[MainWindowViewModel.OnAccountSelectedAsync] Unhandled exception: {Error}", ex.Message);
+            OneDriveSyncClientMessages.AccountSelectUnhandledError(_logger, ex.Message, ex);
         }
     }
 
@@ -168,11 +172,11 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
                     await activity.SetActiveAccountAsync(account.Id.Id, account.Profile.Email);
                     return Unit.Default;
                 })
-                .TapErrorAsync(e => Serilog.Log.Error(e, "[MainWindowViewModel.OnAccountAddedAsync] Error: {Error}", e));
+                .TapErrorAsync(e => OneDriveSyncClientMessages.AccountAddError(_logger, e.Message, e));
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[MainWindowViewModel.OnAccountAddedAsync] Unhandled exception: {Error}", ex.Message);
+            OneDriveSyncClientMessages.AccountAddUnhandledError(_logger, ex.Message, ex);
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
@@ -1,4 +1,6 @@
 using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
 
@@ -17,7 +19,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 /// (libsecret on Linux, DPAPI on Windows, Keychain on macOS).
 /// Falls back to plaintext with a warning on unsupported platforms.
 /// </summary>
-public sealed class TokenCacheService(IFileSystem fileSystem) : ITokenCacheService
+public sealed class TokenCacheService(IFileSystem fileSystem, ILogger<TokenCacheService> logger) : ITokenCacheService
 {
     private const int KeyringTimeoutSeconds = 5;
 
@@ -60,8 +62,7 @@ public sealed class TokenCacheService(IFileSystem fileSystem) : ITokenCacheServi
             }
             catch (Exception ex)
             {
-                Serilog.Log.Warning(ex,
-                    "[TokenCache] Keyring unavailable, falling back to plaintext cache");
+                OneDriveSyncClientMessages.TokenCacheFailed(logger, ex);
             }
 
             storageProperties = new StorageCreationPropertiesBuilder(

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -1,0 +1,291 @@
+using Microsoft.Extensions.Logging;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+
+/// <summary>
+/// Provides extension methods for logging OneDrive Sync Client-specific events, including sync operations, file transfers, and account management.
+/// </summary>
+public static partial class OneDriveSyncClientMessages
+{
+    // Sync Progress & Pipeline (2000-2099)
+
+    /// <summary>Logs that all sync workers completed normally.</summary>
+    [LoggerMessage(EventId = 2000, Level = LogLevel.Information, Message = "[Pipeline] All workers completed normally")]
+    public static partial void SyncPipelineCompleted(ILogger logger);
+
+    /// <summary>Logs sync pipeline completion with job count.</summary>
+    [LoggerMessage(EventId = 2001, Level = LogLevel.Information, Message = "[Pipeline] Complete — {Done}/{Total} jobs processed")]
+    public static partial void SyncPipelineJobsProcessed(ILogger logger, int done, int total);
+
+    /// <summary>Logs final sync progress update.</summary>
+    [LoggerMessage(EventId = 2002, Level = LogLevel.Information, Message = "[Pipeline] Final progress raised — done={Done} total={Total}")]
+    public static partial void SyncPipelineFinalProgress(ILogger logger, int done, int total);
+
+    /// <summary>Logs worker exception during sync pipeline.</summary>
+    [LoggerMessage(EventId = 2003, Level = LogLevel.Error, Message = "[Pipeline] Worker threw unhandled exception: {Type} {Error}")]
+    public static partial void SyncPipelineWorkerException(ILogger logger, string type, string error, Exception ex);
+
+    /// <summary>Logs worker processing a sync job.</summary>
+    [LoggerMessage(EventId = 2004, Level = LogLevel.Debug, Message = "[Worker {Id}] Processing {JobType} {Path}")]
+    public static partial void SyncWorkerProcessing(ILogger logger, int id, string jobType, string path);
+
+    /// <summary>Logs worker exception with details.</summary>
+    [LoggerMessage(EventId = 2005, Level = LogLevel.Error, Message = "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}")]
+    public static partial void SyncWorkerException(ILogger logger, int id, string type, string error, string path, Exception ex);
+
+    /// <summary>Logs when no handler is registered for a job type.</summary>
+    [LoggerMessage(EventId = 2006, Level = LogLevel.Warning, Message = "[Worker {Id}] No handler registered for job type {JobType}")]
+    public static partial void SyncWorkerNoHandler(ILogger logger, int id, string jobType);
+
+    // Sync Service (2100-2199)
+
+    /// <summary>Logs start of account sync.</summary>
+    [LoggerMessage(EventId = 2100, Level = LogLevel.Information, Message = "[SyncService] SyncAccountAsync for {Email}")]
+    public static partial void SyncServiceStarting(ILogger logger, string email);
+
+    /// <summary>Logs completion of account sync.</summary>
+    [LoggerMessage(EventId = 2101, Level = LogLevel.Information, Message = "[SyncService] Sync complete for {Email}")]
+    public static partial void SyncServiceComplete(ILogger logger, string email);
+
+    /// <summary>Logs unhandled error during sync.</summary>
+    [LoggerMessage(EventId = 2102, Level = LogLevel.Error, Message = "[SyncService] Unhandled error syncing {Email}: {Error}")]
+    public static partial void SyncServiceError(ILogger logger, string email, string error, Exception ex);
+
+    // Sync Scheduler (2200-2299)
+
+    /// <summary>Logs scheduled sync failure.</summary>
+    [LoggerMessage(EventId = 2200, Level = LogLevel.Error, Message = "[SyncScheduler] Scheduled sync failed for {Id}: {Error}")]
+    public static partial void SyncSchedulerFailed(ILogger logger, string id, string error, Exception ex);
+
+    /// <summary>Logs unhandled exception in sync scheduler timer callback.</summary>
+    [LoggerMessage(EventId = 2201, Level = LogLevel.Error, Message = "[SyncScheduler] Unhandled exception in timer callback: {Error}")]
+    public static partial void SyncSchedulerTimerError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs fatal error creating timer in sync scheduler.</summary>
+    [LoggerMessage(EventId = 2202, Level = LogLevel.Error, Message = "[SyncScheduler] FATAL ERROR creating Timer: {Error}")]
+    public static partial void SyncSchedulerTimerFatal(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs trigger called for unknown account.</summary>
+    [LoggerMessage(EventId = 2203, Level = LogLevel.Warning, Message = "[SyncScheduler] TriggerAccountAsync called for unknown account {AccountId}")]
+    public static partial void SyncSchedulerUnknownAccount(ILogger logger, string accountId);
+
+    // Local Change Detection (2300-2399)
+
+    /// <summary>Logs new/modified local files found.</summary>
+    [LoggerMessage(EventId = 2300, Level = LogLevel.Information, Message = "[LocalChangeDetector] Found {Count} local new/modified files under {Path}")]
+    public static partial void LocalChangeDetectorFound(ILogger logger, int count, string path);
+
+    /// <summary>Logs error scanning local directory.</summary>
+    [LoggerMessage(EventId = 2301, Level = LogLevel.Error, Message = "[LocalChangeDetector] Error scanning {Path}: {Error}")]
+    public static partial void LocalChangeDetectorError(ILogger logger, string path, string error, Exception ex);
+
+    /// <summary>Logs access denied when scanning local directory.</summary>
+    [LoggerMessage(EventId = 2302, Level = LogLevel.Warning, Message = "[LocalChangeDetector] Access denied: {Path} — {Error}")]
+    public static partial void LocalChangeDetectorAccessDenied(ILogger logger, string path, string error);
+
+    // Local Deletion Detection (2400-2499)
+
+    /// <summary>Logs local file deleted, removing remote.</summary>
+    [LoggerMessage(EventId = 2400, Level = LogLevel.Information, Message = "[LocalDeletionDetector] Local file deleted — removing remote: {Path}")]
+    public static partial void LocalDeletionDetectorDeleted(ILogger logger, string path);
+
+    /// <summary>Logs deleted remote item.</summary>
+    [LoggerMessage(EventId = 2401, Level = LogLevel.Debug, Message = "[LocalDeletionDetector] Deleted remote item {RemoteId}")]
+    public static partial void LocalDeletionDetectorRemoteDeleted(ILogger logger, string remoteId);
+
+    /// <summary>Logs failure to delete remote item with an exception.</summary>
+    [LoggerMessage(EventId = 2402, Level = LogLevel.Error, Message = "[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}")]
+    public static partial void LocalDeletionDetectorDeleteFailed(ILogger logger, string remoteId, string error, Exception ex);
+
+    /// <summary>Logs failure to delete remote item without an exception (API error string only).</summary>
+    [LoggerMessage(EventId = 2403, Level = LogLevel.Error, Message = "[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}")]
+    public static partial void LocalDeletionDetectorDeleteFailed(ILogger logger, string remoteId, string error);
+
+    // Remote Deletion Detection (2500-2599)
+
+    /// <summary>Logs remote file deleted, removing local.</summary>
+    [LoggerMessage(EventId = 2500, Level = LogLevel.Information, Message = "[RemoteDeletionDetector] Remote file deleted — removing local: {Path}")]
+    public static partial void RemoteDeletionDetectorFileDeleted(ILogger logger, string path);
+
+    /// <summary>Logs remote folder deleted, removing local.</summary>
+    [LoggerMessage(EventId = 2501, Level = LogLevel.Information, Message = "[RemoteDeletionDetector] Remote folder deleted — removing local: {Path}")]
+    public static partial void RemoteDeletionDetectorFolderDeleted(ILogger logger, string path);
+
+    /// <summary>Logs remote item no longer present, treating as deleted.</summary>
+    [LoggerMessage(EventId = 2502, Level = LogLevel.Information, Message = "[RemoteDeletionDetector] Remote item no longer present — treating as deleted: {Path}")]
+    public static partial void RemoteDeletionDetectorNotPresent(ILogger logger, string path);
+
+    // Remote Folder Enumeration (2600-2699)
+
+    /// <summary>Logs enumeration of remote folder.</summary>
+    [LoggerMessage(EventId = 2600, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] Enumerating {Path} for {Email}")]
+    public static partial void RemoteFolderEnumeratorEnumerating(ILogger logger, string path, string email);
+
+    /// <summary>Logs enumeration completed with item count.</summary>
+    [LoggerMessage(EventId = 2601, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] Enumerated {Count} items under {Path}")]
+    public static partial void RemoteFolderEnumeratorEnumerated(ILogger logger, int count, string path);
+
+    /// <summary>Logs no sync rules configured for account.</summary>
+    [LoggerMessage(EventId = 2602, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync")]
+    public static partial void RemoteFolderEnumeratorNoRules(ILogger logger, string email);
+
+    /// <summary>Logs backfill of RemoteItemId for rule.</summary>
+    [LoggerMessage(EventId = 2603, Level = LogLevel.Debug, Message = "[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}")]
+    public static partial void RemoteFolderEnumeratorBackfilling(ILogger logger, string path);
+
+    /// <summary>Logs failure to enumerate remote folder.</summary>
+    [LoggerMessage(EventId = 2604, Level = LogLevel.Error, Message = "[RemoteFolderEnumerator] Failed to enumerate {Path}: {Error}")]
+    public static partial void RemoteFolderEnumeratorFailed(ILogger logger, string path, string error);
+
+    /// <summary>Logs generic enumeration error.</summary>
+    [LoggerMessage(EventId = 2605, Level = LogLevel.Error, Message = "[RemoteFolderEnumerator] {Error}")]
+    public static partial void RemoteFolderEnumeratorError(ILogger logger, string error);
+
+    /// <summary>Logs cannot resolve folder ID for rule.</summary>
+    [LoggerMessage(EventId = 2606, Level = LogLevel.Warning, Message = "[RemoteFolderEnumerator] Cannot resolve folder ID for rule path {Path} — skipping")]
+    public static partial void RemoteFolderEnumeratorCannotResolveId(ILogger logger, string path);
+
+    // Download Operations (2700-2799)
+
+    /// <summary>Logs ETag match, skipping download.</summary>
+    [LoggerMessage(EventId = 2700, Level = LogLevel.Debug, Message = "[DownloadJobBuilder] ETag match — skipping unchanged file {Path}")]
+    public static partial void DownloadETagMatch(ILogger logger, string path);
+
+    /// <summary>Logs download URL absent, fetching on-demand.</summary>
+    [LoggerMessage(EventId = 2701, Level = LogLevel.Debug, Message = "DownloadUrl absent for {Path} — fetching on-demand")]
+    public static partial void DownloadUrlAbsent(ILogger logger, string path);
+
+    /// <summary>Logs failure to resolve download URL.</summary>
+    [LoggerMessage(EventId = 2702, Level = LogLevel.Error, Message = "Could not resolve download URL for {Path}: {Error}")]
+    public static partial void DownloadUrlResolveFailed(ILogger logger, string path, string error);
+
+    /// <summary>Logs download failure.</summary>
+    [LoggerMessage(EventId = 2703, Level = LogLevel.Error, Message = "Download failed for {Path}: {Error}")]
+    public static partial void DownloadFailed(ILogger logger, string path, string error);
+
+    /// <summary>Logs HTTP 429 throttle during download with retry details.</summary>
+    [LoggerMessage(EventId = 2704, Level = LogLevel.Warning, Message = "[HttpDownloader] 429 received, waiting {Delay:F1}s (attempt {Attempt}/{Max})")]
+    public static partial void DownloadThrottled(ILogger logger, double delay, int attempt, int max);
+
+    /// <summary>Logs network error during download with retry details.</summary>
+    [LoggerMessage(EventId = 2705, Level = LogLevel.Warning, Message = "[HttpDownloader] Network error, retrying in {Delay:F1}s (attempt {Attempt}/{Max})")]
+    public static partial void DownloadNetworkError(ILogger logger, double delay, int attempt, int max);
+
+    // Upload Operations (2800-2899)
+
+    /// <summary>Logs file upload completion.</summary>
+    [LoggerMessage(EventId = 2800, Level = LogLevel.Information, Message = "Uploaded {Path}")]
+    public static partial void UploadCompleted(ILogger logger, string path);
+
+    /// <summary>Logs upload service starting upload.</summary>
+    [LoggerMessage(EventId = 2801, Level = LogLevel.Information, Message = "[UploadService] Starting upload: {Path} ({Size:F2} MB)")]
+    public static partial void UploadServiceStarting(ILogger logger, string path, double size);
+
+    /// <summary>Logs upload service completed upload.</summary>
+    [LoggerMessage(EventId = 2802, Level = LogLevel.Information, Message = "[UploadService] Upload complete: {Path}")]
+    public static partial void UploadServiceCompleted(ILogger logger, string path);
+
+    /// <summary>Logs upload failure.</summary>
+    [LoggerMessage(EventId = 2803, Level = LogLevel.Error, Message = "Upload failed for {Path}: {Error}")]
+    public static partial void UploadFailed(ILogger logger, string path, string error);
+
+    /// <summary>Logs HTTP 429 throttle during chunked upload.</summary>
+    [LoggerMessage(EventId = 2804, Level = LogLevel.Warning, Message = "[UploadService] 429 on chunk {Start}-{End}, waiting {Delay:F1}s (attempt {A}/{Max})")]
+    public static partial void UploadChunkThrottled(ILogger logger, long start, long end, double delay, int a, int max);
+
+    /// <summary>Logs network error during chunked upload.</summary>
+    [LoggerMessage(EventId = 2805, Level = LogLevel.Warning, Message = "[UploadService] Network error on chunk {Start}-{End}, retrying in {Delay:F1}s (attempt {A}/{Max})")]
+    public static partial void UploadChunkNetworkError(ILogger logger, long start, long end, double delay, int a, int max);
+
+    // Sync Rules & Items (2900-2999)
+
+    /// <summary>Logs persisting sync rule.</summary>
+    [LoggerMessage(EventId = 2900, Level = LogLevel.Debug, Message = "[AccountFilesViewModel] Persisting {RuleType} rule for {Path} (account {AccountId})")]
+    public static partial void RulePersisting(ILogger logger, string ruleType, string path, string accountId);
+
+    /// <summary>Logs file exists locally without SyncedItemEntity.</summary>
+    [LoggerMessage(EventId = 2901, Level = LogLevel.Debug, Message = "[SyncedItemRegistrar] File exists locally without SyncedItemEntity — treating as synced: {Path}")]
+    public static partial void SyncedItemLocalExists(ILogger logger, string path);
+
+    /// <summary>Logs drive ID not available.</summary>
+    [LoggerMessage(EventId = 2902, Level = LogLevel.Warning, Message = "[AccountFilesViewModel] Drive ID not available when building folder tree for account {AccountId}")]
+    public static partial void DriveIdNotAvailable(ILogger logger, string accountId);
+
+    /// <summary>Logs failure to load root folders.</summary>
+    [LoggerMessage(EventId = 2903, Level = LogLevel.Warning, Message = "[AccountFilesViewModel] Failed to load root folders for account {AccountId}: {Error}")]
+    public static partial void RootFoldersLoadFailed(ILogger logger, string accountId, string error);
+
+    /// <summary>Logs failure to persist folder selection.</summary>
+    [LoggerMessage(EventId = 2904, Level = LogLevel.Error, Message = "[AccountFilesViewModel] Failed to persist folder selection for account {AccountId} — {Error}")]
+    public static partial void FolderSelectionPersistFailed(ILogger logger, string accountId, string error, Exception ex);
+
+    /// <summary>Logs failure to load folder tree children.</summary>
+    [LoggerMessage(EventId = 2905, Level = LogLevel.Warning, Message = "[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}")]
+    public static partial void FolderChildrenLoadFailed(ILogger logger, string path, string error);
+
+    // Conflict Resolution (2950-2999)
+
+    /// <summary>Logs conflict resolution failure to get download URL.</summary>
+    [LoggerMessage(EventId = 2950, Level = LogLevel.Error, Message = "[ConflictApplier] Could not resolve download URL for {Path}: {Error}")]
+    public static partial void ConflictDownloadUrlFailed(ILogger logger, string path, string error);
+
+    /// <summary>Logs conflict resolution download failure.</summary>
+    [LoggerMessage(EventId = 2951, Level = LogLevel.Error, Message = "[ConflictApplier] Download failed for {Path}: {Error}")]
+    public static partial void ConflictDownloadFailed(ILogger logger, string path, string error);
+
+    // Account Operations (3000-3099)
+
+    /// <summary>Logs error completing account onboarding wizard.</summary>
+    [LoggerMessage(EventId = 3000, Level = LogLevel.Error, Message = "Error completing account onboarding wizard")]
+    public static partial void AccountOnboardingWizardError(ILogger logger, Exception error);
+
+    /// <summary>Logs unhandled exception in accounts view model wizard completion.</summary>
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Error, Message = "[AccountsViewModel.OnWizardCompletedAsync] Unhandled exception: {Error}")]
+    public static partial void AccountsViewModelWizardError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs failure to set active account.</summary>
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Error, Message = "[AccountsViewModel.OnCardSelected] Failed to set active account: {Error}")]
+    public static partial void AccountSetActiveFailed(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs error adding account.</summary>
+    [LoggerMessage(EventId = 3003, Level = LogLevel.Error, Message = "[MainWindowViewModel.OnAccountAddedAsync] Error: {Error}")]
+    public static partial void AccountAddError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs unhandled exception when account added.</summary>
+    [LoggerMessage(EventId = 3004, Level = LogLevel.Error, Message = "[MainWindowViewModel.OnAccountAddedAsync] Unhandled exception: {Error}")]
+    public static partial void AccountAddUnhandledError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs error selecting account.</summary>
+    [LoggerMessage(EventId = 3005, Level = LogLevel.Error, Message = "[MainWindowViewModel.OnAccountSelectedAsync] Error: {Error}")]
+    public static partial void AccountSelectError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs unhandled exception when account selected.</summary>
+    [LoggerMessage(EventId = 3006, Level = LogLevel.Error, Message = "[MainWindowViewModel.OnAccountSelectedAsync] Unhandled exception: {Error}")]
+    public static partial void AccountSelectUnhandledError(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs fatal error during main window initialization.</summary>
+    [LoggerMessage(EventId = 3007, Level = LogLevel.Error, Message = "[MainWindowViewModel.InitialiseAsync] FATAL ERROR: {Error}")]
+    public static partial void MainWindowInitializeFatal(ILogger logger, string error, Exception ex);
+
+    // Bootstrap & Initialization (3100-3199)
+
+    /// <summary>Logs fatal error during bootstrap.</summary>
+    [LoggerMessage(EventId = 3100, Level = LogLevel.Error, Message = "[AppBootstrapper] Fatal error during bootstrap: {Message}")]
+    public static partial void BootstrapFatal(ILogger logger, string message, Exception ex);
+
+    /// <summary>Logs fatal error during application initialization.</summary>
+    [LoggerMessage(EventId = 3101, Level = LogLevel.Error, Message = "[ApplicationInitializer.InitializeAsync] FATAL ERROR: {Error}")]
+    public static partial void ApplicationInitializeFatal(ILogger logger, string error, Exception ex);
+
+    /// <summary>Logs failure to deserialize settings.</summary>
+    [LoggerMessage(EventId = 3102, Level = LogLevel.Warning, Message = "[SettingsService] Failed to deserialize settings from {Path}; using defaults")]
+    public static partial void SettingsDeserializeFailed(ILogger logger, string path, Exception ex);
+
+    /// <summary>Logs token cache failure.</summary>
+    [LoggerMessage(EventId = 3103, Level = LogLevel.Warning, Message = "Token cache operation failed")]
+    public static partial void TokenCacheFailed(ILogger logger, Exception ex);
+
+    // Application Lifecycle (use ApplicationMessages for these)
+    // - Starting/Stopping handled by ApplicationMessages.Starting/Stopping
+    // - Unhandled exception handled by MainWindowInitializeFatal, BootstrapFatal, etc.
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppBootstrapper.cs
@@ -3,11 +3,13 @@ using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 /// <inheritdoc />
-public sealed class AppBootstrapper(IDbContextFactory<AppDbContext> dbContextFactory, ISettingsService settingsService, IThemeService themeService, ISyncScheduler syncScheduler, MainWindowViewModel mainWindowViewModel) : IAppBootstrapper
+public sealed class AppBootstrapper(IDbContextFactory<AppDbContext> dbContextFactory, ISettingsService settingsService, IThemeService themeService, ISyncScheduler syncScheduler, MainWindowViewModel mainWindowViewModel, ILogger<AppBootstrapper> logger) : IAppBootstrapper
 {
     /// <inheritdoc />
     public async Task BootstrapAsync(IProgress<string> progress, CancellationToken ct = default)
@@ -32,7 +34,7 @@ public sealed class AppBootstrapper(IDbContextFactory<AppDbContext> dbContextFac
         }
         catch (Exception ex)
         {
-            Serilog.Log.Fatal(ex, "[AppBootstrapper] Fatal error during bootstrap: {Message}", ex.Message);
+            OneDriveSyncClientMessages.BootstrapFatal(logger, ex.Message, ex);
             throw;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
@@ -2,12 +2,14 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 /// <inheritdoc />
-public sealed class ApplicationInitializer(IStartupService startupService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings) : IApplicationInitializer
+public sealed class ApplicationInitializer(IStartupService startupService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, ILogger<ApplicationInitializer> logger) : IApplicationInitializer
 {
     /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken ct = default)
@@ -22,7 +24,7 @@ public sealed class ApplicationInitializer(IStartupService startupService, Accou
 
             accounts.RestoreAccounts(restored);
 
-            foreach(var account in restored)
+            foreach (var account in restored)
             {
                 files.AddAccount(account);
                 dashboard.AddAccount(account);
@@ -32,15 +34,15 @@ public sealed class ApplicationInitializer(IStartupService startupService, Accou
 
             var activeAccount = restored.FirstOrDefault(account => account.IsActive);
 
-            if(activeAccount is not null)
+            if (activeAccount is not null)
             {
                 await files.ActivateAccountAsync(activeAccount.Id.Id).ConfigureAwait(false);
                 await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Profile.Email).ConfigureAwait(false);
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Fatal(ex, "[ApplicationInitializer.InitializeAsync] FATAL ERROR: {Error}", ex.Message);
+            OneDriveSyncClientMessages.ApplicationInitializeFatal(logger, ex.Message, ex);
             throw;
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/SettingsService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/SettingsService.cs
@@ -1,15 +1,17 @@
 using System.IO.Abstractions;
 using System.Text.Json;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 /// <inheritdoc />
-public sealed class SettingsService(IFileSystem fileSystem, string? settingsFilePath = null) : ISettingsService
+public sealed class SettingsService(IFileSystem fileSystem, ILogger<SettingsService> logger, string? settingsFilePath = null) : ISettingsService
 {
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
-        WriteIndented        = true,
+        WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
@@ -34,7 +36,7 @@ public sealed class SettingsService(IFileSystem fileSystem, string? settingsFile
         }
         catch (Exception ex)
         {
-            Serilog.Log.Warning(ex, "[SettingsService] Failed to deserialize settings from {Path}; using defaults", path);
+            OneDriveSyncClientMessages.SettingsDeserializeFailed(logger, path, ex);
             Current = new AppSettings();
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ConflictApplier.cs
@@ -2,16 +2,18 @@ using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphService graphService, IFileSystem fileSystem) : IConflictApplier
+public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphService graphService, IFileSystem fileSystem, ILogger<ConflictApplier> logger) : IConflictApplier
 {
     /// <inheritdoc />
     public async Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
     {
-        switch(outcome)
+        switch (outcome)
         {
             case ConflictOutcome.UseRemote:
                 return await ApplyUseRemoteAsync(conflict, accountId, accessToken, ct).ConfigureAwait(false);
@@ -38,14 +40,14 @@ public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphServic
                     _ => true,
                     downloadError =>
                     {
-                        Serilog.Log.Error("[ConflictApplier] Download failed for {Path}: {Error}", conflict.Target.RelativePath, downloadError);
+                        OneDriveSyncClientMessages.ConflictDownloadFailed(logger, conflict.Target.RelativePath, downloadError);
 
                         return false;
                     });
             },
             error =>
             {
-                Serilog.Log.Error("[ConflictApplier] Could not resolve download URL for {Path}: {Error}", conflict.Target.RelativePath, error);
+                OneDriveSyncClientMessages.ConflictDownloadUrlFailed(logger, conflict.Target.RelativePath, error);
 
                 return false;
             }).ConfigureAwait(false);
@@ -55,7 +57,7 @@ public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphServic
     {
         string keepBothName = ConflictResolver.MakeKeepBothName(conflict.Target.LocalPath, conflict.Snapshot.LocalModified, fileSystem);
 
-        if(fileSystem.File.Exists(conflict.Target.LocalPath))
+        if (fileSystem.File.Exists(conflict.Target.LocalPath))
             fileSystem.File.Move(conflict.Target.LocalPath, keepBothName);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
@@ -3,13 +3,15 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.Utilities;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar, IFileSystem fileSystem) : IDownloadJobBuilder
+public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar, IFileSystem fileSystem, ILogger<DownloadJobBuilder> logger) : IDownloadJobBuilder
 {
     /// <inheritdoc />
     public async Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
@@ -43,14 +45,14 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
 
         if (knownItem?.Tags.ETag is not null && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
         {
-            Serilog.Log.Debug("[DownloadJobBuilder] ETag match — skipping unchanged file {Path}", item.Path.RelativePath);
+            OneDriveSyncClientMessages.DownloadETagMatch(logger, item.Path.EffectivePath);
             return null;
         }
 
         if (knownItem is not null && fileSystem.File.Exists(localPath))
         {
             var localModified = new DateTimeOffset(fileSystem.FileInfo.New(localPath).LastWriteTimeUtc, TimeSpan.Zero);
-            bool isConflict   = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
+            bool isConflict = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
 
             if (isConflict)
                 return await BuildConflictJobAsync(account, item, localPath, localModified, onConflict).ConfigureAwait(false);
@@ -74,16 +76,16 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return outcome switch
         {
             ConflictOutcome.UseRemote => BuildDownloadJob(account.Id, item, localPath),
-            ConflictOutcome.UseLocal  => BuildUploadJob(account.Id, item, localPath, localModified),
-            ConflictOutcome.KeepBoth  => BuildKeepBothJob(account.Id, item, localPath, localModified),
-            _                         => null
+            ConflictOutcome.UseLocal => BuildUploadJob(account.Id, item, localPath, localModified),
+            ConflictOutcome.KeepBoth => BuildKeepBothJob(account.Id, item, localPath, localModified),
+            _ => null
         };
     }
 
     private static DownloadSyncJob BuildDownloadJob(AccountId accountId, DeltaItem item, string localPath)
     {
-        var remote   = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
-        var target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
+        var remote = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
+        var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
         var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
 
         return SyncJobFactory.CreateDownload(remote, target, metadata, item.DownloadUrl);
@@ -91,8 +93,8 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
 
     private UploadSyncJob BuildUploadJob(AccountId accountId, DeltaItem item, string localPath, DateTimeOffset localModified)
     {
-        var remote   = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
-        var target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
+        var remote = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
+        var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
         var metadata = SyncFileMetadataFactory.Create(fileSystem.FileInfo.New(localPath).Length, localModified);
 
         return SyncJobFactory.CreateUpload(remote, target, metadata);
@@ -109,8 +111,8 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
     private SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
         => new()
         {
-            Remote   = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
-            Target   = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
+            Remote = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),
+            Target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath),
             Snapshot = ConflictSnapshotFactory.Create(localModified, fileSystem.FileInfo.New(localPath).Length, item.LastModified ?? DateTimeOffset.MinValue, item.Size)
         };
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobHandler.cs
@@ -1,11 +1,13 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService graphService) : IJobHandler
+public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService graphService, ILogger<DownloadJobHandler> logger) : IJobHandler
 {
     /// <inheritdoc />
     public bool CanHandle(SyncJob job) => job is DownloadSyncJob;
@@ -25,14 +27,14 @@ public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService
                     _ => new Result<SyncJob, string>.Ok(downloadJob),
                     error =>
                     {
-                        Serilog.Log.Error("Download failed for {Path}: {Error}", downloadJob.Target.RelativePath, error);
+                        OneDriveSyncClientMessages.DownloadFailed(logger, downloadJob.Target.RelativePath, error);
 
                         return new Result<SyncJob, string>.Error(error);
                     });
             },
             urlError =>
             {
-                Serilog.Log.Error("Could not resolve download URL for {Path}: {Error}", downloadJob.Target.RelativePath, urlError);
+                OneDriveSyncClientMessages.DownloadUrlResolveFailed(logger, downloadJob.Target.RelativePath, urlError);
 
                 return new Result<SyncJob, string>.Error(urlError);
             }).ConfigureAwait(false);
@@ -40,10 +42,10 @@ public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService
 
     private async Task<Result<string, string>> ResolveDownloadUrlAsync(DownloadSyncJob job, string accountId, string accessToken, CancellationToken ct)
     {
-        if(job.DownloadUrl is not null)
+        if (job.DownloadUrl is not null)
             return new Result<string, string>.Ok(job.DownloadUrl);
 
-        Serilog.Log.Debug("DownloadUrl absent for {Path} — fetching on-demand", job.Target.RelativePath);
+        OneDriveSyncClientMessages.DownloadUrlAbsent(logger, job.Target.RelativePath);
 
         return await graphService.GetDownloadUrlAsync(accountId, accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/HttpDownloader.cs
@@ -1,6 +1,8 @@
 using System.IO.Abstractions;
 using System.Reactive;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -10,12 +12,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// A new HttpClient is obtained from IHttpClientFactory per download call so the
 /// factory can rotate and dispose handlers freely without this class holding stale references.
 /// </summary>
-public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSystem fileSystem) : IHttpDownloader
+public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSystem fileSystem, ILogger<HttpDownloader> logger) : IHttpDownloader
 {
-    private const string UserAgent        = "AStar.Dev.OneDrive.Sync/1.0";
-    private const int    MaxRetries       = 5;
+    private const string UserAgent = "AStar.Dev.OneDrive.Sync/1.0";
+    private const int MaxRetries = 5;
     private const double BaseDelaySeconds = 2.0;
-    private const double MaxDelaySeconds  = 120.0;
+    private const double MaxDelaySeconds = 120.0;
 
     /// <inheritdoc />
     public async Task<Result<Unit, string>> DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
@@ -25,7 +27,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
         int attempt = 0;
 
-        while(true)
+        while (true)
         {
             ct.ThrowIfCancellationRequested();
 
@@ -36,13 +38,13 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
             {
                 response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
 
-                if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
-                    if(attempt > MaxRetries)
+                    if (attempt > MaxRetries)
                         return new Result<Unit, string>.Error($"Rate limited after {MaxRetries} retries.");
 
                     var delay = GetRetryDelay(response, attempt);
-                    Serilog.Log.Warning("[HttpDownloader] 429 received, waiting {Delay:F1}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt, MaxRetries);
+                    OneDriveSyncClientMessages.DownloadThrottled(logger, delay.TotalSeconds, attempt, MaxRetries);
 
                     response.Dispose();
                     await Task.Delay(delay, ct);
@@ -60,10 +62,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
                 return new Result<Unit, string>.Ok(Unit.Default);
             }
-            catch(HttpRequestException) when(attempt <= MaxRetries)
+            catch (HttpRequestException) when (attempt <= MaxRetries)
             {
                 var delay = GetBackoffDelay(attempt);
-                Serilog.Log.Warning("[HttpDownloader] Network error, retrying in {Delay:F1}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt, MaxRetries);
+                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, MaxRetries);
                 await Task.Delay(delay, ct);
             }
             finally
@@ -78,10 +80,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
         await using var file = fileSystem.FileStream.New(localPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
 
         byte[] buffer = new byte[81920];
-        long written  = 0;
-        int  read;
+        long written = 0;
+        int read;
 
-        while((read = await source.ReadAsync(buffer, ct)) > 0)
+        while ((read = await source.ReadAsync(buffer, ct)) > 0)
         {
             await file.WriteAsync(buffer.AsMemory(0, read), ct);
             written += read;
@@ -92,7 +94,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
     private void EnsureDirectoryExists(string localPath)
     {
         string? dir = fileSystem.Path.GetDirectoryName(localPath);
-        if(!string.IsNullOrEmpty(dir))
+        if (!string.IsNullOrEmpty(dir))
             _ = fileSystem.Directory.CreateDirectory(dir);
     }
 
@@ -100,13 +102,13 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
     private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
     {
-        if(response.Headers.RetryAfter?.Delta is { } delta)
+        if (response.Headers.RetryAfter?.Delta is { } delta)
             return delta + AddAdditionalSecondBackoff();
 
-        if(response.Headers.RetryAfter?.Date is not { } date) return GetBackoffDelay(attempt);
+        if (response.Headers.RetryAfter?.Date is not { } date) return GetBackoffDelay(attempt);
 
         var wait = date - DateTimeOffset.UtcNow;
-        if(wait > TimeSpan.Zero)
+        if (wait > TimeSpan.Zero)
             return wait + AddAdditionalSecondBackoff();
 
         return GetBackoffDelay(attempt);
@@ -117,7 +119,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
     private static TimeSpan GetBackoffDelay(int attempt)
     {
         double seconds = CalculateExponentialBackoff(attempt);
-        double jitter  = seconds * 0.2 * Random.Shared.NextDouble();
+        double jitter = seconds * 0.2 * Random.Shared.NextDouble();
 
         return TimeSpan.FromSeconds(seconds + jitter);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
@@ -1,7 +1,9 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.Utilities;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -11,24 +13,24 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// Scans local sync directories for files that are new or modified relative to the last synced state.
 /// Uses <see cref="SyncedItemEntity.RemoteModifiedAt"/> as the baseline for conflict/modification detection.
 /// </summary>
-public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDetector
+public sealed class LocalChangeDetector(IFileSystem fileSystem, ILogger<LocalChangeDetector> logger) : ILocalChangeDetector
 {
     /// <inheritdoc />
     public IReadOnlyList<SyncJob> DetectNewAndModifiedFiles(string accountId, string localBasePath, IReadOnlyList<SyncRuleEntity> rules, IReadOnlyDictionary<string, SyncedItemEntity> syncedItemsByLocalPath)
     {
         List<SyncJob> jobs = [];
 
-        foreach(var rule in rules.Where(r => r.RuleType == RuleType.Include))
+        foreach (var rule in rules.Where(r => r.RuleType == RuleType.Include))
         {
             string localFolderPath = BuildLocalPath(localBasePath, rule.RemotePath);
 
-            if(!fileSystem.Directory.Exists(localFolderPath))
+            if (!fileSystem.Directory.Exists(localFolderPath))
                 continue;
 
             ScanDirectory(accountId, localBasePath, localFolderPath, rules, syncedItemsByLocalPath, jobs);
         }
 
-        Serilog.Log.Information("[LocalChangeDetector] Found {Count} local new/modified files under {Path}", jobs.Count, localBasePath);
+        OneDriveSyncClientMessages.LocalChangeDetectorFound(logger, jobs.Count, localBasePath);
 
         return jobs;
     }
@@ -37,23 +39,23 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDe
     {
         try
         {
-            foreach(string filePath in fileSystem.Directory.EnumerateFiles(localDir))
+            foreach (string filePath in fileSystem.Directory.EnumerateFiles(localDir))
             {
                 var info = fileSystem.FileInfo.New(filePath);
 
-                if(IsFileToSkip(info))
+                if (IsFileToSkip(info))
                     continue;
 
                 string remotePath = $"/{fileSystem.Path.GetRelativePath(localBasePath, filePath).Replace(fileSystem.Path.DirectorySeparatorChar, '/')}";
 
-                if(!SyncRuleEvaluator.IsIncluded(remotePath, rules))
+                if (!SyncRuleEvaluator.IsIncluded(remotePath, rules))
                     continue;
 
                 var localModified = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero);
 
-                if(syncedItemsByLocalPath.TryGetValue(filePath, out var known))
+                if (syncedItemsByLocalPath.TryGetValue(filePath, out var known))
                 {
-                    if(localModified <= known.RemoteModifiedAt.AddSeconds(5))
+                    if (localModified <= known.RemoteModifiedAt.AddSeconds(5))
                         continue;
                 }
 
@@ -66,27 +68,27 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem) : ILocalChangeDe
                 jobs.Add(SyncJobFactory.CreateUpload(remote, target, metadata));
             }
 
-            foreach(string subDir in fileSystem.Directory.EnumerateDirectories(localDir))
+            foreach (string subDir in fileSystem.Directory.EnumerateDirectories(localDir))
             {
                 var dirInfo = fileSystem.DirectoryInfo.New(subDir);
-                if(dirInfo.Attributes.HasFlag(FileAttributes.Hidden) || dirInfo.Name.StartsWith('.'))
+                if (dirInfo.Attributes.HasFlag(FileAttributes.Hidden) || dirInfo.Name.StartsWith('.'))
                     continue;
 
                 string subRemotePath = $"/{fileSystem.Path.GetRelativePath(localBasePath, subDir).Replace(fileSystem.Path.DirectorySeparatorChar, '/')}";
 
-                if(!SyncRuleEvaluator.IsIncluded(subRemotePath, rules))
+                if (!SyncRuleEvaluator.IsIncluded(subRemotePath, rules))
                     continue;
 
                 ScanDirectory(accountId, localBasePath, subDir, rules, syncedItemsByLocalPath, jobs);
             }
         }
-        catch(UnauthorizedAccessException ex)
+        catch (UnauthorizedAccessException ex)
         {
-            Serilog.Log.Warning("[LocalChangeDetector] Access denied: {Path} — {Error}", localDir, ex.Message);
+            OneDriveSyncClientMessages.LocalChangeDetectorAccessDenied(logger, localDir, ex.Message);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[LocalChangeDetector] Error scanning {Path}: {Error}", localDir, ex.Message);
+            OneDriveSyncClientMessages.LocalChangeDetectorError(logger, localDir, ex.Message, ex);
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalDeletionDetector.cs
@@ -4,23 +4,25 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem) : ILocalDeletionDetector
+public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<LocalDeletionDetector> logger) : ILocalDeletionDetector
 {
     /// <inheritdoc />
     public async Task DetectAndApplyAsync(AccountId accountId, string accessToken, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
-        foreach(var (remoteId, knownItem) in syncedItems)
+        foreach (var (remoteId, knownItem) in syncedItems)
         {
-            if(knownItem.IsFolder) continue;
-            if(ct.IsCancellationRequested) break;
-            if(fileSystem.File.Exists(knownItem.LocalPath)) continue;
+            if (knownItem.IsFolder) continue;
+            if (ct.IsCancellationRequested) break;
+            if (fileSystem.File.Exists(knownItem.LocalPath)) continue;
 
-            Serilog.Log.Information("[LocalDeletionDetector] Local file deleted — removing remote: {Path}", knownItem.RemotePath);
+            OneDriveSyncClientMessages.LocalDeletionDetectorDeleted(logger, knownItem.RemotePath);
 
             try
             {
@@ -29,19 +31,19 @@ public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedIte
                 await deleteResult.MatchAsync<Unit>(
                     async _ =>
                     {
-                        Serilog.Log.Debug("[LocalDeletionDetector] Deleted remote item {RemoteId}", remoteId);
+                        OneDriveSyncClientMessages.LocalDeletionDetectorRemoteDeleted(logger, remoteId);
                         await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
                         return Unit.Default;
                     },
                     deleteError =>
                     {
-                        Serilog.Log.Error("[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, deleteError);
+                        OneDriveSyncClientMessages.LocalDeletionDetectorDeleteFailed(logger, remoteId, deleteError);
                         return Unit.Default;
                     });
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
-                Serilog.Log.Error(ex, "[LocalDeletionDetector] Failed to delete remote item {RemoteId}: {Error}", remoteId, ex.Message);
+                OneDriveSyncClientMessages.LocalDeletionDetectorDeleteFailed(logger, remoteId, ex.Message, ex);
             }
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ParallelSyncPipeline.cs
@@ -1,6 +1,8 @@
 using System.Threading.Channels;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
@@ -17,13 +19,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// never loads more than ~4 jobs per worker into memory at once.
 /// With 300k files this means memory stays flat regardless of job count.
 /// </summary>
-public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISyncRepository syncRepository) : ISyncPipeline
+public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISyncRepository syncRepository, ILogger<ParallelSyncPipeline> logger) : ISyncPipeline
 {
     /// <inheritdoc />
     public async Task RunAsync(IEnumerable<SyncJob> jobs, string accessToken, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default)
     {
         var jobList = jobs.ToList();
-        if(jobList.Count == 0)
+        if (jobList.Count == 0)
             return;
 
         var tracker = new SyncProgressTracker(jobList.Count, accountId, folderId);
@@ -42,7 +44,7 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
 
         try
         {
-            foreach(var job in jobList)
+            foreach (var job in jobList)
             {
                 ct.ThrowIfCancellationRequested();
                 await channel.Writer.WriteAsync(job, ct);
@@ -56,20 +58,20 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
         try
         {
             await Task.WhenAll(workers);
-            Serilog.Log.Information("[Pipeline] All workers completed normally");
+            OneDriveSyncClientMessages.SyncPipelineCompleted(logger);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[Pipeline] Worker threw unhandled exception: {Type} {Error}", ex.GetType().Name, ex.Message);
+            OneDriveSyncClientMessages.SyncPipelineWorkerException(logger, ex.GetType().Name, ex.Message, ex);
         }
         finally
         {
             onProgress(new SyncProgressEventArgs(accountId: accountId, folderId: folderId, completed: tracker.Done, total: jobList.Count, currentFile: string.Empty, syncState: SyncState.Idle));
-            Serilog.Log.Information("[Pipeline] Final progress raised — done={Done} total={Total}", tracker.Done, jobList.Count);
+            OneDriveSyncClientMessages.SyncPipelineFinalProgress(logger, tracker.Done, jobList.Count);
         }
 
         await syncRepository.ClearCompletedJobsAsync(new AccountId(accountId));
 
-        Serilog.Log.Information("[Pipeline] Complete — {Done}/{Total} jobs processed", tracker.Done, jobList.Count);
+        OneDriveSyncClientMessages.SyncPipelineJobsProcessed(logger, tracker.Done, jobList.Count);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteDeletionDetector.cs
@@ -1,29 +1,30 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
-
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem) : IRemoteDeletionDetector
+public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<RemoteDeletionDetector> logger) : IRemoteDeletionDetector
 {
     /// <inheritdoc />
     public async Task DetectAndApplyAsync(AccountId accountId, Dictionary<string, SyncedItemEntity> syncedItems, IReadOnlySet<string> seenRemoteIds, IReadOnlyList<SyncRuleEntity> rules, CancellationToken ct)
     {
-        foreach(var (remoteId, knownItem) in syncedItems.ToList())
+        foreach (var (remoteId, knownItem) in syncedItems.ToList())
         {
-            if(ct.IsCancellationRequested)
+            if (ct.IsCancellationRequested)
                 break;
 
-            if(!SyncRuleEvaluator.IsIncluded(knownItem.RemotePath, rules))
+            if (!SyncRuleEvaluator.IsIncluded(knownItem.RemotePath, rules))
                 continue;
 
-            if(seenRemoteIds.Contains(remoteId))
+            if (seenRemoteIds.Contains(remoteId))
                 continue;
 
-            Serilog.Log.Information("[RemoteDeletionDetector] Remote item no longer present — treating as deleted: {Path}", knownItem.RemotePath);
+            OneDriveSyncClientMessages.RemoteDeletionDetectorNotPresent(logger, knownItem.RemotePath);
             await HandleRemoteDeleteAsync(accountId, knownItem, syncedItems, ct);
         }
     }
@@ -32,19 +33,19 @@ public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepos
     {
         string localPath = knownItem.LocalPath;
 
-        if(knownItem.IsFolder)
+        if (knownItem.IsFolder)
         {
-            if(fileSystem.Directory.Exists(localPath))
+            if (fileSystem.Directory.Exists(localPath))
             {
-                Serilog.Log.Information("[RemoteDeletionDetector] Remote folder deleted — removing local: {Path}", localPath);
+                OneDriveSyncClientMessages.RemoteDeletionDetectorFolderDeleted(logger, localPath);
                 fileSystem.Directory.Delete(localPath, recursive: true);
             }
         }
         else
         {
-            if(fileSystem.File.Exists(localPath))
+            if (fileSystem.File.Exists(localPath))
             {
-                Serilog.Log.Information("[RemoteDeletionDetector] Remote file deleted — removing local: {Path}", localPath);
+                OneDriveSyncClientMessages.RemoteDeletionDetectorFileDeleted(logger, localPath);
                 fileSystem.File.Delete(localPath);
             }
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/RemoteFolderEnumerator.cs
@@ -5,21 +5,23 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository) : IRemoteFolderEnumerator
+public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, ILogger<RemoteFolderEnumerator> logger) : IRemoteFolderEnumerator
 {
     /// <inheritdoc />
     public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct)
     {
         var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
-        if(rules.Count == 0)
+        if (rules.Count == 0)
         {
-            Serilog.Log.Information("[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync", account.Profile.Email);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorNoRules(logger, account.Profile.Email);
 
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: true);
         }
@@ -30,11 +32,11 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 id => id,
                 error =>
                 {
-                    Serilog.Log.Error("[RemoteFolderEnumerator] {Error}", error);
+                    OneDriveSyncClientMessages.RemoteFolderEnumeratorError(logger, error);
                     return null;
                 }).ConfigureAwait(false);
 
-        if(driveId is null)
+        if (driveId is null)
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: false);
 
         var includeRules = rules.Where(r => r.RuleType == RuleType.Include).ToList();
@@ -45,35 +47,35 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         List<DeltaItem> allDeltaItems = [];
         var seenRemoteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach(var rule in rootIncludeRules)
+        foreach (var rule in rootIncludeRules)
         {
-            if(ct.IsCancellationRequested)
+            if (ct.IsCancellationRequested)
                 break;
 
             string? folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId.Value, ct).ConfigureAwait(false);
 
-            if(folderId is null)
+            if (folderId is null)
             {
-                Serilog.Log.Warning("[RemoteFolderEnumerator] Cannot resolve folder ID for rule path {Path} — skipping", rule.RemotePath);
+                OneDriveSyncClientMessages.RemoteFolderEnumeratorCannotResolveId(logger, rule.RemotePath);
                 continue;
             }
 
-            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerating {Path} for {Email}", rule.RemotePath, account.Profile.Email);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Profile.Email);
             var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, ct)
                 .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
                     deltaItems => deltaItems,
                     error =>
                     {
-                        Serilog.Log.Error("[RemoteFolderEnumerator] Failed to enumerate {Path}: {Error}", rule.RemotePath, error);
+                        OneDriveSyncClientMessages.RemoteFolderEnumeratorFailed(logger, rule.RemotePath, error);
                         return null;
                     }).ConfigureAwait(false);
 
-            if(items is null)
+            if (items is null)
                 continue;
 
-            Serilog.Log.Information("[RemoteFolderEnumerator] Enumerated {Count} items under {Path}", items.Count, rule.RemotePath);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerated(logger, items.Count, rule.RemotePath);
 
-            foreach(var item in items)
+            foreach (var item in items)
                 seenRemoteIds.Add(item.Id.Id);
 
             allDeltaItems.AddRange(items);
@@ -88,9 +90,9 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             ?? TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
             ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct).ConfigureAwait(false);
 
-        if(folderId is not null && folderId != rule.RemoteItemId)
+        if (folderId is not null && folderId != rule.RemoteItemId)
         {
-            Serilog.Log.Debug("[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}", rule.RemotePath);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorBackfilling(logger, rule.RemotePath);
             await syncRuleRepository.UpsertAsync(accountId, rule.RemotePath, RuleType.Include, folderId, ct).ConfigureAwait(false);
         }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -3,7 +3,9 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -12,7 +14,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// Default interval: 60 minutes. Configurable via Settings.
 /// Manual sync can be triggered immediately via <see cref="TriggerNowAsync"/>.
 /// </summary>
-public sealed class SyncScheduler(ISyncService syncService, IAccountRepository accountRepository, ISyncRuleRepository syncRuleRepository) : IAsyncDisposable, ISyncScheduler
+public sealed class SyncScheduler(ISyncService syncService, IAccountRepository accountRepository, ISyncRuleRepository syncRuleRepository, ILogger<SyncScheduler> logger) : IAsyncDisposable, ISyncScheduler
 {
     private Timer? _timer;
     private TimeSpan _interval = TimeSpan.FromMinutes(60);
@@ -38,9 +40,9 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         {
             _timer = new Timer(OnTimerTickAsync, state: null, dueTime: _interval, period: _interval);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Fatal(ex, "[SyncScheduler.Start] FATAL ERROR creating Timer: {Error}", ex.Message);
+            OneDriveSyncClientMessages.SyncSchedulerTimerFatal(logger, ex.Message, ex);
             throw;
         }
     }
@@ -77,7 +79,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
             },
             () =>
             {
-                Serilog.Log.Warning("[SyncScheduler] TriggerAccountAsync called for unknown account {AccountId}", accountId);
+                OneDriveSyncClientMessages.SyncSchedulerUnknownAccount(logger, accountId);
                 return Task.CompletedTask;
             });
     }
@@ -108,7 +110,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         }
         catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[SyncScheduler] Unhandled exception in timer callback: {Error}", ex.Message);
+            OneDriveSyncClientMessages.SyncSchedulerTimerError(logger, ex.Message, ex);
         }
     }
 
@@ -116,24 +118,24 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
     private static OneDriveAccount MapEntityToAccount(AccountEntity entity, IReadOnlyList<SyncRuleEntity> rules) => new()
     {
-        Id                = entity.Id,
-        Profile           = entity.Profile,
-        AccentIndex       = entity.AccentIndex,
-        IsActive          = entity.IsActive,
-        LastSyncedAt      = entity.LastSyncedAt,
-        SyncConfig        = entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? entity.SyncConfig : null,
+        Id = entity.Id,
+        Profile = entity.Profile,
+        AccentIndex = entity.AccentIndex,
+        IsActive = entity.IsActive,
+        LastSyncedAt = entity.LastSyncedAt,
+        SyncConfig = entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? entity.SyncConfig : null,
         SelectedFolderIds = [.. rules.Where(r => r.RuleType == RuleType.Include && r.RemoteItemId is not null).Select(r => new OneDriveFolderId(r.RemoteItemId!))]
     };
 
     private async Task RunSyncPassAsync(CancellationToken ct)
     {
-        if(Interlocked.Exchange(ref _runningFlag, 1) == 1)
+        if (Interlocked.Exchange(ref _runningFlag, 1) == 1)
             return;
 
         try
         {
             var entities = await accountRepository.GetAllAsync(CancellationToken.None);
-            foreach(var entity in entities.TakeWhile(_ => !ct.IsCancellationRequested))
+            foreach (var entity in entities.TakeWhile(_ => !ct.IsCancellationRequested))
             {
                 var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct).ConfigureAwait(false);
                 var account = MapEntityToAccount(entity, rules);
@@ -143,9 +145,9 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
                 {
                     await syncService.SyncAccountAsync(account, ct);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                    Serilog.Log.Error(ex, "[SyncScheduler] Scheduled sync failed for {Id}: {Error}", account.Id.Id, ex.Message);
+                    OneDriveSyncClientMessages.SyncSchedulerFailed(logger, account.Id.Id, ex.Message, ex);
                 }
                 finally
                 {
@@ -163,7 +165,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     {
         StopSync();
 
-        if(_timer is not null)
+        if (_timer is not null)
             await _timer.DisposeAsync();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -5,10 +5,12 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using Microsoft.Extensions.Logging;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-public sealed class SyncService(IAuthService authService, ISyncRepository syncRepository, ISyncPassOrchestrator syncPassOrchestrator, IConflictApplier conflictApplier) : ISyncService
+public sealed class SyncService(IAuthService authService, ISyncRepository syncRepository, ISyncPassOrchestrator syncPassOrchestrator, IConflictApplier conflictApplier, ILogger<SyncService> logger) : ISyncService
 {
     /// <inheritdoc />
     public event EventHandler<SyncProgressEventArgs>? SyncProgressChanged;
@@ -22,7 +24,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
     /// <inheritdoc />
     public async Task SyncAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
-        Serilog.Log.Information("[SyncService] SyncAccountAsync for {Email}", account.Profile.Email);
+        OneDriveSyncClientMessages.SyncServiceStarting(logger, account.Profile.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
         string? accessToken = await authService.AcquireTokenSilentAsync(account.Id.Id, ct)
@@ -34,10 +36,10 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                     return null;
                 }).ConfigureAwait(false);
 
-        if(accessToken is null)
+        if (accessToken is null)
             return;
 
-        if(account.SyncConfig is null)
+        if (account.SyncConfig is null)
         {
             RaiseProgress(account.Id.Id, 0, 0, "No local sync path configured", SyncState.Error);
 
@@ -58,21 +60,21 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                 args => JobCompleted?.Invoke(this, args),
                 ct).ConfigureAwait(false);
 
-            if(!didRun)
+            if (!didRun)
                 RaiseProgress(account.Id.Id, 0, 0, "No folders selected", SyncState.Idle);
             else
             {
-                Serilog.Log.Information("[SyncService] Sync complete for {Email}", account.Profile.Email);
+                OneDriveSyncClientMessages.SyncServiceComplete(logger, account.Profile.Email);
                 RaiseProgress(account.Id.Id, 0, 0, "Sync complete", SyncState.Idle);
             }
         }
-        catch(OperationCanceledException)
+        catch (OperationCanceledException)
         {
             RaiseProgress(account.Id.Id, 0, 0, "Sync cancelled", SyncState.Idle);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Serilog.Log.Error(ex, "[SyncService] Unhandled error syncing {Email}: {Error}", account.Profile.Email, ex.Message);
+            OneDriveSyncClientMessages.SyncServiceError(logger, account.Profile.Email, ex.Message, ex);
             RaiseProgress(account.Id.Id, 0, 0, ex.Message, SyncState.Error);
         }
     }
@@ -83,13 +85,13 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
         string? accessToken = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct)
             .MatchAsync<AuthResult, AuthError, string?>(ok => ok.AccessToken, _ => null).ConfigureAwait(false);
 
-        if(accessToken is null)
+        if (accessToken is null)
             return;
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
         bool applied = await conflictApplier.ApplyAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
 
-        if(!applied)
+        if (!applied)
         {
             RaiseProgress(conflict.Remote.AccountId.Id, 0, 0, "Conflict resolution failed", SyncState.Error);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncWorker.cs
@@ -3,6 +3,8 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
@@ -10,16 +12,16 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// Drains jobs from a <see cref="ChannelReader{T}"/> and dispatches each to the
 /// appropriate <see cref="IJobHandler"/>. Multiple workers run concurrently.
 /// </summary>
-public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers, ISyncRepository syncRepository) : ISyncWorker
+public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers, ISyncRepository syncRepository, ILogger<SyncWorker> logger) : ISyncWorker
 {
     /// <inheritdoc />
     public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
     {
-        await foreach(var job in reader.ReadAllAsync(ct))
+        await foreach (var job in reader.ReadAllAsync(ct))
         {
             ct.ThrowIfCancellationRequested();
 
-            Serilog.Log.Debug("[Worker {Id}] Processing {JobType} {Path}", workerId, job.GetType().Name, job.Target.RelativePath);
+            OneDriveSyncClientMessages.SyncWorkerProcessing(logger, workerId, job.GetType().Name, job.Target.RelativePath);
 
             await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.InProgress).ConfigureAwait(false);
 
@@ -34,20 +36,20 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
                         completedJob => (completedJob, true, null),
                         reason => (currentJob, false, reason)).ConfigureAwait(false);
 
-                if(success)
+                if (success)
                     await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed).ConfigureAwait(false);
                 else
                     await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, error).ConfigureAwait(false);
             }
-            catch(OperationCanceledException)
+            catch (OperationCanceledException)
             {
                 await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued).ConfigureAwait(false);
                 throw;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 error = ex.Message;
-                Serilog.Log.Error(ex, "[Worker {Id}] EXCEPTION type={Type} message={Error} path={Path}", workerId, ex.GetType().Name, ex.Message, job.Target.LocalPath);
+                OneDriveSyncClientMessages.SyncWorkerException(logger, workerId, ex.GetType().Name, ex.Message, job.Target.LocalPath, ex);
                 await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, ex.Message).ConfigureAwait(false);
             }
             finally
@@ -61,9 +63,9 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
     {
         var handler = handlers.FirstOrDefault(h => h.CanHandle(job));
 
-        if(handler is null)
+        if (handler is null)
         {
-            Serilog.Log.Warning("[Worker {Id}] No handler registered for job type {JobType}", workerId, job.GetType().Name);
+            OneDriveSyncClientMessages.SyncWorkerNoHandler(logger, workerId, job.GetType().Name);
 
             return Task.FromResult<Result<SyncJob, string>>(new Result<SyncJob, string>.Error($"No handler registered for job type '{job.GetType().Name}'."));
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncWorkerFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncWorkerFactory.cs
@@ -1,12 +1,13 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class SyncWorkerFactory(IEnumerable<IJobHandler> handlers, ISyncRepository syncRepository) : ISyncWorkerFactory
+public sealed class SyncWorkerFactory(IEnumerable<IJobHandler> handlers, ISyncRepository syncRepository, ILogger<SyncWorker> workerLogger) : ISyncWorkerFactory
 {
     private readonly IReadOnlyList<IJobHandler> _handlers = handlers.ToList().AsReadOnly();
 
     /// <inheritdoc />
-    public ISyncWorker Create(int workerId) => new SyncWorker(workerId, _handlers, syncRepository);
+    public ISyncWorker Create(int workerId) => new SyncWorker(workerId, _handlers, syncRepository, workerLogger);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
@@ -2,12 +2,14 @@ using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem) : ISyncedItemRegistrar
+public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger) : ISyncedItemRegistrar
 {
     /// <inheritdoc />
     public async Task RegisterFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
@@ -21,7 +23,7 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
     /// <inheritdoc />
     public async Task RegisterPhantomAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
-        Serilog.Log.Debug("[SyncedItemRegistrar] File exists locally without SyncedItemEntity — treating as synced: {Path}", localPath);
+        OneDriveSyncClientMessages.SyncedItemLocalExists(logger, localPath);
         var phantomItem = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
         await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
         syncedItems[item.Id.Id] = phantomItem;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadJobHandler.cs
@@ -1,11 +1,13 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 /// <inheritdoc />
-public sealed class UploadJobHandler(IGraphService graphService) : IJobHandler
+public sealed class UploadJobHandler(IGraphService graphService, ILogger<UploadJobHandler> logger) : IJobHandler
 {
     /// <inheritdoc />
     public bool CanHandle(SyncJob job) => job is UploadSyncJob;
@@ -19,13 +21,13 @@ public sealed class UploadJobHandler(IGraphService graphService) : IJobHandler
         return uploadResult.Match<Result<SyncJob, string>>(
             itemId =>
             {
-                Serilog.Log.Information("Uploaded {Path}", uploadJob.Target.RelativePath);
+                OneDriveSyncClientMessages.UploadCompleted(logger, uploadJob.Target.RelativePath);
 
                 return new Result<SyncJob, string>.Ok(uploadJob with { UploadedRemoteItemId = itemId });
             },
             uploadError =>
             {
-                Serilog.Log.Error("Upload failed for {Path}: {Error}", uploadJob.Target.RelativePath, uploadError);
+                OneDriveSyncClientMessages.UploadFailed(logger, uploadJob.Target.RelativePath, uploadError);
 
                 return new Result<SyncJob, string>.Error(uploadError);
             });

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/UploadService.cs
@@ -3,6 +3,8 @@ using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.Drives.Item.Items.Item.CreateUploadSession;
 using Microsoft.Graph.Models;
@@ -20,12 +22,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 ///
 /// Chunk size: 10 MB (must be a multiple of 320 KB per Graph API requirement).
 /// </summary>
-public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSystem fileSystem) : IUploadService
+public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSystem fileSystem, ILogger<UploadService> logger) : IUploadService
 {
-    private const int    ChunkSize10Mb                   = 10 * 1024 * 1024;
-    private const int    MaxRetries                      = 5;
-    private const double BaseDelaySeconds                = 2.0;
-    private const double MaxDelaySeconds                 = 120.0;
+    private const int ChunkSize10Mb = 10 * 1024 * 1024;
+    private const int MaxRetries = 5;
+    private const double BaseDelaySeconds = 2.0;
+    private const double MaxDelaySeconds = 120.0;
     private const string UploadCompletedWithoutItemIdError = "Upload completed without receiving item ID from Graph API.";
 
     /// <summary>
@@ -35,17 +37,22 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
     public async Task<Result<string, string>> UploadAsync(GraphServiceClient client, DriveId driveId, string parentFolderId, string localPath, string remotePath, IProgress<long>? progress = null, CancellationToken ct = default)
     {
         var fileInfo = fileSystem.FileInfo.New(localPath);
-        if(!fileInfo.Exists)
+        if (!fileInfo.Exists)
             return new Result<string, string>.Error($"Local file not found: {localPath}");
 
-        Serilog.Log.Information("[UploadService] Starting upload: {Path} ({Size:F2} MB)", remotePath, fileInfo.Length / (1024.0 * 1024));
+        OneDriveSyncClientMessages.UploadServiceStarting(logger, remotePath, fileInfo.Length / (1024.0 * 1024));
 
         var sessionResult = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
 
         return await sessionResult.MatchAsync<Result<string, string>>(
             async sessionUrl =>
-                await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct)
-                    .TapAsync(_ => Serilog.Log.Information("[UploadService] Upload complete: {Path}", remotePath)),
+            {
+                var result = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
+                if (result is Result<string, string>.Ok)
+                    OneDriveSyncClientMessages.UploadServiceCompleted(logger, remotePath);
+
+                return result;
+            },
             error => new Result<string, string>.Error(error));
     }
 
@@ -79,7 +86,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             .CreateUploadSession
             .PostAsync(requestBody, cancellationToken: ct);
 
-        if(session?.UploadUrl is null)
+        if (session?.UploadUrl is null)
             return new Result<string, string>.Error("Graph API did not return an upload session URL.");
 
         return new Result<string, string>.Ok(session.UploadUrl);
@@ -95,14 +102,14 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         async Task<Result<string, string>> UploadNextChunkAsync(long uploaded)
         {
-            if(uploaded >= totalBytes)
+            if (uploaded >= totalBytes)
                 return new Result<string, string>.Error(UploadCompletedWithoutItemIdError);
 
             ct.ThrowIfCancellationRequested();
 
             int bytesRead = await ReadChunkAsync(file, buffer, totalBytes, uploaded, ct);
 
-            if(bytesRead == 0)
+            if (bytesRead == 0)
                 return new Result<string, string>.Error(UploadCompletedWithoutItemIdError);
 
             long rangeEnd = ComputeRangeEnd(uploaded, bytesRead);
@@ -113,7 +120,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                     long newUploaded = uploaded + bytesRead;
                     progress?.Report(newUploaded);
 
-                    if(itemId is not null)
+                    if (itemId is not null)
                         return new Result<string, string>.Ok(itemId);
 
                     return await UploadNextChunkAsync(newUploaded);
@@ -130,11 +137,11 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
     private static long ComputeRangeEnd(long uploaded, int bytesRead) => uploaded + bytesRead - 1;
 
-    private static async Task<Result<string?, string>> UploadChunkWithRetryAsync(HttpClient http, string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
+    private async Task<Result<string?, string>> UploadChunkWithRetryAsync(HttpClient http, string sessionUrl, ReadOnlyMemory<byte> chunk, long rangeStart, long rangeEnd, long totalBytes, CancellationToken ct)
     {
         int attempt = 0;
 
-        while(true)
+        while (true)
         {
             attempt++;
             ct.ThrowIfCancellationRequested();
@@ -148,32 +155,32 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
                 using var response = await http.PutAsync(sessionUrl, content, ct);
 
-                if(response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
-                    if(attempt > MaxRetries)
+                    if (attempt > MaxRetries)
                         return new Result<string?, string>.Error($"Upload rate limited after {MaxRetries} retries.");
 
                     var delay = GetRetryDelay(response, attempt);
-                    Serilog.Log.Warning("[UploadService] 429 on chunk {Start}-{End}, waiting {Delay:F1}s (attempt {A}/{Max})", rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
+                    OneDriveSyncClientMessages.UploadChunkThrottled(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
 
                     await Task.Delay(delay, ct);
                     continue;
                 }
 
-                if(response.StatusCode == System.Net.HttpStatusCode.Accepted)
+                if (response.StatusCode == System.Net.HttpStatusCode.Accepted)
                     return new Result<string?, string>.Ok(null);
 
-                if(response.StatusCode is System.Net.HttpStatusCode.Created or System.Net.HttpStatusCode.OK)
+                if (response.StatusCode is System.Net.HttpStatusCode.Created or System.Net.HttpStatusCode.OK)
                     return await GetUploadedDocumentId(response, ct);
 
                 _ = response.EnsureSuccessStatusCode();
 
                 return new Result<string?, string>.Ok(null);
             }
-            catch(HttpRequestException) when(attempt <= MaxRetries)
+            catch (HttpRequestException) when (attempt <= MaxRetries)
             {
                 var delay = GetBackoffDelay(attempt);
-                Serilog.Log.Warning("[UploadService] Network error on chunk {Start}-{End}, retrying in {Delay:F1}s (attempt {A}/{Max})", rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
+                OneDriveSyncClientMessages.UploadChunkNetworkError(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
 
                 await Task.Delay(delay, ct);
             }
@@ -185,10 +192,10 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
         string json = await response.Content.ReadAsStringAsync(ct);
         using var doc = System.Text.Json.JsonDocument.Parse(json);
 
-        if(!doc.RootElement.TryGetProperty("id", out var idElement))
+        if (!doc.RootElement.TryGetProperty("id", out var idElement))
             return new Result<string?, string>.Error("Upload response missing item ID.");
         string? itemId = idElement.GetString();
-        if(itemId is null)
+        if (itemId is null)
             return new Result<string?, string>.Error("Upload response missing item ID.");
 
         return new Result<string?, string>.Ok(itemId);
@@ -196,13 +203,13 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
     private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
     {
-        if(response.Headers.RetryAfter?.Delta is { } delta)
+        if (response.Headers.RetryAfter?.Delta is { } delta)
             return delta + TimeSpan.FromSeconds(1);
 
-        if(response.Headers.RetryAfter?.Date is { } date)
+        if (response.Headers.RetryAfter?.Date is { } date)
         {
             var wait = date - DateTimeOffset.UtcNow;
-            if(wait > TimeSpan.Zero)
+            if (wait > TimeSpan.Zero)
                 return wait + TimeSpan.FromSeconds(1);
         }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -7,8 +7,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Onboarding;
 
 public sealed partial class AddAccountWizardViewModel(IAuthService authService, IGraphService graphService) : ObservableObject, IDisposable
@@ -238,15 +236,9 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
 
     private void Finish()
     {
-        var account = new OneDriveAccount
-        {
-            Id = new AccountId(_accountId),
-            Profile = AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
-            SelectedFolderIds = [.. Folders.Where(f => f.IsSelected).Select(f => new OneDriveFolderId(f.Id))],
-            FolderNames = Folders
-                .Where(f => f.IsSelected)
-                .ToDictionary(f => new OneDriveFolderId(f.Id), f => f.Name)
-        };
+        var account = OneDriveAccountFactory.CreateFromWizardResult(
+            _accountId, AccountProfileFactory.Create(ConfirmedDisplayName, ConfirmedEmail),
+            Folders.Where(f => f.IsSelected));
         Completed?.Invoke(this, account);
     }
 


### PR DESCRIPTION
# Summary

Refactor logging in AStar.Dev.OneDrive.Sync.Client to use ILogger + LogMessage

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #315 

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

<!-- e.g., libs/MyLib, apps/MyApp, web/Api -->

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [ ] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.
