### PR TITLE
feat(apps/desktop): add editable file classification rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -129,6 +129,8 @@
   ],
   "chat.tools.terminal.autoApprove": {
     "dotnet build": true,
-    "dotnet test": true
+    "dotnet test": true,
+    "git -C /home/jbarden/repos/astar-dev-mono": true,
+    "gh": true
   }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
@@ -149,8 +149,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
     {
         var repository = Substitute.For<IAccountRepository>();
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = SyncPathValue;
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = SyncPathValue
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -164,8 +166,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         AccountEntity? captured = null;
         await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = SyncPathValue;
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = SyncPathValue
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -180,9 +184,11 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         AccountEntity? captured = null;
         await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = SyncPathValue;
-        sut.ConflictPolicy = ConflictPolicy.RemoteWins;
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = SyncPathValue,
+            ConflictPolicy = ConflictPolicy.RemoteWins
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -196,8 +202,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         var repository = Substitute.For<IAccountRepository>();
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         var account = BuildAccount();
-        var sut = new AccountSyncSettingsViewModel(account, repository);
-        sut.LocalSyncPath = SyncPathValue;
+        var sut = new AccountSyncSettingsViewModel(account, repository)
+        {
+            LocalSyncPath = SyncPathValue
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -210,8 +218,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
     {
         var repository = Substitute.For<IAccountRepository>();
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = string.Empty;
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = string.Empty
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -225,8 +235,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         AccountEntity? captured = null;
         await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = string.Empty;
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = string.Empty
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -241,8 +253,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         AccountEntity? captured = null;
         await repository.UpsertAsync(Arg.Do<AccountEntity>(entity => captured = entity), Arg.Any<CancellationToken>());
-        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository);
-        sut.LocalSyncPath = "   ";
+        var sut = new AccountSyncSettingsViewModel(BuildAccount(), repository)
+        {
+            LocalSyncPath = "   "
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 
@@ -256,8 +270,10 @@ public sealed class GivenAnAccountSyncSettingsViewModel
         var repository = Substitute.For<IAccountRepository>();
         repository.GetByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(Option.Some(BuildEntity()));
         var account = BuildAccount();
-        var sut = new AccountSyncSettingsViewModel(account, repository);
-        sut.LocalSyncPath = string.Empty;
+        var sut = new AccountSyncSettingsViewModel(account, repository)
+        {
+            LocalSyncPath = string.Empty
+        };
 
         await sut.SaveCommand.ExecuteAsync(null);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
@@ -16,6 +16,8 @@ public sealed class GivenAFileClassificationRulesViewModel
                    .Returns(Task.FromResult<IReadOnlyList<FileClassificationRuleEntry>>([]));
         _repository.AddAsync(Arg.Any<FileClassificationRule>(), Arg.Any<CancellationToken>())
                    .Returns(Task.FromResult(1));
+        _repository.UpdateAsync(Arg.Any<int>(), Arg.Any<FileClassificationRule>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.CompletedTask);
     }
 
     [Fact]
@@ -38,9 +40,11 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_command_executed_then_rule_persisted_and_added_to_collection()
     {
-        FileClassificationRulesViewModel sut = new(_repository);
-        sut.NewKeywords = "photos, photo";
-        sut.NewLevel1 = "Media";
+        FileClassificationRulesViewModel sut = new(_repository)
+        {
+            NewKeywords = "photos, photo",
+            NewLevel1 = "Media"
+        };
 
         await sut.AddCommand.ExecuteAsync(null);
 
@@ -51,9 +55,11 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_keywords_empty_then_add_command_disabled()
     {
-        FileClassificationRulesViewModel sut = new(_repository);
-        sut.NewKeywords = string.Empty;
-        sut.NewLevel1 = "Media";
+        FileClassificationRulesViewModel sut = new(_repository)
+        {
+            NewKeywords = string.Empty,
+            NewLevel1 = "Media"
+        };
 
         sut.AddCommand.CanExecute(null).ShouldBeFalse();
     }
@@ -61,9 +67,11 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_level1_empty_then_add_command_disabled()
     {
-        FileClassificationRulesViewModel sut = new(_repository);
-        sut.NewKeywords = "photos";
-        sut.NewLevel1 = string.Empty;
+        FileClassificationRulesViewModel sut = new(_repository)
+        {
+            NewKeywords = "photos",
+            NewLevel1 = string.Empty
+        };
 
         sut.AddCommand.CanExecute(null).ShouldBeFalse();
     }
@@ -71,12 +79,14 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_succeeds_then_form_inputs_cleared()
     {
-        FileClassificationRulesViewModel sut = new(_repository);
-        sut.NewKeywords = "photos, photo";
-        sut.NewLevel1 = "Media";
-        sut.NewLevel2 = "Photos";
-        sut.NewLevel3 = "Personal";
-        sut.NewIsSpecial = true;
+        FileClassificationRulesViewModel sut = new(_repository)
+        {
+            NewKeywords = "photos, photo",
+            NewLevel1 = "Media",
+            NewLevel2 = "Photos",
+            NewLevel3 = "Personal",
+            NewIsSpecial = true
+        };
 
         await sut.AddCommand.ExecuteAsync(null);
 
@@ -103,5 +113,45 @@ public sealed class GivenAFileClassificationRulesViewModel
 
         await _repository.Received(1).DeleteAsync(42, Arg.Any<CancellationToken>());
         sut.Rules.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_rule_updated_then_repository_is_called_and_row_values_refresh()
+    {
+        IReadOnlyList<FileClassificationRuleEntry> entries =
+        [
+            new(7, FileClassificationRuleFactory.Create(["budget"], FileClassificationFactory.Create("Finance", Option.None<string>(), Option.None<string>(), false)))
+        ];
+        _repository.GetAllWithIdsAsync(Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult(entries));
+        FileClassificationRulesViewModel sut = new(_repository);
+        await sut.LoadAsync(CancellationToken.None);
+
+        await sut.Rules[0].EditCommand.ExecuteAsync(null);
+        sut.Rules[0].Keywords = "budget, finance";
+        sut.Rules[0].Level1 = "Finances";
+        sut.Rules[0].Level2 = "Budget";
+        sut.Rules[0].Level3 = "Quarterly";
+        sut.Rules[0].IsSpecial = true;
+
+        await sut.Rules[0].SaveCommand.ExecuteAsync(null);
+
+        await _repository.Received(1).UpdateAsync(
+            7,
+            Arg.Is<FileClassificationRule>(rule =>
+                rule.Keywords.Count == 2 &&
+                rule.Keywords[0] == "budget" &&
+                rule.Keywords[1] == "finance" &&
+                rule.Classification.Level1 == "Finances" &&
+                rule.Classification.Level2 == Option.Some("Budget") &&
+                rule.Classification.Level3 == Option.Some("Quarterly") &&
+                rule.Classification.IsSpecial),
+            Arg.Any<CancellationToken>());
+        sut.Rules[0].Keywords.ShouldBe("budget, finance");
+        sut.Rules[0].Level1.ShouldBe("Finances");
+        sut.Rules[0].Level2.ShouldBe("Budget");
+        sut.Rules[0].Level3.ShouldBe("Quarterly");
+        sut.Rules[0].IsSpecial.ShouldBeTrue();
+        sut.Rules[0].IsEditing.ShouldBeFalse();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Controls/GivenAnIconRailButton.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Controls/GivenAnIconRailButton.cs
@@ -35,9 +35,10 @@ public sealed class GivenAnIconRailButton
     [AvaloniaFact]
     public void when_is_active_set_to_true_then_active_bar_becomes_visible()
     {
-        var sut = new IconRailButton();
-
-        sut.IsActive = true;
+        var sut = new IconRailButton
+        {
+            IsActive = true
+        };
 
         sut.FindControl<Rectangle>("ActiveBar")!.IsVisible.ShouldBeTrue();
     }
@@ -45,9 +46,10 @@ public sealed class GivenAnIconRailButton
     [AvaloniaFact]
     public void when_is_active_set_to_true_then_rail_button_has_active_class()
     {
-        var sut = new IconRailButton();
-
-        sut.IsActive = true;
+        var sut = new IconRailButton
+        {
+            IsActive = true
+        };
 
         sut.FindControl<Button>("RailBtn")!.Classes.Contains(ActiveClassName).ShouldBeTrue();
     }
@@ -55,8 +57,10 @@ public sealed class GivenAnIconRailButton
     [AvaloniaFact]
     public void when_is_active_set_to_false_after_true_then_active_bar_becomes_hidden()
     {
-        var sut = new IconRailButton();
-        sut.IsActive = true;
+        var sut = new IconRailButton
+        {
+            IsActive = true
+        };
 
         sut.IsActive = false;
 
@@ -66,8 +70,10 @@ public sealed class GivenAnIconRailButton
     [AvaloniaFact]
     public void when_is_active_set_to_false_after_true_then_rail_button_loses_active_class()
     {
-        var sut = new IconRailButton();
-        sut.IsActive = true;
+        var sut = new IconRailButton
+        {
+            IsActive = true
+        };
 
         sut.IsActive = false;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
@@ -11,8 +11,10 @@ internal sealed class WireMockGraphClientFactory(WireMockServer server) : IGraph
     public GraphServiceClient CreateClient(string accessToken)
     {
         var authProvider = new BaseBearerTokenAuthenticationProvider(new TestTokenProvider(accessToken));
-        var adapter = new HttpClientRequestAdapter(authProvider);
-        adapter.BaseUrl = server.Url;
+        var adapter = new HttpClientRequestAdapter(authProvider)
+        {
+            BaseUrl = server.Url
+        };
 
         return new GraphServiceClient(adapter);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadService.cs
@@ -234,16 +234,24 @@ public sealed class GivenAnUploadService
 
     private static ResponseMessage Created201Response()
     {
-        var msg = new ResponseMessage { StatusCode = 201, Headers = JsonContentTypeHeaders() };
-        msg.BodyData = new BodyData { DetectedBodyType = WireMockBodyType.String, BodyAsString = ItemIdJson() };
+        var msg = new ResponseMessage
+        {
+            StatusCode = 201,
+            Headers = JsonContentTypeHeaders(),
+            BodyData = new BodyData { DetectedBodyType = WireMockBodyType.String, BodyAsString = ItemIdJson() }
+        };
 
         return msg;
     }
 
     private static ResponseMessage Ok200Response()
     {
-        var msg = new ResponseMessage { StatusCode = 200, Headers = JsonContentTypeHeaders() };
-        msg.BodyData = new BodyData { DetectedBodyType = WireMockBodyType.String, BodyAsString = ItemIdJson() };
+        var msg = new ResponseMessage
+        {
+            StatusCode = 200,
+            Headers = JsonContentTypeHeaders(),
+            BodyData = new BodyData { DetectedBodyType = WireMockBodyType.String, BodyAsString = ItemIdJson() }
+        };
 
         return msg;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Splash/GivenASplashWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Splash/GivenASplashWindowViewModel.cs
@@ -29,9 +29,10 @@ public sealed class GivenASplashWindowViewModel
     [Fact]
     public void when_status_is_set_then_new_value_is_returned()
     {
-        var sut = new Client.Splash.SplashWindowViewModel();
-
-        sut.Status = "Configuring database…";
+        var sut = new Client.Splash.SplashWindowViewModel
+        {
+            Status = "Configuring database…"
+        };
 
         sut.Status.ShouldBe("Configuring database…");
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRuleRowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRuleRowViewModel.cs
@@ -8,35 +8,102 @@ namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
 public sealed partial class FileClassificationRuleRowViewModel : ObservableObject
 {
     private readonly Func<int, Task> onDelete;
+    private readonly Func<int, FileClassificationRule, Task> onUpdate;
 
-    public FileClassificationRuleRowViewModel(int id, FileClassificationRule rule, Func<int, Task> onDelete)
+    private string originalKeywords;
+    private string originalLevel1;
+    private string originalLevel2;
+    private string originalLevel3;
+    private bool originalIsSpecial;
+
+    public FileClassificationRuleRowViewModel(int id, FileClassificationRule rule, Func<int, Task> onDelete, Func<int, FileClassificationRule, Task> onUpdate)
     {
         Id = id;
+        this.onDelete = onDelete;
+        this.onUpdate = onUpdate;
+
         Keywords = string.Join(", ", rule.Keywords);
         Level1 = rule.Classification.Level1;
         Level2 = rule.Classification.Level2.MapOrDefault(v => v, string.Empty);
         Level3 = rule.Classification.Level3.MapOrDefault(v => v, string.Empty);
         IsSpecial = rule.Classification.IsSpecial;
-        this.onDelete = onDelete;
+
+        originalKeywords = Keywords;
+        originalLevel1 = Level1;
+        originalLevel2 = Level2;
+        originalLevel3 = Level3;
+        originalIsSpecial = IsSpecial;
     }
 
     /// <summary>Database Id — used to identify the row for deletion.</summary>
     public int Id { get; }
 
-    /// <inheritdoc />
-    public string Keywords { get; }
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    public partial string Keywords { get; set; }
 
-    /// <inheritdoc />
-    public string Level1 { get; }
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveCommand))]
+    public partial string Level1 { get; set; }
 
-    /// <inheritdoc />
-    public string Level2 { get; }
+    [ObservableProperty]
+    public partial string Level2 { get; set; }
 
-    /// <inheritdoc />
-    public string Level3 { get; }
+    [ObservableProperty]
+    public partial string Level3 { get; set; }
 
-    /// <inheritdoc />
-    public bool IsSpecial { get; }
+    [ObservableProperty]
+    public partial bool IsSpecial { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsEditing { get; set; }
+
+    private bool CanSave => !string.IsNullOrWhiteSpace(Keywords) && !string.IsNullOrWhiteSpace(Level1);
+
+    [RelayCommand]
+    private Task EditAsync()
+    {
+        IsEditing = true;
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSave))]
+    private async Task SaveAsync()
+    {
+        var keywords = Keywords
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct()
+            .ToList()
+            .AsReadOnly();
+
+        var level2 = string.IsNullOrWhiteSpace(Level2) ? Option.None<string>() : Option.Some(Level2.Trim());
+        var level3 = string.IsNullOrWhiteSpace(Level3) ? Option.None<string>() : Option.Some(Level3.Trim());
+        var rule = FileClassificationRuleFactory.Create(
+            keywords,
+            FileClassificationFactory.Create(Level1.Trim(), level2, level3, IsSpecial));
+
+        await onUpdate(Id, rule);
+
+        originalKeywords = Keywords;
+        originalLevel1 = Level1;
+        originalLevel2 = Level2;
+        originalLevel3 = Level3;
+        originalIsSpecial = IsSpecial;
+        IsEditing = false;
+    }
+
+    [RelayCommand]
+    private Task CancelAsync()
+    {
+        Keywords = originalKeywords;
+        Level1 = originalLevel1;
+        Level2 = originalLevel2;
+        Level3 = originalLevel3;
+        IsSpecial = originalIsSpecial;
+        IsEditing = false;
+
+        return Task.CompletedTask;
+    }
 
     [RelayCommand]
     private Task DeleteAsync() => onDelete(Id);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -43,8 +43,8 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
     {
         var entries = await repository.GetAllWithIdsAsync(cancellationToken);
         Rules.Clear();
-        foreach(var entry in entries)
-            Rules.Add(new FileClassificationRuleRowViewModel(entry.Id, entry.Rule, DeleteRuleAsync));
+        foreach (var entry in entries)
+            Rules.Add(new FileClassificationRuleRowViewModel(entry.Id, entry.Rule, DeleteRuleAsync, UpdateRuleAsync));
     }
 
     private bool CanAdd => !string.IsNullOrWhiteSpace(NewKeywords) && !string.IsNullOrWhiteSpace(NewLevel1);
@@ -63,7 +63,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         var rule = FileClassificationRuleFactory.Create(keywords, classification);
 
         var id = await repository.AddAsync(rule);
-        Rules.Add(new FileClassificationRuleRowViewModel(id, rule, DeleteRuleAsync));
+        Rules.Add(new FileClassificationRuleRowViewModel(id, rule, DeleteRuleAsync, UpdateRuleAsync));
 
         NewKeywords = string.Empty;
         NewLevel1 = string.Empty;
@@ -72,11 +72,16 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         NewIsSpecial = false;
     }
 
+    private async Task UpdateRuleAsync(int id, FileClassificationRule rule)
+    {
+        await repository.UpdateAsync(id, rule, CancellationToken.None);
+    }
+
     private async Task DeleteRuleAsync(int id)
     {
         await repository.DeleteAsync(id);
         var row = Rules.FirstOrDefault(r => r.Id == id);
-        if(row is not null)
+        if (row is not null)
             Rules.Remove(row);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml
@@ -45,7 +45,9 @@
                                     Padding="12,8"
                                     Margin="0,0,0,6">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <StackPanel Grid.Column="0" Spacing="2">
+                                    <StackPanel Grid.Column="0"
+                                                Spacing="2"
+                                                IsVisible="{Binding !IsEditing}">
                                         <TextBlock FontSize="{StaticResource FontSizeSm}"
                                                    Foreground="{DynamicResource TextPrimaryBrush}">
                                             <Run FontWeight="Medium" Text="{Binding Keywords}"/>
@@ -68,16 +70,82 @@
                                                    IsVisible="{Binding IsSpecial}"/>
                                     </StackPanel>
 
-                                    <Button Grid.Column="1"
-                                            Content="Delete"
-                                            Padding="8,4"
-                                            CornerRadius="{StaticResource RadiusMd}"
-                                            Background="Transparent"
-                                            BorderBrush="{DynamicResource BorderDefaultBrush}"
-                                            BorderThickness="1"
-                                            FontSize="{StaticResource FontSizeXs}"
-                                            VerticalAlignment="Center"
-                                            Command="{Binding DeleteCommand}"/>
+                                    <StackPanel Grid.Column="0"
+                                                Spacing="8"
+                                                IsVisible="{Binding IsEditing}">
+                                        <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto,8,Auto">
+                                            <TextBox Grid.Row="0" Grid.Column="0"
+                                                     Text="{Binding Keywords}"
+                                                     PlaceholderText="Keywords (comma-separated)"
+                                                     FontSize="{StaticResource FontSizeSm}"
+                                                     CornerRadius="{StaticResource RadiusMd}"/>
+                                            <TextBox Grid.Row="0" Grid.Column="2"
+                                                     Text="{Binding Level1}"
+                                                     PlaceholderText="Level 1"
+                                                     FontSize="{StaticResource FontSizeSm}"
+                                                     CornerRadius="{StaticResource RadiusMd}"/>
+
+                                            <TextBox Grid.Row="2" Grid.Column="0"
+                                                     Text="{Binding Level2}"
+                                                     PlaceholderText="Level 2 (optional)"
+                                                     FontSize="{StaticResource FontSizeSm}"
+                                                     CornerRadius="{StaticResource RadiusMd}"/>
+                                            <TextBox Grid.Row="2" Grid.Column="2"
+                                                     Text="{Binding Level3}"
+                                                     PlaceholderText="Level 3 (optional)"
+                                                     FontSize="{StaticResource FontSizeSm}"
+                                                     CornerRadius="{StaticResource RadiusMd}"/>
+
+                                            <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
+                                                        Orientation="Horizontal"
+                                                        HorizontalAlignment="Right"
+                                                        Spacing="12">
+                                                <CheckBox Content="Special"
+                                                          IsChecked="{Binding IsSpecial}"
+                                                          FontSize="{StaticResource FontSizeSm}"
+                                                          VerticalAlignment="Center"/>
+                                                <Button Content="Cancel"
+                                                        Padding="12,6"
+                                                        CornerRadius="{StaticResource RadiusMd}"
+                                                        Background="Transparent"
+                                                        BorderBrush="{DynamicResource BorderDefaultBrush}"
+                                                        BorderThickness="1"
+                                                        FontSize="{StaticResource FontSizeSm}"
+                                                        Command="{Binding CancelCommand}"/>
+                                                <Button Content="Save"
+                                                        Padding="12,6"
+                                                        CornerRadius="{StaticResource RadiusMd}"
+                                                        Background="{DynamicResource TextAccentBrush}"
+                                                        Foreground="White"
+                                                        BorderThickness="0"
+                                                        FontSize="{StaticResource FontSizeSm}"
+                                                        Command="{Binding SaveCommand}"/>
+                                            </StackPanel>
+                                        </Grid>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Column="1"
+                                                Orientation="Horizontal"
+                                                Spacing="8"
+                                                VerticalAlignment="Center"
+                                                IsVisible="{Binding !IsEditing}">
+                                        <Button Content="Edit"
+                                                Padding="8,4"
+                                                CornerRadius="{StaticResource RadiusMd}"
+                                                Background="Transparent"
+                                                BorderBrush="{DynamicResource BorderDefaultBrush}"
+                                                BorderThickness="1"
+                                                FontSize="{StaticResource FontSizeXs}"
+                                                Command="{Binding EditCommand}"/>
+                                        <Button Content="Delete"
+                                                Padding="8,4"
+                                                CornerRadius="{StaticResource RadiusMd}"
+                                                Background="Transparent"
+                                                BorderBrush="{DynamicResource BorderDefaultBrush}"
+                                                BorderThickness="1"
+                                                FontSize="{StaticResource FontSizeXs}"
+                                                Command="{Binding DeleteCommand}"/>
+                                    </StackPanel>
                                 </Grid>
                             </Border>
                         </DataTemplate>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRuleRepository.cs
@@ -62,12 +62,29 @@ public sealed class FileClassificationRuleRepository(IDbContextFactory<AppDbCont
         return entity.Id;
     }
 
+    public async Task UpdateAsync(int id, FileClassificationRule rule, CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await db.FileClassificationRules.FindAsync([id], cancellationToken);
+        if (entity is null)
+            return;
+
+        entity.Keywords = string.Join('|', rule.Keywords);
+        entity.Level1 = rule.Classification.Level1;
+        entity.Level2 = rule.Classification.Level2.MapOrDefault(v => v, (string?)null);
+        entity.Level3 = rule.Classification.Level3.MapOrDefault(v => v, (string?)null);
+        entity.IsSpecial = rule.Classification.IsSpecial;
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         var entity = await db.FileClassificationRules.FindAsync([id], cancellationToken);
-        if(entity is null)
+        if (entity is null)
             return;
 
         db.FileClassificationRules.Remove(entity);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRuleRepository.cs
@@ -13,6 +13,9 @@ public interface IFileClassificationRuleRepository
     /// <summary>Persists a new rule and returns the assigned database Id.</summary>
     Task<int> AddAsync(FileClassificationRule rule, CancellationToken cancellationToken = default);
 
+    /// <summary>Updates the persisted rule with the specified Id.</summary>
+    Task UpdateAsync(int id, FileClassificationRule rule, CancellationToken cancellationToken = default);
+
     /// <summary>Removes the rule with the given Id. No-op if the Id does not exist.</summary>
     Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
Adds inline edit/save/cancel support for file classification rules, persists updates through the repository layer, and covers the behavior with unit tests.

## Verification
- `dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj --filter GivenAFileClassificationRulesViewModel` → 7 passed, 0 failed
- `dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj` → 954 passed, 0 failed

## Notes
- Approved by user for PR creation.