### PR TITLE
feat(apps/desktop): file classification for OneDrive synced items

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassification.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassification.cs
@@ -1,0 +1,40 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAFileClassification
+{
+    [Fact]
+    public void when_three_level_classification_then_tag_name_is_level3()
+    {
+        var classification = FileClassificationFactory.Create("Subject", Option.Some("Vehicle"), Option.Some("Car"), false);
+
+        classification.TagName.ShouldBe("Car");
+    }
+
+    [Fact]
+    public void when_two_level_classification_then_tag_name_is_level2()
+    {
+        var classification = FileClassificationFactory.Create("Colour", Option.Some("Red"), Option.None<string>(), false);
+
+        classification.TagName.ShouldBe("Red");
+    }
+
+    [Fact]
+    public void when_one_level_classification_then_tag_name_is_level1()
+    {
+        var classification = FileClassificationFactory.Create("Archive", Option.None<string>(), Option.None<string>(), false);
+
+        classification.TagName.ShouldBe("Archive");
+    }
+
+    [Fact]
+    public void when_unclassified_sentinel_created_then_tag_name_is_unclassified()
+    {
+        var classification = FileClassificationFactory.CreateUnclassified();
+
+        classification.TagName.ShouldBe("Unclassified");
+        classification.IsSpecial.ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassifier.cs
@@ -1,0 +1,135 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAFileClassifier
+{
+    private static FileClassificationRule Rule(string keyword, string level1, string? level2 = null, string? level3 = null, bool isSpecial = false)
+        => FileClassificationRuleFactory.Create(
+            [keyword],
+            FileClassificationFactory.Create(
+                level1,
+                level2 is not null ? Option.Some(level2) : Option.None<string>(),
+                level3 is not null ? Option.Some(level3) : Option.None<string>(),
+                isSpecial));
+
+    [Fact]
+    public void when_classifying_segment_based_path_then_path_segments_produce_tokens()
+    {
+        var rule = Rule("tuscany", "Travel");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/Photos/Tuscany/IMG_001.jpg", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Travel");
+    }
+
+    [Fact]
+    public void when_classifying_compound_filename_then_hyphen_separated_parts_produce_tokens()
+    {
+        var rule = Rule("car", "Vehicle");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/docs/red-car-landscape.jpg", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Vehicle");
+    }
+
+    [Fact]
+    public void when_classifying_path_with_mixed_separators_then_all_delimiter_types_are_split()
+    {
+        var rule = Rule("finance", "Category");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/My_Documents/Finance Reports/Q1-2026.xlsx", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Category");
+    }
+
+    [Fact]
+    public void when_classifying_root_only_path_then_filename_parts_produce_tokens()
+    {
+        var rule = Rule("somefile", "Misc");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/somefile.txt", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Misc");
+    }
+
+    [Fact]
+    public void when_one_rule_keyword_appears_in_tokens_then_result_contains_that_classification()
+    {
+        var rule = Rule("landscape", "Subject", "Landscape");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/photos/landscape.jpg", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].TagName.ShouldBe("Landscape");
+    }
+
+    [Fact]
+    public void when_multiple_rule_keywords_appear_in_tokens_then_result_contains_all_classifications()
+    {
+        var redRule = Rule("red", "Colour", "Red");
+        var carRule = Rule("car", "Subject", "Vehicle", "Car");
+        var rules = new[] { redRule, carRule };
+
+        var result = FileClassifier.Classify("/photos/red-car.jpg", rules);
+
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void when_no_rule_keywords_appear_in_tokens_then_result_contains_unclassified_sentinel()
+    {
+        var rule = Rule("spacecraft", "Science");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/docs/report.pdf", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].TagName.ShouldBe("Unclassified");
+    }
+
+    [Fact]
+    public void when_rule_has_multiple_keywords_and_one_matches_then_rule_contributes_its_classification()
+    {
+        var rule = FileClassificationRuleFactory.Create(
+            ["car", "vehicle", "auto"],
+            FileClassificationFactory.Create("Transport", Option.None<string>(), Option.None<string>(), false));
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/photos/car-show.jpg", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Transport");
+    }
+
+    [Fact]
+    public void when_rules_list_is_empty_then_result_contains_unclassified_sentinel()
+    {
+        var result = FileClassifier.Classify("/photos/beach.jpg", []);
+
+        result.ShouldHaveSingleItem();
+        result[0].TagName.ShouldBe("Unclassified");
+    }
+
+    [Fact]
+    public void when_keyword_matches_case_insensitively_then_rule_fires()
+    {
+        var rule = Rule("photos", "Category");
+        var rules = new[] { rule };
+
+        var result = FileClassifier.Classify("/PHOTOS/beach.jpg", rules);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Category");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
@@ -20,7 +20,12 @@ public sealed class GivenASyncedItemRegistrar
     public GivenASyncedItemRegistrar()
         => _fileSystem.Directory.Returns(_mockDirectory);
 
-    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
+    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, [], _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
+
+    private SyncedItemRegistrar CreateSutWithRules(IReadOnlyList<FileClassificationRule> rules) => new(_syncedItemRepository, rules, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
+
+    private static FileClassificationRule ClassificationRule(string keyword, string level1)
+        => FileClassificationRuleFactory.Create([keyword], FileClassificationFactory.Create(level1, Option.None<string>(), Option.None<string>(), false));
 
     private static FolderDeltaItem FolderItem(string id, string remotePath)
         => DeltaItemFactory.CreateFolder(new OneDriveItemId(id), new DriveId("drive-1"), Option.None<OneDriveFolderId>(), ItemPathFactory.Create(id, remotePath), VersionInfoFactory.Create(Option.None<string>(), Option.None<string>()));
@@ -87,5 +92,65 @@ public sealed class GivenASyncedItemRegistrar
         await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/Documents/phantom.txt", "/sync-root/Documents/phantom.txt", syncedItems, TestContext.Current.CancellationToken);
 
         syncedItems.ShouldContainKey("item-phantom");
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_with_matching_rules_then_upsert_classifications_is_called_with_matched_tags()
+    {
+        const int entityId = 42;
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(entityId));
+        var sut = CreateSutWithRules([ClassificationRule("photos", "Media")]);
+        var item = FileItem("file-1", "/photos/beach.jpg");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/photos/beach.jpg", "/sync/photos/beach.jpg", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertClassificationsAsync(
+            entityId,
+            Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Media")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_with_no_matching_rules_then_upsert_classifications_is_called_with_unclassified()
+    {
+        const int entityId = 7;
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(entityId));
+        var sut = CreateSutWithRules([ClassificationRule("spacecraft", "Science")]);
+        var item = FileItem("file-2", "/docs/report.pdf");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/docs/report.pdf", "/sync/docs/report.pdf", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertClassificationsAsync(
+            entityId,
+            Arg.Is<IReadOnlyList<FileClassification>>(list => list.Count == 1 && list[0].TagName == "Unclassified"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_twice_then_upsert_classifications_is_called_each_time()
+    {
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(1));
+        var sut = CreateSutWithRules([ClassificationRule("photos", "Media")]);
+        var item = FileItem("file-3", "/photos/sunset.jpg");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/photos/sunset.jpg", "/sync/photos/sunset.jpg", syncedItems, TestContext.Current.CancellationToken);
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/photos/sunset.jpg", "/sync/photos/sunset.jpg", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(2).UpsertClassificationsAsync(Arg.Any<int>(), Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_folder_called_then_upsert_classifications_is_not_called()
+    {
+        var sut = CreateSutWithRules([ClassificationRule("photos", "Media")]);
+        var item = FolderItem("folder-2", "/photos");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/photos", "/sync/photos", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.DidNotReceive().UpsertClassificationsAsync(Arg.Any<int>(), Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -15,6 +15,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
 using Testably.Abstractions;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Startup;
 
@@ -77,6 +79,23 @@ public class App : Application, IDisposable
                 .Bind(configuration.GetSection("EntraId"))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
+
+        var classificationRuleOptions = configuration
+            .GetSection("FileClassificationRules")
+            .Get<List<FileClassificationRuleOptions>>() ?? [];
+
+        var classificationRules = classificationRuleOptions
+            .Select(o => FileClassificationRuleFactory.Create(
+                o.Keywords,
+                FileClassificationFactory.Create(
+                    o.Level1,
+                    o.Level2 is not null ? Option.Some(o.Level2) : Option.None<string>(),
+                    o.Level3 is not null ? Option.Some(o.Level3) : Option.None<string>(),
+                    o.IsSpecial)))
+            .ToList()
+            .AsReadOnly();
+
+        _ = services.AddSingleton<IReadOnlyList<FileClassificationRule>>(classificationRules);
         _ = services.AddShell(inMemoryLogSink);
 
         return services.BuildServiceProvider();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/AppDbContext.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/AppDbContext.cs
@@ -11,6 +11,7 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<DriveStateEntity> DriveStates => Set<DriveStateEntity>();
     public DbSet<SyncRuleEntity> SyncRules => Set<SyncRuleEntity>();
     public DbSet<SyncedItemEntity> SyncedItems => Set<SyncedItemEntity>();
+    public DbSet<SyncedItemClassificationEntity> SyncedItemClassifications => Set<SyncedItemClassificationEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemClassificationEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemClassificationEntityConfiguration.cs
@@ -1,0 +1,22 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Configuration;
+
+public sealed class SyncedItemClassificationEntityConfiguration : IEntityTypeConfiguration<SyncedItemClassificationEntity>
+{
+    public void Configure(EntityTypeBuilder<SyncedItemClassificationEntity> builder)
+    {
+        _ = builder.HasKey(e => e.Id);
+        _ = builder.Property(e => e.Level1).IsRequired();
+        _ = builder.Property(e => e.Level2).IsRequired(false);
+        _ = builder.Property(e => e.Level3).IsRequired(false);
+        _ = builder.Property(e => e.TagName).IsRequired();
+        _ = builder.HasIndex(e => e.TagName);
+        _ = builder.HasOne(e => e.SyncedItem)
+                   .WithMany()
+                   .HasForeignKey(e => e.SyncedItemId)
+                   .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemClassificationEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemClassificationEntity.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+/// <summary>Stores a single classification tag for a synced file item.</summary>
+public sealed class SyncedItemClassificationEntity
+{
+    /// <summary>Primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Foreign key to the owning <see cref="SyncedItemEntity"/>.</summary>
+    public int SyncedItemId { get; set; }
+
+    /// <summary>The top-level classification category.</summary>
+    public string Level1 { get; set; } = string.Empty;
+
+    /// <summary>The second-level classification category, or null if not applicable.</summary>
+    public string? Level2 { get; set; }
+
+    /// <summary>The third-level classification category, or null if not applicable.</summary>
+    public string? Level3 { get; set; }
+
+    /// <summary>The most-specific classification level: Level3 if present, Level2 if present, otherwise Level1.</summary>
+    public string TagName { get; set; } = string.Empty;
+
+    /// <summary>Indicates whether this classification is flagged as special.</summary>
+    public bool IsSpecial { get; set; }
+
+    /// <summary>Navigation property to the owning synced item.</summary>
+    [ForeignKey(nameof(SyncedItemId))]
+    public SyncedItemEntity? SyncedItem { get; set; }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524212430_AddFileClassification")]
+    partial class AddFileClassification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFileClassification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SyncedItemClassifications",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SyncedItemId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Level1 = table.Column<string>(type: "TEXT", nullable: false),
+                    Level2 = table.Column<string>(type: "TEXT", nullable: true),
+                    Level3 = table.Column<string>(type: "TEXT", nullable: true),
+                    TagName = table.Column<string>(type: "TEXT", nullable: false),
+                    IsSpecial = table.Column<bool>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SyncedItemClassifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SyncedItemClassifications_SyncedItems_SyncedItemId",
+                        column: x => x.SyncedItemId,
+                        principalTable: "SyncedItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SyncedItemClassifications_SyncedItemId",
+                table: "SyncedItemClassifications",
+                column: "SyncedItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SyncedItemClassifications_TagName",
+                table: "SyncedItemClassifications",
+                column: "TagName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SyncedItemClassifications");
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -9,8 +10,11 @@ public interface ISyncedItemRepository
     /// <summary>Returns all synced items for the specified account, loaded into a dictionary keyed by remote item ID for fast lookups.</summary>
     Task<Dictionary<string, SyncedItemEntity>> GetAllByAccountAsync(AccountId accountId, CancellationToken cancellationToken);
 
-    /// <summary>Inserts or updates the synced item record.</summary>
-    Task UpsertAsync(SyncedItemEntity item, CancellationToken cancellationToken);
+    /// <summary>Inserts or updates the synced item record. Returns the database Id of the entity after the operation.</summary>
+    Task<int> UpsertAsync(SyncedItemEntity item, CancellationToken cancellationToken);
+
+    /// <summary>Replaces all classification rows for the specified synced item with the provided classifications.</summary>
+    Task UpsertClassificationsAsync(int syncedItemId, IReadOnlyList<FileClassification> classifications, CancellationToken cancellationToken);
 
     /// <summary>Removes the synced item record with the specified remote item ID.</summary>
     Task DeleteByRemoteIdAsync(AccountId accountId, OneDriveItemId remoteItemId, CancellationToken cancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -1,4 +1,6 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.EntityFrameworkCore;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
@@ -18,7 +20,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
         return items.ToDictionary(i => i.RemoteItemId.Id);
     }
 
-    public async Task UpsertAsync(SyncedItemEntity item, CancellationToken cancellationToken)
+    public async Task<int> UpsertAsync(SyncedItemEntity item, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
@@ -28,17 +30,41 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
         if(existing is null)
         {
             _ = db.SyncedItems.Add(item);
-        }
-        else
-        {
-            existing.RemoteParentId   = item.RemoteParentId;
-            existing.RemotePath       = item.RemotePath;
-            existing.LocalPath        = item.LocalPath;
-            existing.IsFolder         = item.IsFolder;
-            existing.RemoteModifiedAt = item.RemoteModifiedAt;
-            existing.Tags             = item.Tags;
+            _ = await db.SaveChangesAsync(cancellationToken);
+
+            return item.Id;
         }
 
+        existing.RemoteParentId   = item.RemoteParentId;
+        existing.RemotePath       = item.RemotePath;
+        existing.LocalPath        = item.LocalPath;
+        existing.IsFolder         = item.IsFolder;
+        existing.RemoteModifiedAt = item.RemoteModifiedAt;
+        existing.Tags             = item.Tags;
+        _ = await db.SaveChangesAsync(cancellationToken);
+
+        return existing.Id;
+    }
+
+    public async Task UpsertClassificationsAsync(int syncedItemId, IReadOnlyList<FileClassification> classifications, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        _ = await db.SyncedItemClassifications
+                   .Where(c => c.SyncedItemId == syncedItemId)
+                   .ExecuteDeleteAsync(cancellationToken);
+
+        var entities = classifications.Select(c => new SyncedItemClassificationEntity
+        {
+            SyncedItemId = syncedItemId,
+            Level1       = c.Level1,
+            Level2       = c.Level2.MapOrDefault<string, string?>(v => v, null),
+            Level3       = c.Level3.MapOrDefault<string, string?>(v => v, null),
+            TagName      = c.TagName,
+            IsSpecial    = c.IsSpecial
+        });
+
+        db.SyncedItemClassifications.AddRange(entities);
         _ = await db.SaveChangesAsync(cancellationToken);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassification.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassification.cs
@@ -1,0 +1,10 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Represents the classification tags derived from a synced file's remote path.</summary>
+public sealed record FileClassification(string Level1, Option<string> Level2, Option<string> Level3, bool IsSpecial)
+{
+    /// <summary>The most-specific classification level: Level3 if present, then Level2, then Level1.</summary>
+    public string TagName => Level3.MapOrDefault(v => v, Level2.MapOrDefault(v => v, Level1));
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationFactory.cs
@@ -1,0 +1,18 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="FileClassification"/>.</summary>
+public static class FileClassificationFactory
+{
+    /// <summary>Creates a <see cref="FileClassification"/> with the specified levels.</summary>
+    public static FileClassification Create(string level1, Option<string> level2, Option<string> level3, bool isSpecial)
+    {
+        ArgumentNullException.ThrowIfNull(level1);
+
+        return new(level1, level2, level3, isSpecial);
+    }
+
+    /// <summary>Creates the "Unclassified" sentinel used when no rules match a file's path.</summary>
+    public static FileClassification CreateUnclassified() => new("Unclassified", Option.None<string>(), Option.None<string>(), false);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRule.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRule.cs
@@ -1,0 +1,4 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>A rule that maps a set of path keywords to a <see cref="FileClassification"/>.</summary>
+public sealed record FileClassificationRule(IReadOnlyList<string> Keywords, FileClassification Classification);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleFactory.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="FileClassificationRule"/>.</summary>
+public static class FileClassificationRuleFactory
+{
+    /// <summary>Creates a <see cref="FileClassificationRule"/>.</summary>
+    public static FileClassificationRule Create(IReadOnlyList<string> keywords, FileClassification classification) => new(keywords, classification);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
@@ -10,5 +10,21 @@ public static class FileClassifier
     /// Returns a single "Unclassified" sentinel when no rules match or the rule list is empty.
     /// </summary>
     public static IReadOnlyList<FileClassification> Classify(string remotePath, IReadOnlyList<FileClassificationRule> rules)
-        => throw new NotImplementedException();
+    {
+        var tokens = Tokenise(remotePath);
+        var matches = rules
+            .Where(rule => rule.Keywords.Any(kw => tokens.Contains(kw.ToLowerInvariant())))
+            .Select(rule => rule.Classification)
+            .ToList();
+
+        if(matches.Count == 0)
+            return [FileClassificationFactory.CreateUnclassified()];
+
+        return matches.AsReadOnly();
+    }
+
+    private static HashSet<string> Tokenise(string remotePath)
+        => remotePath.Split(Separators, StringSplitOptions.RemoveEmptyEntries)
+                     .Select(t => t.ToLowerInvariant())
+                     .ToHashSet();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
@@ -1,0 +1,14 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Classifies a remote file path against a set of configured rules.</summary>
+public static class FileClassifier
+{
+    private static readonly char[] Separators = ['/', '-', '_', '.', ' '];
+
+    /// <summary>
+    /// Tokenises <paramref name="remotePath"/> and evaluates each rule, returning all matching classifications.
+    /// Returns a single "Unclassified" sentinel when no rules match or the rule list is empty.
+    /// </summary>
+    public static IReadOnlyList<FileClassification> Classify(string remotePath, IReadOnlyList<FileClassificationRule> rules)
+        => throw new NotImplementedException();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/FileClassificationRuleOptions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/FileClassificationRuleOptions.cs
@@ -1,0 +1,20 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
+
+/// <summary>Config-bound POCO for a single file classification rule, sourced from the <c>FileClassificationRules</c> section.</summary>
+public sealed class FileClassificationRuleOptions
+{
+    /// <summary>One or more lowercase keywords to match against path tokens.</summary>
+    public IReadOnlyList<string> Keywords { get; init; } = [];
+
+    /// <summary>Top-level classification category (required).</summary>
+    public string Level1 { get; init; } = string.Empty;
+
+    /// <summary>Second-level classification category, or null if not used.</summary>
+    public string? Level2 { get; init; }
+
+    /// <summary>Third-level classification category, or null if not used.</summary>
+    public string? Level3 { get; init; }
+
+    /// <summary>Whether this classification should be flagged as special.</summary>
+    public bool IsSpecial { get; init; }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
@@ -9,14 +9,14 @@ using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
 /// <inheritdoc />
-public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger) : ISyncedItemRegistrar
+public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IReadOnlyList<FileClassificationRule> classificationRules, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger) : ISyncedItemRegistrar
 {
     /// <inheritdoc />
     public async Task RegisterFolderAsync(AccountId accountId, FolderDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
         _ = fileSystem.Directory.CreateDirectory(localPath);
         var entity = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
-        await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
+        _ = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
         syncedItems[item.Id.Id] = entity;
     }
 
@@ -25,7 +25,9 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
     {
         OneDriveSyncClientMessages.SyncedItemLocalExists(logger, localPath);
         var phantomItem = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
-        await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
+        var syncedItemId = await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
+        var classifications = FileClassifier.Classify(remotePath, classificationRules);
+        await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
         syncedItems[item.Id.Id] = phantomItem;
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -27,6 +27,26 @@
       "offline_access"
     ]
   },
+  "FileClassificationRules": [
+    {
+      "Keywords": [ "photos", "photo", "img", "image", "jpeg", "jpg", "png" ],
+      "Level1": "Media",
+      "Level2": "Photos",
+      "IsSpecial": false
+    },
+    {
+      "Keywords": [ "video", "mp4", "mov", "avi" ],
+      "Level1": "Media",
+      "Level2": "Videos",
+      "IsSpecial": false
+    },
+    {
+      "Keywords": [ "finance", "invoice", "receipt", "tax" ],
+      "Level1": "Documents",
+      "Level2": "Finance",
+      "IsSpecial": false
+    }
+  ],
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",

--- a/openspec/changes/file-classification-onedrive-sync/.openspec.yaml
+++ b/openspec/changes/file-classification-onedrive-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/file-classification-onedrive-sync/design.md
+++ b/openspec/changes/file-classification-onedrive-sync/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The OneDrive sync client downloads files via a delta-based pipeline. Each file passes through `DownloadJobBuilder` → `DownloadJobHandler` → `SyncedItemRegistrar`. The registrar is the single point where a downloaded file is persisted to the local SQLite DB (`SyncedItemEntity`). It already has the full remote path available.
+
+Classification is purely additive: no existing pipeline stage changes behaviour. The sync client never acts on classifications — they exist solely for downstream querying.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tokenise the remote path of every registered file and match against configured keyword rules
+- Persist matching tags to a new `SyncedItemClassificationEntity` table
+- Keep classification as a pure function — deterministic, no I/O, fully testable in isolation
+- Zero performance impact on unchanged files (delta processing is already incremental)
+
+**Non-Goals:**
+- No UI for managing rules
+- No per-account rule scoping
+- No re-classify-all command
+- No routing, priority, or conflict policy changes based on classification
+- No changes to upload or delete paths
+
+## Decisions
+
+### 1. Classification runs in `SyncedItemRegistrar`, not `DownloadJobBuilder`
+
+**Decision:** Classify at registration time, not job-build time.
+
+**Rationale:** Classification is a persistence concern — it produces DB rows. `SyncedItemRegistrar` already owns DB writes for items. Putting classification there keeps it co-located with its output and avoids carrying unused data on `SyncJob` through the entire pipeline.
+
+**Alternative considered:** Classify in `DownloadJobBuilder`, carry on `DownloadSyncJob`. Rejected because classification result is not needed during download execution, and it would bloat the job record with data irrelevant to the download itself.
+
+### 2. `FileClassifier` is a pure static function, not a DI service
+
+**Decision:** `FileClassifier.Classify(remotePath, rules)` — static method, no interface, no DI registration.
+
+**Rationale:** Classification has no side effects and no dependencies. Making it an interface adds ceremony with no benefit. The rule list is injected into `SyncedItemRegistrar` as `IReadOnlyList<FileClassificationRule>` (bound from config), not wrapped in a service.
+
+**Alternative considered:** `IFileClassifier` interface injected into registrar. Rejected — over-engineering for a pure function. Test by calling directly.
+
+### 3. Tokenisation splits on `/`, `-`, `_`, `.`, ` ` with lowercase normalisation
+
+**Decision:** Full path string split on all common delimiters, lowercased, empty tokens stripped and deduped.
+
+**Rationale:** Covers both path-segment matching (`/Photos/Tuscany/`) and compound filename matching (`red-car-landscape.jpg`). File extension tokens (e.g. `jpg`) are included — rules can target extensions if desired.
+
+**Alternative considered:** Split only on `/` (segment-only). Rejected — would not match `red-car.jpg` for keyword "red".
+
+### 4. All matching rules fire — multiple tags per file
+
+**Decision:** Evaluate every rule. Each matching rule contributes one `FileClassification`. Result is `IReadOnlyList<FileClassification>`.
+
+**Rationale:** A file in `/Finance/Photos/` is legitimately both "Finance" and "Photos". Single-winner semantics would silently drop valid tags.
+
+**Alternative considered:** First-match or longest-match-wins. Rejected — loses information without benefit given search is the only consumer.
+
+### 5. No match → "Unclassified" sentinel tag
+
+**Decision:** If no rules match, write a single tag with `Level1 = "Unclassified"`, `TagName = "Unclassified"`.
+
+**Rationale:** Every file is findable. Search UI can show an "Unclassified" bucket without needing a special `LEFT JOIN / WHERE NULL` query.
+
+### 6. `TagName` denormalised as most-specific level
+
+**Decision:** `TagName` = `Level3 ?? Level2 ?? Level1`. Stored redundantly on the entity.
+
+**Rationale:** Primary search query is `WHERE TagName = 'landscape'`. Avoids a `CASE` expression or application-side resolution on every query. Cost: one extra string column per tag row.
+
+### 7. Classification is a snapshot — no automatic re-classification on rule change
+
+**Decision:** Tags are written once at registration. If rules change, existing items keep old tags until they next appear in a delta.
+
+**Rationale:** Simplest correct behaviour. Re-classify-all is a future command, not a required feature now. Predictable — users know what triggers re-classification.
+
+## Risks / Trade-offs
+
+- **Stale tags after rule change** → Acceptable for now; re-classify-all is a clear future addition. Document in config comments.
+- **Token false positives** (e.g. keyword "car" matches file in `/Oscar/`) → Rules author controls keywords; keep keywords specific. Future: support phrase or path-anchored rules.
+- **Extension tokens in keyword matches** (e.g. keyword "mp4" matched via extension) → Actually desirable — lets rules target file types. Document as a feature.
+- **Large tag tables at scale** → Each file gets ≥1 tag row. At 300k files with avg 3 tags = ~900k rows. SQLite handles this comfortably with an index on `TagName`.
+
+## Migration Plan
+
+1. Add EF Core migration — creates `SyncedItemClassifications` table
+2. Migration is additive — no existing data modified
+3. Rollback: drop migration, remove table — no data loss on existing `SyncedItemEntity` rows
+4. No config change required to run — `FileClassificationRules` defaults to empty; files get "Unclassified" tag

--- a/openspec/changes/file-classification-onedrive-sync/proposal.md
+++ b/openspec/changes/file-classification-onedrive-sync/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Synced files have no semantic metadata beyond their path. Downstream apps (e.g. a file search UI) need to find files by user-defined concepts like "red", "car", or "landscape" — but cannot query path strings meaningfully. Classification translates folder/filename structure into queryable tags at sync time.
+
+## What Changes
+
+- New `FileClassificationRule` config block in `appsettings.json` — global, not per-account
+- New `FileClassifier` service — pure path-token matching, no DB dependency
+- New `SyncedItemClassificationEntity` DB table — one-to-many off `SyncedItemEntity`
+- `SyncedItemRegistrar` extended to classify files at registration time
+- EF Core migration for the new table
+- Classification is read-only from the sync client's perspective — no routing, priority, or policy changes
+
+## Capabilities
+
+### New Capabilities
+
+- `file-classification`: Tokenise a remote file path, match tokens against configured keyword rules, persist resulting tags to the database alongside the synced item
+
+### Modified Capabilities
+
+- `synced-item-registration`: `SyncedItemRegistrar` gains a classification step — tags are written when a file item is registered or upserted
+
+## Impact
+
+- **`apps/desktop/AStar.Dev.OneDrive.Sync.Client`**: new domain types, new DB entity, new service, extended registrar, new migration
+- **`appsettings.json`**: new `FileClassificationRules` config section
+- **No changes** to sync pipeline logic, conflict resolution, upload/delete paths, or any other app
+- **Additive only** — existing behaviour unchanged; classification is a new side-effect of file registration

--- a/openspec/changes/file-classification-onedrive-sync/specs/file-classification/spec.md
+++ b/openspec/changes/file-classification-onedrive-sync/specs/file-classification/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Path tokenisation
+The system SHALL tokenise a remote file path into a set of lowercase tokens by splitting on `/`, `-`, `_`, `.`, and space characters. Empty tokens SHALL be discarded. Duplicate tokens SHALL be deduplicated. The result SHALL be treated as a set (order-independent).
+
+#### Scenario: Segment-based path
+- **WHEN** the remote path is `/Photos/Tuscany/IMG_001.jpg`
+- **THEN** tokens are `{ photos, tuscany, img_001, jpg }` (underscore within `img_001` also split, `img` and `001` separate tokens)
+
+#### Scenario: Compound filename
+- **WHEN** the remote path is `/docs/red-car-landscape.jpg`
+- **THEN** tokens include `red`, `car`, `landscape`, and `jpg`
+
+#### Scenario: Mixed separators
+- **WHEN** the remote path is `/My_Documents/Finance Reports/Q1-2026.xlsx`
+- **THEN** tokens include `my`, `documents`, `finance`, `reports`, `q1`, `2026`, `xlsx`
+
+#### Scenario: Root-only path
+- **WHEN** the remote path is `/somefile.txt`
+- **THEN** tokens are `{ somefile, txt }`
+
+### Requirement: Rule matching
+The system SHALL evaluate every configured `FileClassificationRule` against the token set. A rule matches if at least one of its `Keywords` appears in the token set (case-insensitive comparison). Every matching rule SHALL contribute exactly one `FileClassification` to the result. Rules that do not match SHALL contribute nothing.
+
+#### Scenario: Single rule matches
+- **WHEN** tokens include `landscape` and one rule has keyword `landscape`
+- **THEN** result contains that rule's classification
+
+#### Scenario: Multiple rules match
+- **WHEN** tokens include both `red` and `car` and there are separate rules for each
+- **THEN** result contains both classifications
+
+#### Scenario: No rules match
+- **WHEN** no rule keyword appears in the token set
+- **THEN** result contains exactly one classification with `Level1 = "Unclassified"` and `TagName = "Unclassified"`
+
+#### Scenario: Rule with multiple keywords — partial match
+- **WHEN** a rule has keywords `["car","vehicle","auto"]` and tokens contain `car` but not `vehicle` or `auto`
+- **THEN** the rule matches and contributes its classification
+
+#### Scenario: Empty rules list
+- **WHEN** no `FileClassificationRules` are configured
+- **THEN** result contains exactly one classification with `TagName = "Unclassified"`
+
+### Requirement: Classification shape
+Each `FileClassification` SHALL carry `Level1` (required string), `Level2` (optional string), `Level3` (optional string), and `IsSpecial` (bool). The `TagName` SHALL be computed as `Level3 ?? Level2 ?? Level1`.
+
+#### Scenario: Three-level classification
+- **WHEN** a rule specifies `Level1 = "Subject"`, `Level2 = "Vehicle"`, `Level3 = "Car"`
+- **THEN** `TagName = "Car"`
+
+#### Scenario: Two-level classification
+- **WHEN** a rule specifies `Level1 = "Colour"`, `Level2 = "Red"`, no Level3
+- **THEN** `TagName = "Red"`
+
+#### Scenario: One-level classification
+- **WHEN** a rule specifies only `Level1 = "Archive"`, no Level2 or Level3
+- **THEN** `TagName = "Archive"`

--- a/openspec/changes/file-classification-onedrive-sync/specs/synced-item-registration/spec.md
+++ b/openspec/changes/file-classification-onedrive-sync/specs/synced-item-registration/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Classification persisted at file registration
+When a `FileDeltaItem` is registered or upserted in the database, the system SHALL classify the item using its remote path and persist the resulting tags as `SyncedItemClassificationEntity` rows linked to the `SyncedItemEntity`. Existing tags for the item SHALL be replaced on each registration.
+
+#### Scenario: New file with matching rules
+- **WHEN** a new `FileDeltaItem` with remote path `/Photos/red-car.jpg` is registered and rules exist for `red` and `car`
+- **THEN** two `SyncedItemClassificationEntity` rows are written, linked to the new `SyncedItemEntity`
+
+#### Scenario: New file with no matching rules
+- **WHEN** a new `FileDeltaItem` is registered and no rules match its path
+- **THEN** one `SyncedItemClassificationEntity` row is written with `TagName = "Unclassified"`
+
+#### Scenario: Re-registration replaces tags
+- **WHEN** a `FileDeltaItem` that was previously classified is registered again (delta update)
+- **THEN** old classification rows for that item are deleted and new ones written
+
+#### Scenario: Folder items not classified
+- **WHEN** a `FolderDeltaItem` is registered
+- **THEN** no `SyncedItemClassificationEntity` rows are written for that item

--- a/openspec/changes/file-classification-onedrive-sync/tasks.md
+++ b/openspec/changes/file-classification-onedrive-sync/tasks.md
@@ -1,0 +1,59 @@
+## 1. Domain Types
+
+- [x] 1.1 Create `FileClassification` record (`Level1`, `Level2`, `Level3`, `IsSpecial`, computed `TagName`)
+- [x] 1.2 Create `FileClassificationFactory` static factory with `Create` method
+- [x] 1.3 Create `FileClassificationRule` record (`Keywords`, `FileClassification`)
+- [x] 1.4 Create `FileClassificationRuleFactory` static factory with `Create` method
+
+## 2. Classifier
+
+- [x] 2.1 Create `FileClassifier` static class with `Classify(string remotePath, IReadOnlyList<FileClassificationRule> rules)` method
+- [x] 2.2 Implement tokenisation: split on `/`, `-`, `_`, `.`, space; lowercase; strip empty; deduplicate
+- [x] 2.3 Implement rule evaluation: all rules evaluated, each match contributes one tag
+- [x] 2.4 Implement "Unclassified" sentinel when no rules match
+
+## 3. Tests — Classifier
+
+- [x] 3.1 Write failing tests for tokenisation scenarios (segment path, compound filename, mixed separators, root-only path)
+- [x] 3.2 Write failing tests for rule matching scenarios (single match, multiple matches, no match, partial keyword match, empty rules)
+- [x] 3.3 Write failing tests for `TagName` derivation (three-level, two-level, one-level)
+- [x] 3.4 Run tests — confirm RED, commit failing tests
+- [x] 3.5 Implement classifier to make tests GREEN
+
+## 4. DB Entity & Migration
+
+- [x] 4.1 Create `SyncedItemClassificationEntity` with properties: `Id`, `SyncedItemId` (FK), `Level1`, `Level2`, `Level3`, `TagName`, `IsSpecial`
+- [x] 4.2 Register entity in `SyncClientDbContext` with index on `TagName`
+- [x] 4.3 Add EF Core migration for new table
+- [x] 4.4 Verify migration applies cleanly (`dotnet ef database update`)
+
+## 5. Config Binding
+
+- [x] 5.1 Create `FileClassificationRuleOptions` POCO for config binding (`Keywords`, `Level1`, `Level2`, `Level3`, `IsSpecial`)
+- [x] 5.2 Register `FileClassificationRuleOptions` in DI/config pipeline bound to `FileClassificationRules` section
+- [x] 5.3 Add representative example rules to `appsettings.json` (commented-out or dev-only)
+
+## 6. Repository
+
+- [x] 6.1 Add `UpsertClassificationsAsync(int syncedItemId, IReadOnlyList<FileClassification> classifications, CancellationToken ct)` to `ISyncedItemRepository`
+- [x] 6.2 Implement: delete existing rows for `syncedItemId`, insert new rows
+
+## 7. Registrar Integration
+
+- [x] 7.1 Inject `IReadOnlyList<FileClassificationRule>` and repository classification method into `SyncedItemRegistrar`
+- [x] 7.2 Call `FileClassifier.Classify(remotePath, rules)` and persist tags in `RegisterPhantomAsync` and any file registration path
+- [x] 7.3 Confirm folder registration paths (`RegisterFolderAsync`) do NOT classify
+
+## 8. Tests — Registrar Integration
+
+- [x] 8.1 Write failing test: new file with matching rules → classification rows written
+- [x] 8.2 Write failing test: new file with no matching rules → "Unclassified" row written
+- [x] 8.3 Write failing test: re-registration replaces existing tags
+- [x] 8.4 Write failing test: folder registration writes no classification rows
+- [x] 8.5 Run tests — confirm RED, commit failing tests
+- [x] 8.6 Implement registrar changes to make tests GREEN
+
+## 9. Build & Verify
+
+- [x] 9.1 `dotnet build` — zero errors, zero warnings
+- [x] 9.2 `dotnet test` — all tests pass


### PR DESCRIPTION
## Summary

- Adds path-based file classification to the OneDrive sync client — tokenises each synced file's remote path, evaluates all configured keyword rules, and persists matching tags to a new `SyncedItemClassifications` table
- `FileClassifier` is a pure static function (no DI) — deterministic, fully testable in isolation; rules are injected into `SyncedItemRegistrar` as `IReadOnlyList<FileClassificationRule>` bound from config
- Classification is additive and file-only: `RegisterPhantomAsync` classifies; `RegisterFolderAsync` does not; no existing pipeline stages change behaviour

## Changes

- **Domain**: `FileClassification` record (Level1/2/3, IsSpecial, computed TagName), `FileClassificationRule`, `FileClassificationFactory`, `FileClassificationRuleFactory`, `FileClassifier` static class
- **DB**: `SyncedItemClassificationEntity` + EF entity config + `AddFileClassification` migration (FK → `SyncedItemEntity`, index on `TagName`)
- **Repository**: `ISyncedItemRepository.UpsertAsync` → `Task<int>` (returns entity Id); new `UpsertClassificationsAsync` (delete-then-insert per item)
- **Registrar**: `SyncedItemRegistrar` injects `IReadOnlyList<FileClassificationRule>`, classifies files and persists tags after each `RegisterPhantomAsync`
- **Config**: `FileClassificationRuleOptions` POCO bound from `FileClassificationRules` section; example rules in `appsettings.json`
- **Tests**: 18 new tests (classifier behaviour, TagName derivation, registrar integration) — 936 total, all pass

## Test plan

- [x] `dotnet build` — zero errors
- [x] `dotnet test` — 936 pass, 0 fail
- [x] Verify `SyncedItemClassifications` table created after fresh `dotnet ef database update`
- [x] Confirm files registered via delta sync receive classification rows; folders do not
- [x] Confirm re-registration replaces (not appends) classification rows
- [x] Confirm empty `FileClassificationRules` config → every file gets "Unclassified" tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)