### PR TITLE
feat(apps/desktop): per-account sync cancellation (#325)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
@@ -1,0 +1,30 @@
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenADashboardAccountViewModel
+{
+    private static DashboardAccountViewModel CreateSut(ISyncScheduler scheduler)
+        => new(
+            new OneDriveAccount { Id = new AccountId("test-account") },
+            scheduler,
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ILocalizationService>());
+
+    [Fact]
+    public async Task when_cancel_sync_command_invoked_then_scheduler_cancel_account_called_with_correct_id()
+    {
+        var mockScheduler = Substitute.For<ISyncScheduler>();
+        var sut = CreateSut(mockScheduler);
+
+        await ((IAsyncRelayCommand)sut.CancelSyncCommand).ExecuteAsync(null);
+
+        await mockScheduler.Received(1).CancelAccountAsync("test-account");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
@@ -25,6 +25,6 @@ public sealed class GivenADashboardAccountViewModel
 
         await ((IAsyncRelayCommand)sut.CancelSyncCommand).ExecuteAsync(null);
 
-        await mockScheduler.Received(1).CancelAccountAsync("test-account");
+        await mockScheduler.Received(1).CancelAccountSyncAsync("test-account");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -415,6 +415,39 @@ public sealed class GivenASyncScheduler
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task when_cancel_account_called_for_unknown_account_then_no_exception_thrown()
+    {
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
+
+        await Should.NotThrowAsync(() => scheduler.CancelAccountAsync("non-existent-account"));
+    }
+
+    [Fact]
+    public async Task when_cancel_account_called_for_active_sync_then_token_passed_to_sync_service_is_cancelled()
+    {
+        CancellationToken capturedToken = default;
+        var syncStarted = new TaskCompletionSource();
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                capturedToken = callInfo.ArgAt<CancellationToken>(1);
+                syncStarted.SetResult();
+                await Task.Delay(Timeout.Infinite, capturedToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            });
+
+        var scheduler = CreateScheduler(mockSyncService, Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
+        var account = new OneDriveAccount { Id = new AccountId("cancel-test") };
+
+        var triggerTask = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+        await syncStarted.Task;
+        await scheduler.CancelAccountAsync("cancel-test");
+        await triggerTask;
+
+        capturedToken.IsCancellationRequested.ShouldBeTrue();
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -252,8 +252,8 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id         = new AccountId(accountIdStr),
-            Profile    = AccountProfileFactory.Create("Test User", "test@outlook.com"),
+            Id = new AccountId(accountIdStr),
+            Profile = AccountProfileFactory.Create("Test User", "test@outlook.com"),
             SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/some/path")),
         }));
         var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
@@ -320,12 +320,12 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id           = new AccountId(accountIdStr),
-            Profile      = AccountProfileFactory.Create("Map Test User", "maptest@outlook.com"),
-            AccentIndex  = 3,
-            IsActive     = true,
+            Id = new AccountId(accountIdStr),
+            Profile = AccountProfileFactory.Create("Map Test User", "maptest@outlook.com"),
+            AccentIndex = 3,
+            IsActive = true,
             LastSyncedAt = lastSyncedAt,
-            SyncConfig   = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/sync/path")),
+            SyncConfig = AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore("/sync/path")),
         }));
         var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
 
@@ -351,8 +351,8 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id         = new AccountId(accountIdStr),
-            Profile    = AccountProfileFactory.Create("No Path User", "nopath@outlook.com"),
+            Id = new AccountId(accountIdStr),
+            Profile = AccountProfileFactory.Create("No Path User", "nopath@outlook.com"),
             SyncConfig = AccountSyncConfigFactory.Default,
         }));
         var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
@@ -372,7 +372,7 @@ public sealed class GivenASyncScheduler
         var mockRepository = Substitute.For<IAccountRepository>();
         _ = mockRepository.GetByIdAsync(new AccountId(accountIdStr), Arg.Any<CancellationToken>()).Returns(Option.Some(new AccountEntity
         {
-            Id      = new AccountId(accountIdStr),
+            Id = new AccountId(accountIdStr),
             Profile = AccountProfileFactory.Create("Rules User", "rules@outlook.com"),
         }));
         var rulesRepo = Substitute.For<ISyncRuleRepository>();
@@ -420,7 +420,7 @@ public sealed class GivenASyncScheduler
     {
         var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
 
-        await Should.NotThrowAsync(() => scheduler.CancelAccountAsync("non-existent-account"));
+        await Should.NotThrowAsync(() => scheduler.CancelAccountSyncAsync("non-existent-account"));
     }
 
     [Fact]
@@ -442,7 +442,7 @@ public sealed class GivenASyncScheduler
 
         var triggerTask = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
         await syncStarted.Task;
-        await scheduler.CancelAccountAsync("cancel-test");
+        await scheduler.CancelAccountSyncAsync("cancel-test");
         await triggerTask;
 
         capturedToken.IsCancellationRequested.ShouldBeTrue();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Dashboard;
 public sealed partial class DashboardAccountViewModel : ObservableObject
 {
     private readonly OneDriveAccount _account;
-    private readonly ISyncScheduler   _scheduler;
+    private readonly ISyncScheduler _scheduler;
 
     /// <summary>Raw string account ID — unwrapped at the display boundary.</summary>
     public string AccountId => _account.Id.Id;
@@ -85,6 +85,9 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     private void ToggleExpand() => IsExpanded = !IsExpanded;
 
     [RelayCommand]
+    private Task CancelSyncAsync() => _scheduler.CancelAccountSyncAsync(_account.Id.Id);
+
+    [RelayCommand]
     private async Task SyncNowAsync()
     {
         AddRecentActivity(new ActivityItemViewModel { FileName = _localizationService.GetLocal("Sync.Starting") });
@@ -94,9 +97,9 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
             {
                 var fullAccount = new OneDriveAccount
                 {
-                    Id           = entity.Id,
-                    Profile      = entity.Profile,
-                    SyncConfig   = entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? Option.Some(entity.SyncConfig) : Option.None<AccountSyncConfig>(),
+                    Id = entity.Id,
+                    Profile = entity.Profile,
+                    SyncConfig = entity.SyncConfig.LocalSyncPath.Value.Length > 0 ? Option.Some(entity.SyncConfig) : Option.None<AccountSyncConfig>(),
                     LastSyncedAt = entity.LastSyncedAt
                 };
                 await _scheduler.TriggerAccountAsync(fullAccount);
@@ -109,7 +112,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
         ConflictCount = conflicts;
         IsSyncing = state == SyncState.Syncing;
 
-        if(state is not (SyncState.Idle or SyncState.Completed)) return;
+        if (state is not (SyncState.Idle or SyncState.Completed)) return;
 
         _account.LastSyncedAt = Option.Some(DateTimeOffset.UtcNow);
         UpdateLastSyncText(state);
@@ -118,7 +121,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public void AddRecentActivity(ActivityItemViewModel item)
     {
         RecentActivity.Insert(0, item);
-        while(RecentActivity.Count > 3)
+        while (RecentActivity.Count > 3)
             RecentActivity.RemoveAt(RecentActivity.Count - 1);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardView.axaml
@@ -180,7 +180,7 @@
                                             </TextBlock>
                                         </Border>
 
-                                        <!-- Sync now + expand -->
+                                        <!-- Sync now + cancel + expand -->
                                         <StackPanel Grid.Column="4"
                                                     Orientation="Horizontal"
                                                     Spacing="6">
@@ -193,6 +193,16 @@
                                                     FontSize="{StaticResource FontSizeXs}"
                                                     IsEnabled="{Binding !IsSyncing}"
                                                     Command="{Binding SyncNowCommand}"/>
+
+                                            <Button Content="Cancel"
+                                                    Padding="10,4"
+                                                    CornerRadius="{StaticResource RadiusSm}"
+                                                    Background="Transparent"
+                                                    BorderBrush="{DynamicResource BorderDefaultBrush}"
+                                                    BorderThickness="1"
+                                                    FontSize="{StaticResource FontSizeXs}"
+                                                    IsVisible="{Binding IsSyncing}"
+                                                    Command="{Binding CancelSyncCommand}"/>
 
                                             <Button Padding="6,4"
                                                     Background="Transparent"

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -69,6 +69,10 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 2203, Level = LogLevel.Warning, Message = "[SyncScheduler] TriggerAccountAsync called for unknown account {AccountId}")]
     public static partial void SyncSchedulerUnknownAccount(ILogger logger, string accountId);
 
+    /// <summary>Logs sync cancellation requested for an account.</summary>
+    [LoggerMessage(EventId = 2204, Level = LogLevel.Information, Message = "[SyncScheduler] Sync cancellation requested for {AccountId}")]
+    public static partial void SyncSchedulerCancelled(ILogger logger, string accountId);
+
     // Local Change Detection (2300-2399)
 
     /// <summary>Logs new/modified local files found.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
@@ -2,7 +2,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
-public interface                                                                                                            ISyncScheduler
+public interface ISyncScheduler
 {
     /// <summary>
     /// Runs scheduled sync passes for all connected accounts.
@@ -45,6 +45,12 @@ public interface                                                                
     /// Triggers an immediate sync for a single account.
     /// </summary>
     Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cancels any in-progress sync for the specified account. No-op if no sync is currently running for that account.
+    /// </summary>
+    /// <param name="accountId">The raw string account ID to cancel.</param>
+    Task CancelAccountSyncAsync(string accountId);
 
     /// <summary>
     /// Performs any necessary cleanup when the scheduler is no longer needed, such as disposing of timers or other resources. After disposal, the scheduler should not be used to trigger syncs or raise events.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -16,6 +17,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 /// </summary>
 public sealed class SyncScheduler(ISyncService syncService, IAccountRepository accountRepository, ISyncRuleRepository syncRuleRepository, ILogger<SyncScheduler> logger) : IAsyncDisposable, ISyncScheduler
 {
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _activeSyncs = new();
     private Timer? _timer;
     private TimeSpan _interval = TimeSpan.FromMinutes(60);
     private long _runningFlag;
@@ -87,15 +89,30 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     /// <inheritdoc />
     public async Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _activeSyncs.TryAdd(account.Id.Id, cts);
         SyncStarted?.Invoke(this, account.Id.Id);
         try
         {
-            await syncService.SyncAccountAsync(account, ct);
+            await syncService.SyncAccountAsync(account, cts.Token);
         }
         finally
         {
+            _activeSyncs.TryRemove(account.Id.Id, out _);
             SyncCompleted?.Invoke(this, account.Id.Id);
         }
+    }
+
+    /// <inheritdoc />
+    public Task CancelAccountSyncAsync(string accountId)
+    {
+        if (_activeSyncs.TryGetValue(accountId, out var cts))
+        {
+            OneDriveSyncClientMessages.SyncSchedulerCancelled(logger, accountId);
+            cts.Cancel();
+        }
+
+        return Task.CompletedTask;
     }
 
     // ReSharper disable once AsyncVoidMethod - Timer requires this signature
@@ -165,6 +182,11 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     public async ValueTask DisposeAsync()
     {
         StopSync();
+
+        foreach (var cts in _activeSyncs.Values)
+            cts.Cancel();
+
+        _activeSyncs.Clear();
 
         if (_timer is not null)
             await _timer.DisposeAsync();


### PR DESCRIPTION
feat(apps/desktop): per-account sync cancellation (#325)

Adds CancelAccountSyncAsync to ISyncScheduler. SyncScheduler maintains
a ConcurrentDictionary<string, CancellationTokenSource> keyed by account
ID — TriggerAccountAsync registers a linked CTS per invocation and
CancelAccountSyncAsync cancels it on demand. DisposeAsync cancels all
active syncs on shutdown.

SyncWorker already resets in-flight jobs to Queued on
OperationCanceledException; SyncService already surfaces "Sync cancelled"
progress — no changes needed there.

DashboardAccountViewModel gets CancelSyncCommand which delegates to
CancelAccountSyncAsync. DashboardView shows a Cancel button bound to
IsSyncing so it only appears while a sync is in progress.

Closes #325