### PR TITLE
fix(apps/desktop): use 'root' folder ID in upload jobs so Graph API path is valid (#321)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenALocalChangeDetector.cs
@@ -150,7 +150,7 @@ public sealed class GivenALocalChangeDetector
     }
 
     [Fact]
-    public void when_new_file_is_not_in_lookup_then_job_folder_id_is_empty()
+    public void when_new_file_is_not_in_lookup_then_job_folder_id_is_root()
     {
         var mockFileSystem = new MockFileSystem();
         mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
@@ -159,7 +159,28 @@ public sealed class GivenALocalChangeDetector
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
-        jobs[0].Remote.FolderId.Id.ShouldBe(string.Empty);
+        jobs[0].Remote.FolderId.Id.ShouldBe("root");
+    }
+
+    [Fact]
+    public void when_known_file_is_modified_then_job_folder_id_is_root()
+    {
+        const string filePath = $"{BasePath}/Documents/modified.txt";
+        var lastWrite = new DateTime(2025, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTime(filePath, lastWrite);
+        var staleRemoteModified = new DateTimeOffset(lastWrite, TimeSpan.Zero).AddSeconds(-10);
+        var lookup = new Dictionary<string, SyncedItemEntity>
+        {
+            [filePath] = new() { RemoteModifiedAt = staleRemoteModified, RemoteItemId = new OneDriveItemId("remote-id-folder-test") }
+        };
+        var sut = CreateSut(mockFileSystem);
+        var rules = new[] { Rule("/Documents", RuleType.Include) };
+
+        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
+
+        jobs[0].Remote.FolderId.Id.ShouldBe("root");
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/LocalChangeDetector.cs
@@ -61,7 +61,7 @@ public sealed class LocalChangeDetector(IFileSystem fileSystem, ILogger<LocalCha
 
                 string relativePathForUpload = remotePath.TrimStart('/');
 
-                var remote = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId(string.Empty), known?.RemoteItemId ?? new OneDriveItemId(string.Empty));
+                var remote = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId("root"), known?.RemoteItemId ?? new OneDriveItemId(string.Empty));
                 var target = SyncFileTargetFactory.Create(filePath, relativePathForUpload);
                 var metadata = SyncFileMetadataFactory.Create(info.Length, localModified);
 


### PR DESCRIPTION
## Summary

- `LocalChangeDetector` was setting `FolderId = string.Empty` on every upload job
- `UploadService` passed that to `Items[""]` in the Graph SDK, producing the invalid URL `/items/:/path:/createUploadSession`
- Every upload session POST failed silently — the job appeared in the activity log but the remote file was never written
- Fix: use `"root"` as the folder ID so the SDK generates `/items/root:/path:/createUploadSession`, a valid root-relative path upload endpoint

**Connection to #316**: This bug was latent but only became observable after #316 stopped re-downloading unchanged files. Previously, downloads always ran first and overwrote local modifications before the upload phase could act on them. After #316, local changes survive to be detected and queued — but the upload itself was failing due to the empty folder ID.

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test` — 913 tests pass
- [x] Two new/updated `GivenALocalChangeDetector` tests confirm that upload jobs always carry `FolderId = "root"` (both for new files and modified known files)
- [x] RED commit precedes GREEN commit per TDD workflow

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)