### PR TITLE
fix(apps/desktop): prevent repeated downloads of unchanged files (#316)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -2,6 +2,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveFolderId = AStar.Dev.OneDrive.Sync.Client.Domain.OneDriveFolderId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
@@ -49,5 +50,32 @@ public sealed class GivenASyncedItemEntityFactory
         var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
 
         entity.Tags.CTag.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_creating_from_download_job_with_etag_in_metadata_then_tags_etag_is_populated()
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("item-1"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "/file.txt");
+        var versionInfo = VersionInfoFactory.Create("etag-abc", null);
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1), versionInfo);
+        var job = SyncJobFactory.CreateDownload(remote, target, metadata);
+
+        var entity = SyncedItemEntityFactory.CreateFromDownloadJob(new AccountId("acc-1"), job, "/file.txt");
+
+        entity.Tags.ETag.ShouldBe("etag-abc");
+    }
+
+    [Fact]
+    public void when_creating_from_download_job_with_null_version_info_then_tags_etag_is_null()
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("item-1"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
+        var job = SyncJobFactory.CreateDownload(remote, target, metadata);
+
+        var entity = SyncedItemEntityFactory.CreateFromDownloadJob(new AccountId("acc-1"), job, "/file.txt");
+
+        entity.Tags.ETag.ShouldBeNull();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
@@ -179,6 +179,66 @@ public sealed class GivenADownloadJobBuilder
     }
 
     [Fact]
+    public async Task when_known_item_exists_with_matching_remote_timestamp_and_null_etag_and_local_file_exists_then_no_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var remoteModified = DateTimeOffset.UtcNow.AddDays(-1);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTimeUtc(localFile, remoteModified.UtcDateTime);
+
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
+            RemoteModifiedAt = remoteModified,
+            Tags = VersionInfoFactory.Create(null, null)
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_known_item_exists_and_remote_is_newer_than_stored_modified_and_null_etag_then_download_job_is_created()
+    {
+        const string localFile = $"{BasePath}/Documents/a.txt";
+        var storedRemoteModified = DateTimeOffset.UtcNow.AddDays(-2);
+        var newRemoteModified = DateTimeOffset.UtcNow.AddDays(-1);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(localFile).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTimeUtc(localFile, storedRemoteModified.UtcDateTime);
+
+        var knownItem = new SyncedItemEntity
+        {
+            AccountId = new AccountId("user-1"),
+            RemoteItemId = new OneDriveItemId("item-a"),
+            RemotePath = "/Documents/a.txt",
+            LocalPath = localFile,
+            RemoteModifiedAt = storedRemoteModified,
+            Tags = VersionInfoFactory.Create(null, null)
+        };
+        var syncedItems = new Dictionary<string, SyncedItemEntity> { ["item-a"] = knownItem };
+
+        var sut = CreateSut(mockFileSystem);
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: newRemoteModified) };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeOfType<DownloadSyncJob>();
+    }
+
+    [Fact]
     public async Task when_file_item_has_nested_path_then_download_job_local_path_starts_with_base_path()
     {
         var sut = CreateSut(new MockFileSystem());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
@@ -349,4 +349,17 @@ public sealed class GivenADownloadJobBuilder
 
         result.ShouldBeEmpty();
     }
+
+    [Fact]
+    public async Task when_download_job_is_created_then_metadata_version_info_is_populated_from_delta_item()
+    {
+        var sut = CreateSut(new MockFileSystem());
+        var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", etag: "etag-from-delta") };
+        var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
+
+        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+
+        result.ShouldHaveSingleItem();
+        result[0].Metadata.VersionInfo!.ETag.ShouldBe("etag-from-delta");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -45,7 +45,8 @@ public static class SyncedItemEntityFactory
             RemotePath       = remotePath,
             LocalPath        = job.Target.LocalPath,
             IsFolder         = false,
-            RemoteModifiedAt = job.Metadata.RemoteModified
+            RemoteModifiedAt = job.Metadata.RemoteModified,
+            Tags             = job.Metadata.VersionInfo ?? new VersionInfo(null, null)
         };
 
     /// <summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadata.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadata.cs
@@ -1,4 +1,6 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
 /// <summary>Remote file attributes captured at the time the sync job was queued.</summary>
-public sealed record SyncFileMetadata(long FileSize, DateTimeOffset RemoteModified);
+public sealed record SyncFileMetadata(long FileSize, DateTimeOffset RemoteModified, VersionInfo? VersionInfo = null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadataFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncFileMetadataFactory.cs
@@ -1,8 +1,10 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
 /// <summary>Factory for <see cref="SyncFileMetadata"/>.</summary>
 public static class SyncFileMetadataFactory
 {
     /// <summary>Creates a <see cref="SyncFileMetadata"/> from the given file attributes.</summary>
-    public static SyncFileMetadata Create(long fileSize, DateTimeOffset remoteModified) => new(fileSize, remoteModified);
+    public static SyncFileMetadata Create(long fileSize, DateTimeOffset remoteModified, VersionInfo? versionInfo = null) => new(fileSize, remoteModified, versionInfo);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
@@ -56,6 +56,10 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
 
             if (isConflict)
                 return await BuildConflictJobAsync(account, item, localPath, localModified, onConflict).ConfigureAwait(false);
+
+            bool remoteUnchanged = item.LastModified is null || item.LastModified <= knownItem.RemoteModifiedAt.AddSeconds(5);
+            if (remoteUnchanged)
+                return null;
         }
         else if (knownItem is null && fileSystem.File.Exists(localPath))
         {
@@ -86,7 +90,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
     {
         var remote = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
         var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
-        var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue);
+        var metadata = SyncFileMetadataFactory.Create(item.Size, item.LastModified ?? DateTimeOffset.MinValue, item.VersionInfo);
 
         return SyncJobFactory.CreateDownload(remote, target, metadata, item.DownloadUrl);
     }


### PR DESCRIPTION
## Summary

- `SyncedItemEntityFactory.CreateFromDownloadJob` now persists `VersionInfo` (ETag/CTag) into `Tags` after each successful download, so the ETag fast-path check works on the next sync pass
- `DownloadJobBuilder.ProcessFileItemAsync` now returns `null` when the remote timestamp is unchanged and there is no local conflict, providing a timestamp-based fallback when ETag is absent
- `SyncFileMetadata` and `SyncFileMetadataFactory` extended with optional `VersionInfo?` so the ETag flows through the job pipeline from delta item → download job → persisted entity

## Root causes (issue #316)

1. **ETag never stored**: `CreateFromDownloadJob` left `Tags` at its default `new VersionInfo(null, null)`, so `Tags.ETag` was always `null`. The ETag fast-path in `DownloadJobBuilder` always fell through.
2. **No "file is current" path**: after the conflict check, `ProcessFileItemAsync` fell through unconditionally to `BuildDownloadJob` — re-queuing a download even when the remote file was unchanged.

## Test plan

- [x] `GivenADownloadJobBuilder.when_known_item_exists_with_matching_remote_timestamp_and_null_etag_and_local_file_exists_then_no_job_is_created` — Bug 2 regression guard
- [x] `GivenADownloadJobBuilder.when_known_item_exists_with_newer_remote_timestamp_then_download_job_is_created` — remote changes still trigger a download
- [x] `GivenADownloadJobBuilder.when_download_job_is_created_then_metadata_version_info_is_populated_from_delta_item` — ETag propagation link
- [x] `GivenASyncedItemEntityFactory.when_creating_from_download_job_with_etag_in_metadata_then_tags_etag_is_populated` — Bug 1 regression guard
- [x] `GivenASyncedItemEntityFactory.when_creating_from_download_job_with_null_version_info_then_tags_etag_is_null` — null-safe path
- [x] All 903 previously-passing tests still pass

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)