### PR TITLE
feat(apps/desktop): discriminated union FolderDeltaItem/FileDeltaItem/DeletedDeltaItem (#278)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -9,8 +9,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
 
 public sealed class GivenASyncedItemEntityFactory
 {
-    private static DeltaItem CreateDeltaItem(string? etag, string? ctag)
-        => DeltaItemFactory.Create(new OneDriveItemId("item-1"), new DriveId("drive-1"), null, ItemPathFactory.Create("file.txt", "/file.txt"), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, ctag));
+    private static FileDeltaItem CreateDeltaItem(string? etag, string? ctag)
+        => DeltaItemFactory.CreateFile(new OneDriveItemId("item-1"), new DriveId("drive-1"), null, ItemPathFactory.Create("file.txt", "/file.txt"), 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, ctag));
 
     [Fact]
     public void when_creating_from_delta_item_then_tags_etag_is_populated()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
@@ -8,26 +8,46 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
 public sealed class GivenADeltaItem
 {
     [Fact]
-    public void when_created_with_all_properties_then_they_are_preserved()
+    public void when_file_created_then_it_is_FileDeltaItem()
+    {
+        var item = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("file.txt"), 100L, DateTimeOffset.UtcNow, null, VersionInfoFactory.Create(null, null));
+
+        item.ShouldBeOfType<FileDeltaItem>();
+    }
+
+    [Fact]
+    public void when_folder_created_then_it_is_FolderDeltaItem()
+    {
+        var item = DeltaItemFactory.CreateFolder(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("Documents"), VersionInfoFactory.Create(null, null));
+
+        item.ShouldBeOfType<FolderDeltaItem>();
+    }
+
+    [Fact]
+    public void when_deleted_created_then_it_is_DeletedDeltaItem()
+    {
+        var item = DeltaItemFactory.CreateDeleted(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("gone.txt"));
+
+        item.ShouldBeOfType<DeletedDeltaItem>();
+    }
+
+    [Fact]
+    public void when_file_created_with_all_properties_then_they_are_preserved()
     {
         string id = "file-123";
         var driveId = new DriveId("drive-456");
         string name = "document.docx";
         string parentId = "folder-789";
-        bool isFolder = false;
-        bool isDeleted = false;
         long size = 2048L;
         var lastModified = DateTimeOffset.UtcNow.AddHours(-1);
         string downloadUrl = "https://graph.microsoft.com/v1.0/drives/abc/items/xyz/content";
         string relativePath = "Documents/document.docx";
 
-        var item = DeltaItemFactory.Create(
+        var item = DeltaItemFactory.CreateFile(
             new OneDriveItemId(id),
             driveId,
             new OneDriveFolderId(parentId),
             ItemPathFactory.Create(name, relativePath),
-            isFolder,
-            isDeleted,
             size,
             lastModified,
             downloadUrl,
@@ -37,8 +57,6 @@ public sealed class GivenADeltaItem
         item.DriveId.ShouldBe(driveId);
         item.Path.Name.ShouldBe(name);
         item.ParentId?.Id.ShouldBe(parentId);
-        item.IsFolder.ShouldBe(isFolder);
-        item.IsDeleted.ShouldBe(isDeleted);
         item.Size.ShouldBe(size);
         item.LastModified.ShouldBe(lastModified);
         item.DownloadUrl.ShouldBe(downloadUrl);
@@ -46,89 +64,88 @@ public sealed class GivenADeltaItem
     }
 
     [Fact]
-    public void when_created_without_relative_path_then_relative_path_is_null()
+    public void when_folder_created_with_all_properties_then_they_are_preserved()
     {
-        var item = DeltaItemFactory.Create(
-            new OneDriveItemId("file-123"),
-            new DriveId("drive-456"),
-            new OneDriveFolderId("folder-789"),
-            ItemPathFactory.Create("document.docx"),
-            false,
-            false,
-            2048,
-            DateTimeOffset.UtcNow,
-            "url",
-            VersionInfoFactory.Create(null, null));
+        string id = "folder-123";
+        var driveId = new DriveId("drive-456");
+        string name = "Documents";
+        string parentId = "root-id";
+
+        var item = DeltaItemFactory.CreateFolder(
+            new OneDriveItemId(id),
+            driveId,
+            new OneDriveFolderId(parentId),
+            ItemPathFactory.Create(name),
+            VersionInfoFactory.Create("etag-1", null));
+
+        item.Id.Id.ShouldBe(id);
+        item.DriveId.ShouldBe(driveId);
+        item.Path.Name.ShouldBe(name);
+        item.ParentId?.Id.ShouldBe(parentId);
+        item.VersionInfo.ETag.ShouldBe("etag-1");
+    }
+
+    [Fact]
+    public void when_file_created_without_relative_path_then_relative_path_is_null()
+    {
+        var item = DeltaItemFactory.CreateFile(new OneDriveItemId("file-123"), new DriveId("drive-456"), new OneDriveFolderId("folder-789"), ItemPathFactory.Create("document.docx"), 2048, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.Path.RelativePath.ShouldBeNull();
     }
 
     [Fact]
-    public void when_created_as_deleted_then_is_deleted_is_true()
+    public void when_file_size_is_zero_then_it_is_preserved()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("name"), false, true, 0, null, null, VersionInfoFactory.Create(null, null));
-
-        item.IsDeleted.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void when_created_as_folder_then_is_folder_is_true()
-    {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("Documents"), true, false, 0, null, null, VersionInfoFactory.Create(null, null));
-
-        item.IsFolder.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void when_created_as_file_then_is_folder_is_false()
-    {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("file.txt"), false, false, 1024, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
-
-        item.IsFolder.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void when_size_is_zero_then_it_is_preserved()
-    {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("empty.txt"), false, false, 0, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("empty.txt"), 0, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.Size.ShouldBe(0);
     }
 
     [Fact]
-    public void when_size_is_large_then_it_is_preserved()
+    public void when_file_size_is_large_then_it_is_preserved()
     {
         long largeSize = 1_099_511_627_776L;
 
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("large.iso"), false, false, largeSize, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("large.iso"), largeSize, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
 
         item.Size.ShouldBe(largeSize);
     }
 
     [Fact]
-    public void when_last_modified_is_null_then_it_is_null()
+    public void when_file_last_modified_is_null_then_it_is_null()
     {
-        var item = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 0, null, "url", VersionInfoFactory.Create(null, null));
+        var item = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), 0, null, "url", VersionInfoFactory.Create(null, null));
 
         item.LastModified.ShouldBeNull();
     }
 
     [Fact]
-    public void when_two_instances_have_same_values_then_they_are_equal()
+    public void when_two_file_instances_have_same_values_then_they_are_equal()
     {
-        var item1 = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
-        var item2 = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, item1.LastModified, "url", VersionInfoFactory.Create(null, null));
+        var item1 = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), 100, DateTimeOffset.UtcNow, "url", VersionInfoFactory.Create(null, null));
+        var item2 = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), 100, item1.LastModified, "url", VersionInfoFactory.Create(null, null));
 
         item1.ShouldBe(item2);
     }
 
     [Fact]
-    public void when_deleted_flag_differs_then_instances_are_not_equal()
+    public void when_file_and_folder_have_same_base_properties_then_they_are_not_equal()
     {
-        var timestamp = DateTimeOffset.UtcNow;
-        var active = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, false, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
-        var deleted = DeltaItemFactory.Create(new OneDriveItemId("id"), new DriveId("drive"), new OneDriveFolderId("parent"), ItemPathFactory.Create("name"), false, true, 100, timestamp, "url", VersionInfoFactory.Create(null, null));
+        var fileItem = DeltaItemFactory.CreateFile(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("name"), 0, null, null, VersionInfoFactory.Create(null, null));
+        var folderItem = DeltaItemFactory.CreateFolder(new OneDriveItemId("id"), new DriveId("drive"), null, ItemPathFactory.Create("name"), VersionInfoFactory.Create(null, null));
 
-        active.ShouldNotBe(deleted);
+        ((DeltaItem)fileItem).ShouldNotBe((DeltaItem)folderItem);
+    }
+
+    [Fact]
+    public void when_deleted_item_created_then_properties_are_preserved()
+    {
+        var id = new OneDriveItemId("deleted-1");
+        var driveId = new DriveId("drive-1");
+
+        var item = DeltaItemFactory.CreateDeleted(id, driveId, null, ItemPathFactory.Create("gone.txt"));
+
+        item.Id.ShouldBe(id);
+        item.DriveId.ShouldBe(driveId);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -236,7 +236,7 @@ public sealed class GivenAGraphService : IDisposable
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(3);
         items.ShouldContain(i => i.Id.Id == "file-root");
-        items.ShouldContain(i => i.Id.Id == "subfolder-001" && i.IsFolder);
+        items.ShouldContain(i => i.Id.Id == "subfolder-001" && i is FolderDeltaItem);
         items.ShouldContain(i => i.Id.Id == "file-sub");
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenADownloadJobBuilder.cs
@@ -29,11 +29,11 @@ public sealed class GivenADownloadJobBuilder
     private static SyncRuleEntity IncludeRule(string remotePath)
         => new() { RemotePath = remotePath, RuleType = RuleType.Include };
 
-    private static DeltaItem FileItem(string id, string relativePath, string? etag = null, DateTimeOffset? lastModified = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), false, false, 100L, lastModified ?? DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
+    private static FileDeltaItem FileItem(string id, string relativePath, string? etag = null, DateTimeOffset? lastModified = null)
+        => DeltaItemFactory.CreateFile(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), 100L, lastModified ?? DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(etag, null));
 
-    private static DeltaItem FolderItem(string id, string relativePath)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+    private static FolderDeltaItem FolderItem(string id, string relativePath)
+        => DeltaItemFactory.CreateFolder(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, relativePath), VersionInfoFactory.Create(null, null));
 
     [Fact]
     public async Task when_item_path_is_not_included_by_rules_then_no_job_is_created()
@@ -56,7 +56,7 @@ public sealed class GivenADownloadJobBuilder
 
         await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
-        await _syncedItemRegistrar.Received(1).RegisterFolderAsync(Arg.Any<AccountId>(), Arg.Is<DeltaItem>(i => i.Id.Id == "subfolder-1"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
+        await _syncedItemRegistrar.Received(1).RegisterFolderAsync(Arg.Any<AccountId>(), Arg.Is<FolderDeltaItem>(i => i.Id.Id == "subfolder-1"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public sealed class GivenADownloadJobBuilder
 
         await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
-        await _syncedItemRegistrar.Received(1).RegisterPhantomAsync(Arg.Any<AccountId>(), Arg.Is<DeltaItem>(i => i.Id.Id == "item-phantom"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
+        await _syncedItemRegistrar.Received(1).RegisterPhantomAsync(Arg.Any<AccountId>(), Arg.Is<FileDeltaItem>(i => i.Id.Id == "item-phantom"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenARemoteFolderEnumerator.cs
@@ -39,8 +39,8 @@ public sealed class GivenARemoteFolderEnumerator
     private static SyncRuleEntity IncludeRule(string remotePath, string? remoteItemId = null)
         => new() { RemotePath = remotePath, RuleType = RuleType.Include, RemoteItemId = remoteItemId };
 
-    private static DeltaItem FileItem(string id, string name, string? relativePath = null)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
+    private static FileDeltaItem FileItem(string id, string name, string? relativePath = null)
+        => DeltaItemFactory.CreateFile(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(name, relativePath ?? name), 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
 
     [Fact]
     public async Task when_no_rules_configured_then_result_has_no_rules_flag_set()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncedItemRegistrar.cs
@@ -21,11 +21,11 @@ public sealed class GivenASyncedItemRegistrar
 
     private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
 
-    private static DeltaItem FolderItem(string id, string remotePath)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), true, false, 0L, null, null, VersionInfoFactory.Create(null, null));
+    private static FolderDeltaItem FolderItem(string id, string remotePath)
+        => DeltaItemFactory.CreateFolder(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), VersionInfoFactory.Create(null, null));
 
-    private static DeltaItem FileItem(string id, string remotePath)
-        => DeltaItemFactory.Create(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), false, false, 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
+    private static FileDeltaItem FileItem(string id, string remotePath)
+        => DeltaItemFactory.CreateFile(new OneDriveItemId(id), new DriveId("drive-1"), null, ItemPathFactory.Create(id, remotePath), 100L, DateTimeOffset.UtcNow.AddDays(-1), null, VersionInfoFactory.Create(null, null));
 
     [Fact]
     public async Task when_register_folder_called_then_directory_is_created()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -4,7 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 
 /// <summary>
-/// Factory class for creating instances of <see cref="SyncedItemEntity"/> from various sources such as remote delta items and synchronization jobs. This class centralizes the logic for constructing SyncedItemEntity objects, ensuring consistency and maintainability in how synchronized items are represented within the sync client application. By providing specific factory methods for different scenarios, we can simplify the creation process and reduce duplication of code across the application when dealing with synchronized items.
+/// Factory class for creating instances of <see cref="SyncedItemEntity"/> from various sources such as remote delta items and synchronization jobs.
 /// </summary>
 public static class SyncedItemEntityFactory
 {
@@ -16,17 +16,38 @@ public static class SyncedItemEntityFactory
     /// <param name="remotePath">The remote path of the item in OneDrive.</param>
     /// <param name="localPath">The local path of the item on the user's file system.</param>
     /// <returns>A new instance of <see cref="SyncedItemEntity"/>.</returns>
-    public static SyncedItemEntity Create(AccountId accountId, DeltaItem item, string remotePath, string localPath)
+    public static SyncedItemEntity Create(AccountId accountId, FileDeltaItem item, string remotePath, string localPath)
         => new()
         {
-            AccountId        = accountId,
-            RemoteItemId     = item.Id,
-            RemoteParentId   = item.ParentId?.Id ?? string.Empty,
-            RemotePath       = remotePath,
-            LocalPath        = localPath,
-            IsFolder         = item.IsFolder,
+            AccountId = accountId,
+            RemoteItemId = item.Id,
+            RemoteParentId = item.ParentId?.Id ?? string.Empty,
+            RemotePath = remotePath,
+            LocalPath = localPath,
+            IsFolder = false,
             RemoteModifiedAt = item.LastModified ?? DateTimeOffset.MinValue,
-            Tags             = item.VersionInfo
+            Tags = item.VersionInfo
+        };
+
+    /// <summary>
+    /// Creates a new instance of <see cref="SyncedItemEntity"/> based on the provided account ID, delta item representing a folder from the OneDrive API, and the corresponding remote and local paths. This method extracts relevant information from the folder delta item, such as the item ID, parent ID, and version info, to populate the properties of the SyncedItemEntity. The resulting entity can then be used to track the synchronization state of the folder within the sync client application, allowing for efficient updates and conflict resolution as needed. Note that since folders do not have a modification timestamp in the same way files do, the RemoteModifiedAt property is set to DateTimeOffset.MinValue for folder items.
+    /// </summary>
+    /// <param name="accountId">The ID of the account to which the item belongs.</param>
+    /// <param name="item">The delta item representing a folder from the OneDrive API.</param>
+    /// <param name="remotePath">The remote path of the folder in OneDrive.</param>
+    /// <param name="localPath">The local path of the folder on the user's file system.</param>
+    /// <returns>A new instance of <see cref="SyncedItemEntity"/>.</returns>
+    public static SyncedItemEntity Create(AccountId accountId, FolderDeltaItem item, string remotePath, string localPath)
+        => new()
+        {
+            AccountId = accountId,
+            RemoteItemId = item.Id,
+            RemoteParentId = item.ParentId?.Id ?? string.Empty,
+            RemotePath = remotePath,
+            LocalPath = localPath,
+            IsFolder = true,
+            RemoteModifiedAt = DateTimeOffset.MinValue,
+            Tags = item.VersionInfo
         };
 
     /// <summary>
@@ -39,14 +60,14 @@ public static class SyncedItemEntityFactory
     public static SyncedItemEntity CreateFromDownloadJob(AccountId accountId, SyncJob job, string remotePath)
         => new()
         {
-            AccountId        = accountId,
-            RemoteItemId     = job.Remote.RemoteItemId,
-            RemoteParentId   = string.Empty,
-            RemotePath       = remotePath,
-            LocalPath        = job.Target.LocalPath,
-            IsFolder         = false,
+            AccountId = accountId,
+            RemoteItemId = job.Remote.RemoteItemId,
+            RemoteParentId = string.Empty,
+            RemotePath = remotePath,
+            LocalPath = job.Target.LocalPath,
+            IsFolder = false,
             RemoteModifiedAt = job.Metadata.RemoteModified,
-            Tags             = job.Metadata.VersionInfo ?? new VersionInfo(null, null)
+            Tags = job.Metadata.VersionInfo ?? new VersionInfo(null, null)
         };
 
     /// <summary>
@@ -60,12 +81,12 @@ public static class SyncedItemEntityFactory
     public static SyncedItemEntity CreateFromUploadJob(AccountId accountId, UploadSyncJob job, string remotePath, IFileSystem fileSystem)
         => new()
         {
-            AccountId        = accountId,
-            RemoteItemId     = new OneDriveItemId(job.UploadedRemoteItemId!),
-            RemoteParentId   = string.Empty,
-            RemotePath       = remotePath,
-            LocalPath        = job.Target.LocalPath,
-            IsFolder         = false,
+            AccountId = accountId,
+            RemoteItemId = new OneDriveItemId(job.UploadedRemoteItemId!),
+            RemoteParentId = string.Empty,
+            RemotePath = remotePath,
+            LocalPath = job.Target.LocalPath,
+            IsFolder = false,
             RemoteModifiedAt = new DateTimeOffset(fileSystem.FileInfo.New(job.Target.LocalPath).LastWriteTimeUtc, TimeSpan.Zero)
         };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItem.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItem.cs
@@ -4,5 +4,14 @@ using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItem
 
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
-/// <summary>Represents a single item returned by the Microsoft Graph delta API.</summary>
-public sealed record DeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path, bool IsFolder, bool IsDeleted, long Size, DateTimeOffset? LastModified, string? DownloadUrl, VersionInfo VersionInfo);
+/// <summary>Represents a single item returned from the Microsoft Graph drive API.</summary>
+public abstract record DeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path);
+
+/// <summary>Represents a file item returned from the Microsoft Graph drive API.</summary>
+public sealed record FileDeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path, long Size, DateTimeOffset? LastModified, string? DownloadUrl, VersionInfo VersionInfo) : DeltaItem(Id, DriveId, ParentId, Path);
+
+/// <summary>Represents a folder item returned from the Microsoft Graph drive API.</summary>
+public sealed record FolderDeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path, VersionInfo VersionInfo) : DeltaItem(Id, DriveId, ParentId, Path);
+
+/// <summary>Represents an item that has been deleted remotely, as reported by the Microsoft Graph delta API.</summary>
+public sealed record DeletedDeltaItem(OneDriveItemId Id, DriveId DriveId, OneDriveFolderId? ParentId, ItemPath Path) : DeltaItem(Id, DriveId, ParentId, Path);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItemFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/DeltaItemFactory.cs
@@ -4,9 +4,15 @@ using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItem
 
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
-/// <summary>Factory for <see cref="DeltaItem"/>.</summary>
+/// <summary>Factory for <see cref="DeltaItem"/> and its derived types.</summary>
 public static class DeltaItemFactory
 {
-    /// <summary>Creates a <see cref="DeltaItem"/> representing a remote drive item.</summary>
-    public static DeltaItem Create(OneDriveItemId id, DriveId driveId, OneDriveFolderId? parentId, ItemPath path, bool isFolder, bool isDeleted, long size, DateTimeOffset? lastModified, string? downloadUrl, VersionInfo versionInfo) => new(id, driveId, parentId, path, isFolder, isDeleted, size, lastModified, downloadUrl, versionInfo);
+    /// <summary>Creates a <see cref="FileDeltaItem"/>.</summary>
+    public static FileDeltaItem CreateFile(OneDriveItemId id, DriveId driveId, OneDriveFolderId? parentId, ItemPath path, long size, DateTimeOffset? lastModified, string? downloadUrl, VersionInfo versionInfo) => new(id, driveId, parentId, path, size, lastModified, downloadUrl, versionInfo);
+
+    /// <summary>Creates a <see cref="FolderDeltaItem"/>.</summary>
+    public static FolderDeltaItem CreateFolder(OneDriveItemId id, DriveId driveId, OneDriveFolderId? parentId, ItemPath path, VersionInfo versionInfo) => new(id, driveId, parentId, path, versionInfo);
+
+    /// <summary>Creates a <see cref="DeletedDeltaItem"/>.</summary>
+    public static DeletedDeltaItem CreateDeleted(OneDriveItemId id, DriveId driveId, OneDriveFolderId? parentId, ItemPath path) => new(id, driveId, parentId, path);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -231,17 +231,19 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                         ? item.Name ?? string.Empty
                         : $"{relativePath}/{item.Name}";
 
-    private static DeltaItem MapToDeltaItem(DriveItem item, string itemPath) => DeltaItemFactory.Create(
-        new OneDriveItemId(item.Id!),
-        new DriveId(item.ParentReference?.DriveId ?? string.Empty),
-        item.ParentReference?.Id is string pid ? new OneDriveFolderId(pid) : null,
-        ItemPathFactory.Create(item.Name ?? string.Empty, itemPath),
-        isFolder: item.Folder is not null,
-        isDeleted: false,
-        item.Size ?? 0L,
-        item.LastModifiedDateTime,
-        ExtractDownloadUrl(item),
-        VersionInfoFactory.Create(item.ETag, item.CTag));
+    private static DeltaItem MapToDeltaItem(DriveItem item, string itemPath)
+    {
+        var id = new OneDriveItemId(item.Id!);
+        var driveId = new DriveId(item.ParentReference?.DriveId ?? string.Empty);
+        OneDriveFolderId? parentId = item.ParentReference?.Id is string pid ? new OneDriveFolderId(pid) : null;
+        var path = ItemPathFactory.Create(item.Name ?? string.Empty, itemPath);
+        var versionInfo = VersionInfoFactory.Create(item.ETag, item.CTag);
+
+        if (item.Folder is not null)
+            return DeltaItemFactory.CreateFolder(id, driveId, parentId, path, versionInfo);
+
+        return DeltaItemFactory.CreateFile(id, driveId, parentId, path, item.Size ?? 0L, item.LastModifiedDateTime, ExtractDownloadUrl(item), versionInfo);
+    }
 
     private static string? ExtractDownloadUrl(DriveItem item)
         => item.AdditionalData?.TryGetValue(DownloadUrlKey, out object? url) is true

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/DownloadJobBuilder.cs
@@ -23,14 +23,17 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
             if (!SyncRuleEvaluator.IsIncluded(item.Path.EffectivePath, rules))
                 continue;
 
-            if (item.IsFolder)
+            if (item is FolderDeltaItem folderItem)
             {
-                string folderLocalPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
-                await syncedItemRegistrar.RegisterFolderAsync(account.Id, item, item.Path.EffectivePath, folderLocalPath, syncedItems, ct).ConfigureAwait(false);
+                string folderLocalPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, folderItem.Path.EffectivePath.TrimStart('/'));
+                await syncedItemRegistrar.RegisterFolderAsync(account.Id, folderItem, folderItem.Path.EffectivePath, folderLocalPath, syncedItems, ct).ConfigureAwait(false);
                 continue;
             }
 
-            var job = await ProcessFileItemAsync(account, item, syncedItems, onConflict, ct).ConfigureAwait(false);
+            if (item is not FileDeltaItem fileItem)
+                continue;
+
+            var job = await ProcessFileItemAsync(account, fileItem, syncedItems, onConflict, ct).ConfigureAwait(false);
             if (job is not null)
                 jobs.Add(job);
         }
@@ -38,7 +41,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return jobs;
     }
 
-    private async Task<SyncJob?> ProcessFileItemAsync(OneDriveAccount account, DeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    private async Task<SyncJob?> ProcessFileItemAsync(OneDriveAccount account, FileDeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
     {
         string localPath = BuildLocalPath(account.SyncConfig!.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
         syncedItems.TryGetValue(item.Id.Id, out var knownItem);
@@ -70,7 +73,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return BuildDownloadJob(account.Id, item, localPath);
     }
 
-    private async Task<SyncJob?> BuildConflictJobAsync(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified, Func<SyncConflict, Task> onConflict)
+    private async Task<SyncJob?> BuildConflictJobAsync(OneDriveAccount account, FileDeltaItem item, string localPath, DateTimeOffset localModified, Func<SyncConflict, Task> onConflict)
     {
         var conflict = BuildConflict(account, item, localPath, localModified);
         await onConflict(conflict).ConfigureAwait(false);
@@ -86,7 +89,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         };
     }
 
-    private static DownloadSyncJob BuildDownloadJob(AccountId accountId, DeltaItem item, string localPath)
+    private static DownloadSyncJob BuildDownloadJob(AccountId accountId, FileDeltaItem item, string localPath)
     {
         var remote = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
         var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
@@ -95,7 +98,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return SyncJobFactory.CreateDownload(remote, target, metadata, item.DownloadUrl);
     }
 
-    private UploadSyncJob BuildUploadJob(AccountId accountId, DeltaItem item, string localPath, DateTimeOffset localModified)
+    private UploadSyncJob BuildUploadJob(AccountId accountId, FileDeltaItem item, string localPath, DateTimeOffset localModified)
     {
         var remote = RemoteItemRefFactory.Create(accountId, new OneDriveFolderId(string.Empty), item.Id);
         var target = SyncFileTargetFactory.Create(localPath, item.Path.EffectivePath);
@@ -104,7 +107,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return SyncJobFactory.CreateUpload(remote, target, metadata);
     }
 
-    private DownloadSyncJob BuildKeepBothJob(AccountId accountId, DeltaItem item, string localPath, DateTimeOffset localModified)
+    private DownloadSyncJob BuildKeepBothJob(AccountId accountId, FileDeltaItem item, string localPath, DateTimeOffset localModified)
     {
         string newName = ConflictResolver.MakeKeepBothName(localPath, localModified, fileSystem);
         fileSystem.File.Move(localPath, newName);
@@ -112,7 +115,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return BuildDownloadJob(accountId, item, localPath);
     }
 
-    private SyncConflict BuildConflict(OneDriveAccount account, DeltaItem item, string localPath, DateTimeOffset localModified)
+    private SyncConflict BuildConflict(OneDriveAccount account, FileDeltaItem item, string localPath, DateTimeOffset localModified)
         => new()
         {
             Remote = RemoteItemRefFactory.Create(account.Id, new OneDriveFolderId(string.Empty), item.Id),

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncedItemRegistrar.cs
@@ -10,8 +10,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 public interface ISyncedItemRegistrar
 {
     /// <summary>Creates the local directory and upserts the folder tracking entity.</summary>
-    Task RegisterFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+    Task RegisterFolderAsync(AccountId accountId, FolderDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
 
     /// <summary>Registers a phantom file — exists locally with no tracking record — as already synced.</summary>
-    Task RegisterPhantomAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+    Task RegisterPhantomAsync(AccountId accountId, FileDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncedItemRegistrar.cs
@@ -12,7 +12,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger) : ISyncedItemRegistrar
 {
     /// <inheritdoc />
-    public async Task RegisterFolderAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    public async Task RegisterFolderAsync(AccountId accountId, FolderDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
         _ = fileSystem.Directory.CreateDirectory(localPath);
         var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
@@ -21,7 +21,7 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
     }
 
     /// <inheritdoc />
-    public async Task RegisterPhantomAsync(AccountId accountId, DeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    public async Task RegisterPhantomAsync(AccountId accountId, FileDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
         OneDriveSyncClientMessages.SyncedItemLocalExists(logger, localPath);
         var phantomItem = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);


### PR DESCRIPTION
## Summary

- Replaces `IsFolder`/`IsDeleted` bool flags on `DeltaItem` with a discriminated union: `FileDeltaItem`, `FolderDeltaItem`, `DeletedDeltaItem`
- All consumers updated to use pattern matching (`is FolderDeltaItem`, `is not FileDeltaItem`) instead of boolean checks
- `ISyncedItemRegistrar` methods now accept the specific subtype (`FolderDeltaItem`/`FileDeltaItem`), enforcing correctness at compile time
- `SyncedItemEntityFactory.Create` split into typed overloads — `IsFolder` is now a literal `true`/`false`, not read from a flag
- `DeletedDeltaItem` carries only base properties — a deleted item cannot accidentally have `Size`, `DownloadUrl`, or `VersionInfo`

## Test plan

- [x] RED commit: tests updated to reference new types before production code existed
- [x] GREEN: `dotnet test` — 914 pass, 0 new failures (1 pre-existing `GivenAnHttpDownloader` failure unrelated to this change)
- [x] `dotnet build` — zero errors, zero warnings

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)