### PR TITLE
fix(apps/desktop): dashboard conflict count never decrements after resolution

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelTrackingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelTrackingConflicts.cs
@@ -1,0 +1,62 @@
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenADashboardViewModelTrackingConflicts
+{
+    private readonly ISyncScheduler _scheduler = Substitute.For<ISyncScheduler>();
+    private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    private DashboardViewModel CreateSut() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
+
+    private static OneDriveAccount CreateAccount(string id) => new() { Id = new AccountId(id) };
+
+    private static SyncConflict CreateConflict(string accountId) => new()
+    {
+        Id       = Guid.NewGuid(),
+        Remote   = RemoteItemRefFactory.Create(new AccountId(accountId), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)),
+        Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow.AddMinutes(-5), 0L),
+        State    = ConflictState.Pending
+    };
+
+    [Fact]
+    public void when_conflict_resolved_then_total_conflicts_decrements_to_zero()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        sut.AddAccount(CreateAccount("acc-1"));
+        var conflict = CreateConflict("acc-1");
+
+        _syncEventAggregator.ConflictDetected += Raise.Event<EventHandler<SyncConflict>>(this, conflict);
+        _syncEventAggregator.ConflictResolved += Raise.Event<EventHandler<SyncConflict>>(this, conflict);
+
+        sut.TotalConflicts.ShouldBe(0);
+    }
+
+    [Fact]
+    public void when_one_of_two_conflicts_resolved_then_total_conflicts_is_one()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        sut.AddAccount(CreateAccount("acc-1"));
+        var conflictA = CreateConflict("acc-1");
+        var conflictB = CreateConflict("acc-1");
+
+        _syncEventAggregator.ConflictDetected += Raise.Event<EventHandler<SyncConflict>>(this, conflictA);
+        _syncEventAggregator.ConflictDetected += Raise.Event<EventHandler<SyncConflict>>(this, conflictB);
+        _syncEventAggregator.ConflictResolved += Raise.Event<EventHandler<SyncConflict>>(this, conflictA);
+
+        sut.TotalConflicts.ShouldBe(1);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -103,4 +103,22 @@ public sealed class GivenASyncServiceResolvingConflicts
         captured.ShouldNotBeNull();
         captured.SyncState.ShouldBe(SyncState.Error);
     }
+
+    [Fact]
+    public async Task when_auth_succeeds_and_applier_succeeds_then_conflict_resolved_event_is_raised()
+    {
+        _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        var conflict = CreateConflict();
+        SyncConflict? resolved = null;
+        var sut = CreateSut();
+        sut.ConflictResolved += (_, c) => resolved = c;
+
+        await sut.ResolveConflictAsync(conflict, ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
+
+        resolved.ShouldNotBeNull();
+        resolved.Id.ShouldBe(conflict.Id);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncEventAggregator.cs
@@ -74,4 +74,18 @@ public sealed class GivenASyncEventAggregator
         captured.ShouldNotBeNull();
         captured.ShouldBe("acc-4");
     }
+
+    [Fact]
+    public void when_sync_service_raises_conflict_resolved_then_aggregator_raises_conflict_resolved()
+    {
+        var sut = CreateSut();
+        SyncConflict? captured = null;
+        sut.ConflictResolved += (_, conflict) => captured = conflict;
+        var conflict = new SyncConflict { Remote = RemoteItemRefFactory.Create(new AccountId("acc-5"), new OneDriveFolderId(string.Empty), new OneDriveItemId(string.Empty)) };
+
+        _syncService.ConflictResolved += Raise.Event<EventHandler<SyncConflict>>(this, conflict);
+
+        captured.ShouldNotBeNull();
+        captured.Remote.AccountId.Id.ShouldBe("acc-5");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -50,6 +50,7 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
         syncEventAggregator.JobCompleted += OnJobCompleted;
         syncEventAggregator.SyncCompleted += OnSyncCompleted;
         syncEventAggregator.ConflictDetected += OnConflictDetected;
+        syncEventAggregator.ConflictResolved += OnConflictResolved;
     }
 
     public void AddAccount(OneDriveAccount account)
@@ -134,6 +135,17 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
             return;
 
         section.UpdateSyncState(section.SyncState, section.ConflictCount + 1);
+
+        RecalculateGlobals();
+    }
+
+    private void OnConflictResolved(object? sender, SyncConflict conflict)
+    {
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == conflict.Remote.AccountId.Id);
+        if(section is null)
+            return;
+
+        section.UpdateSyncState(section.SyncState, Math.Max(0, section.ConflictCount - 1));
 
         RecalculateGlobals();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncService.cs
@@ -25,18 +25,15 @@ public interface ISyncService
     /// </summary>
     Task ResolveConflictAsync(SyncConflict conflict, ConflictPolicy policy, CancellationToken ct = default);
 
-    /// <summary>
-    /// Raised when sync progress updates are available for an account. This includes overall sync progress as well as granular progress for individual file jobs.
-    /// </summary>
+    /// <summary>Raised when sync progress updates are available for an account. This includes overall sync progress as well as granular progress for individual file jobs.</summary>
     event EventHandler<SyncProgressEventArgs> SyncProgressChanged;
 
-    /// <summary>
-    /// Raised when an individual file sync job completes, providing details about the completed job and its result. This allows subscribers to react to specific file operations completing, such as updating the UI or triggering follow-up actions.
-    /// </summary>
+    /// <summary>Raised when an individual file sync job completes, providing details about the completed job and its result. This allows subscribers to react to specific file operations completing, such as updating the UI or triggering follow-up actions.</summary>
     event EventHandler<JobCompletedEventArgs> JobCompleted;
 
-    /// <summary>
-    /// Raised when a sync conflict is detected during the sync process. Subscribers can handle this event to present conflict resolution options to the user or to automatically apply a resolution policy. The event args will include details about the conflict, such as the account, file, and nature of the conflict.
-    /// </summary>
+    /// <summary>Raised when a sync conflict is detected during the sync process. Subscribers can handle this event to present conflict resolution options to the user or to automatically apply a resolution policy. The event args will include details about the conflict, such as the account, file, and nature of the conflict.</summary>
     event EventHandler<SyncConflict> ConflictDetected;
+
+    /// <summary>Raised when a pending conflict has been successfully resolved and persisted.</summary>
+    event EventHandler<SyncConflict> ConflictResolved;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncEventAggregator.cs
@@ -20,6 +20,9 @@ public interface ISyncEventAggregator
     /// <summary>Raised when a new conflict is detected and queued.</summary>
     event EventHandler<SyncConflict> ConflictDetected;
 
+    /// <summary>Raised when a pending conflict has been successfully resolved and persisted.</summary>
+    event EventHandler<SyncConflict> ConflictResolved;
+
     /// <summary>Raised when a full sync pass for an account has completed.</summary>
     event EventHandler<string> SyncCompleted;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncEventAggregator.cs
@@ -23,6 +23,9 @@ public sealed class SyncEventAggregator : ISyncEventAggregator
     public event EventHandler<SyncConflict>? ConflictDetected;
 
     /// <inheritdoc />
+    public event EventHandler<SyncConflict>? ConflictResolved;
+
+    /// <inheritdoc />
     public event EventHandler<string>? SyncCompleted;
 
     public SyncEventAggregator(ISyncService syncService, ISyncScheduler scheduler, IUiDispatcher dispatcher)
@@ -32,6 +35,7 @@ public sealed class SyncEventAggregator : ISyncEventAggregator
         syncService.SyncProgressChanged += OnSyncProgressChanged;
         syncService.JobCompleted += OnJobCompleted;
         syncService.ConflictDetected += OnConflictDetected;
+        syncService.ConflictResolved += OnConflictResolved;
         scheduler.SyncCompleted += OnSyncCompleted;
     }
 
@@ -40,6 +44,8 @@ public sealed class SyncEventAggregator : ISyncEventAggregator
     private void OnJobCompleted(object? sender, JobCompletedEventArgs args) => _dispatcher.Post(() => JobCompleted?.Invoke(this, args));
 
     private void OnConflictDetected(object? sender, SyncConflict conflict) => _dispatcher.Post(() => ConflictDetected?.Invoke(this, conflict));
+
+    private void OnConflictResolved(object? sender, SyncConflict conflict) => _dispatcher.Post(() => ConflictResolved?.Invoke(this, conflict));
 
     private void OnSyncCompleted(object? sender, string accountId) => _dispatcher.Post(() => SyncCompleted?.Invoke(this, accountId));
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -24,6 +24,9 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
     public event EventHandler<SyncConflict>? ConflictDetected;
 
     /// <inheritdoc />
+    public event EventHandler<SyncConflict>? ConflictResolved;
+
+    /// <inheritdoc />
     public async Task SyncAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
         OneDriveSyncClientMessages.SyncServiceStarting(logger, account.Profile.Email);
@@ -101,6 +104,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
         }
 
         await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
+        ConflictResolved?.Invoke(this, conflict);
     }
 
     private void RaiseProgress(string accountId, int completed, int total, string currentFile, SyncState syncState)


### PR DESCRIPTION
## Summary

- `ISyncService` had no `ConflictResolved` event — after a user resolved a conflict the dashboard count could only ever go up, never down
- Added `ConflictResolved` event to `ISyncService`, `ISyncEventAggregator`, and `SyncEventAggregator` (same forwarding pattern as `ConflictDetected`)
- `DashboardViewModel.SubscribeToSyncEvents` now subscribes to `ConflictResolved` and decrements the per-account and global conflict counts

## Test plan

- [ ] `GivenASyncServiceResolvingConflicts.when_auth_succeeds_and_applier_succeeds_then_conflict_resolved_event_is_raised` — proves `SyncService` fires the event
- [ ] `GivenASyncEventAggregator.when_sync_service_raises_conflict_resolved_then_aggregator_raises_conflict_resolved` — proves the aggregator forwards it
- [ ] `GivenADashboardViewModelTrackingConflicts.when_conflict_resolved_then_total_conflicts_decrements_to_zero` — proves the dashboard count goes back to 0
- [ ] `GivenADashboardViewModelTrackingConflicts.when_one_of_two_conflicts_resolved_then_total_conflicts_is_one` — proves partial resolution works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)