### PR TITLE
fix(apps/desktop): localise hard-coded time strings in AccountCardViewModel (#336)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountCardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountCardViewModel.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Avalonia.Media;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
@@ -12,8 +13,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_constructed_then_is_active_is_synchronized_from_model()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-1"), IsActive = true };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.IsActive.ShouldBeTrue();
     }
@@ -22,97 +24,105 @@ public sealed class GivenAnAccountCardViewModel
     public void when_constructed_with_inactive_model_then_is_active_is_false()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-2"), IsActive = false };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.IsActive.ShouldBeFalse();
     }
 
     [Fact]
-    public void when_constructed_with_no_sync_history_then_last_sync_text_is_never_synced()
+    public void when_constructed_with_no_sync_history_then_localization_receives_never_synced_key()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-3"), LastSyncedAt = null };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("Never synced");
+        localization.Received(1).GetLocal("Common.NeverSynced");
     }
 
     [Fact]
-    public void when_constructed_with_recent_sync_within_two_minutes_then_last_sync_text_is_just_now()
+    public void when_constructed_with_recent_sync_within_two_minutes_then_localization_receives_just_now_key()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-4"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("Just now");
+        localization.Received(1).GetLocal("Common.JustNow");
     }
 
     [Fact]
-    public void when_last_synced_thirty_minutes_ago_then_last_sync_text_shows_minutes()
+    public void when_last_synced_thirty_minutes_ago_then_localization_receives_minutes_ago_key()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-5"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-30)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("30m ago");
+        localization.Received(1).GetLocal("Common.MinutesAgo", Arg.Any<object[]>());
     }
 
     [Fact]
-    public void when_last_synced_three_hours_ago_then_last_sync_text_shows_hours()
+    public void when_last_synced_three_hours_ago_then_localization_receives_hours_ago_key()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-6"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-3)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("3h ago");
+        localization.Received(1).GetLocal("Common.HoursAgo", Arg.Any<object[]>());
     }
 
     [Fact]
-    public void when_last_synced_yesterday_then_last_sync_text_is_yesterday()
+    public void when_last_synced_yesterday_then_localization_receives_yesterday_key()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-7"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-24)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("Yesterday");
+        localization.Received(1).GetLocal("Common.Yesterday");
     }
 
     [Fact]
-    public void when_last_synced_five_days_ago_then_last_sync_text_shows_days()
+    public void when_last_synced_five_days_ago_then_localization_receives_days_ago_key()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-8"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-5)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("5d ago");
+        localization.Received(1).GetLocal("Common.DaysAgo", Arg.Any<object[]>());
     }
 
     [Fact]
     public void when_select_command_is_executed_then_selected_event_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-9") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool eventRaised = false;
         AccountCardViewModel? raisedViewModel = null;
 
@@ -132,7 +142,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_remove_command_is_executed_then_remove_requested_event_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-10") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool eventRaised = false;
         AccountCardViewModel? raisedViewModel = null;
 
@@ -152,7 +163,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_refresh_from_model_called_with_updated_is_active_then_is_active_is_updated()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-11"), IsActive = true };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
 
         model.IsActive = false;
         sut.RefreshFromModel();
@@ -164,7 +176,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_refresh_from_model_called_then_display_name_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-12"), Profile = AccountProfileFactory.Create("Alice", string.Empty) };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -182,7 +195,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_refresh_from_model_called_then_email_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-13"), Profile = AccountProfileFactory.Create(string.Empty, "alice@outlook.com") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -200,7 +214,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_refresh_from_model_called_then_initials_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-14"), Profile = AccountProfileFactory.Create("Bob Smith", string.Empty) };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -218,7 +233,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_is_active_is_changed_then_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-15"), IsActive = false };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -236,7 +252,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_sync_state_is_changed_then_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-16") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -254,7 +271,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_conflict_count_is_changed_then_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-17") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -272,7 +290,8 @@ public sealed class GivenAnAccountCardViewModel
     public void when_last_sync_text_is_changed_then_property_changed_is_raised()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-18") };
-        var sut = new AccountCardViewModel(model);
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
         bool propertyChangedRaised = false;
 
         sut.PropertyChanged += (sender, args) =>
@@ -290,8 +309,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_display_name_has_two_parts_then_initials_are_first_letter_of_each()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-19"), Profile = AccountProfileFactory.Create("Alice Smith", string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("AS");
     }
@@ -300,8 +320,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_display_name_is_single_word_then_initials_are_first_letter()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-20"), Profile = AccountProfileFactory.Create("Alice", string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("A");
     }
@@ -310,8 +331,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_display_name_is_empty_and_email_provided_then_initials_are_first_letter_of_email()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-21"), Profile = AccountProfileFactory.Create(string.Empty, "bob@outlook.com") };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("B");
     }
@@ -320,8 +342,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_display_name_and_email_are_empty_then_initials_are_question_mark()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-22"), Profile = AccountProfileFactory.Create(string.Empty, string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("?");
     }
@@ -330,8 +353,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_display_name_has_multiple_words_then_initials_use_first_and_last()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-23"), Profile = AccountProfileFactory.Create("John Michael Smith", string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("JS");
     }
@@ -340,8 +364,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_initials_are_derived_from_display_name_then_they_are_uppercase()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-24"), Profile = AccountProfileFactory.Create("alice smith", string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("AS");
     }
@@ -350,8 +375,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_initials_are_derived_from_email_then_they_are_uppercase()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-25"), Profile = AccountProfileFactory.Create(string.Empty, "alice@outlook.com") };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("A");
     }
@@ -360,8 +386,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_accent_index_is_zero_then_accent_hex_returns_first_palette_color()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-26"), AccentIndex = 0 };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.AccentHex.ShouldBe("#185FA5");
     }
@@ -370,8 +397,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_accent_index_is_beyond_palette_length_then_accent_hex_wraps_around()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-27"), AccentIndex = 6 };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.AccentHex.ShouldBe("#185FA5");
     }
@@ -380,8 +408,9 @@ public sealed class GivenAnAccountCardViewModel
     public void when_accent_index_is_five_then_accent_hex_returns_last_palette_color()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-28"), AccentIndex = 5 };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.AccentHex.ShouldBe("#854F0B");
     }
@@ -390,94 +419,117 @@ public sealed class GivenAnAccountCardViewModel
     public void when_accent_color_is_queried_then_it_returns_parsed_color_from_hex()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-29"), AccentIndex = 0 };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         var expectedColor = Color.Parse("#185FA5");
         sut.AccentColor.ShouldBe(expectedColor);
     }
 
     [Fact]
-    public void when_last_synced_exactly_two_minutes_ago_then_text_shows_minutes_not_just_now()
+    public void when_last_synced_exactly_two_minutes_ago_then_localization_receives_minutes_ago_key_not_just_now()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-31"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-2)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("2m ago");
+        localization.Received(1).GetLocal("Common.MinutesAgo", Arg.Any<object[]>());
+        localization.DidNotReceive().GetLocal("Common.JustNow");
     }
 
     [Fact]
-    public void when_last_synced_exactly_one_hour_ago_then_text_shows_hours_not_minutes()
+    public void when_last_synced_exactly_one_hour_ago_then_localization_receives_hours_ago_key_not_minutes()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-32"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-1)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("1h ago");
+        localization.Received(1).GetLocal("Common.HoursAgo", Arg.Any<object[]>());
+        localization.DidNotReceive().GetLocal("Common.MinutesAgo", Arg.Any<object[]>());
     }
 
     [Fact]
-    public void when_last_synced_exactly_one_day_ago_then_text_is_yesterday_not_hours()
+    public void when_last_synced_exactly_one_day_ago_then_localization_receives_yesterday_key_not_hours()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-33"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-1)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("Yesterday");
+        localization.Received(1).GetLocal("Common.Yesterday");
+        localization.DidNotReceive().GetLocal("Common.HoursAgo", Arg.Any<object[]>());
     }
 
     [Fact]
-    public void when_last_synced_exactly_two_days_ago_then_text_shows_days_not_yesterday()
+    public void when_last_synced_exactly_two_days_ago_then_localization_receives_days_ago_key_not_yesterday()
     {
         var model = new OneDriveAccount
         {
             Id = new AccountId("account-34"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-2)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        _ = new AccountCardViewModel(model, localization);
 
-        sut.LastSyncText.ShouldBe("2d ago");
+        localization.Received(1).GetLocal("Common.DaysAgo", Arg.Any<object[]>());
+        localization.DidNotReceive().GetLocal("Common.Yesterday");
     }
 
     [Fact]
-    public void when_refresh_from_model_is_called_then_last_sync_text_is_recalculated()
+    public void when_constructed_with_sync_within_two_minutes_then_just_now_key_is_looked_up()
     {
         var model = new OneDriveAccount
         {
-            Id = new AccountId("account-35"),
+            Id = new AccountId("account-35a"),
             LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
         };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
-        sut.LastSyncText.ShouldBe("Just now");
+        _ = new AccountCardViewModel(model, localization);
 
-        // Simulate time passing by updating the model's LastSyncedAt
+        localization.Received(1).GetLocal("Common.JustNow");
+    }
+
+    [Fact]
+    public void when_refresh_from_model_is_called_after_time_passes_then_minutes_ago_key_is_looked_up()
+    {
+        var model = new OneDriveAccount
+        {
+            Id = new AccountId("account-35b"),
+            LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+        };
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = new AccountCardViewModel(model, localization);
+
         model.LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
         sut.RefreshFromModel();
 
-        sut.LastSyncText.ShouldBe("5m ago");
+        localization.Received(1).GetLocal("Common.MinutesAgo", Arg.Any<object[]>());
     }
 
     [Fact]
     public void when_display_name_contains_extra_whitespace_then_initials_ignore_empty_parts()
     {
         var model = new OneDriveAccount { Id = new AccountId("account-36"), Profile = AccountProfileFactory.Create("Alice    Smith", string.Empty) };
+        var localization = Substitute.For<ILocalizationService>();
 
-        var sut = new AccountCardViewModel(model);
+        var sut = new AccountCardViewModel(model, localization);
 
         sut.Initials.ShouldBe("AS");
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
@@ -100,5 +101,5 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     }
 
     private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService onboardingService)
-        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>(), Substitute.For<ILogger<AccountsViewModel>>());
+        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>(), Substitute.For<ILocalizationService>(), Substitute.For<ILogger<AccountsViewModel>>());
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -42,7 +42,7 @@ public sealed class GivenAMainWindowViewModel
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);
@@ -128,7 +128,7 @@ public sealed class GivenAMainWindowViewModel
     {
         const string accountIdStr = "active-account-123";
         var accountsVm = CreateAccountsViewModel();
-        accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test User", "test@example.com") });
+        accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test User", "test@example.com") }, _localizationService);
         var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), CreateClassificationRulesViewModel(), new StatusBarViewModel(accountsVm), Substitute.For<ILogger<MainWindowViewModel>>());
 
         await sut.SyncNowCommand.ExecuteAsync(null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -7,6 +7,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
@@ -17,10 +18,11 @@ public sealed class GivenAStatusBarViewModel
     private readonly IGraphService _graphService = Substitute.For<IGraphService>();
     private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
     private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
 
-    private static AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) });
+    private AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) }, _localizationService);
 
     [Fact]
     public void when_active_account_is_null_then_has_account_is_false()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -67,7 +67,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
 
     private MainWindowViewModel CreateMainWindowViewModel()
     {
-        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator, localizationService, Substitute.For<ILogger<AccountsViewModel>>());
         var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
         var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -42,7 +42,7 @@ public sealed class GivenAnApplicationInitializer
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>());
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountCardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountCardViewModel.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -12,6 +13,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 public sealed partial class AccountCardViewModel : ObservableObject
 {
     private readonly OneDriveAccount _model;
+    private readonly ILocalizationService _localizationService;
 
     private static readonly string[] _palette =
     [
@@ -83,9 +85,10 @@ public sealed partial class AccountCardViewModel : ObservableObject
     [RelayCommand]
     private void Remove() => RemoveRequested?.Invoke(this, this);
 
-    public AccountCardViewModel(OneDriveAccount model)
+    public AccountCardViewModel(OneDriveAccount model, ILocalizationService localizationService)
     {
         _model = model;
+        _localizationService = localizationService;
         IsActive = model.IsActive;
         UpdateLastSyncText();
     }
@@ -102,18 +105,18 @@ public sealed partial class AccountCardViewModel : ObservableObject
 
     private void UpdateLastSyncText()
     {
-        if(_model.LastSyncedAt is not Option<DateTimeOffset>.Some lastSyncedAt)
+        if (_model.LastSyncedAt is not Option<DateTimeOffset>.Some lastSyncedAt)
         {
-            LastSyncText = "Never synced";
+            LastSyncText = _localizationService.GetLocal("Common.NeverSynced");
             return;
         }
 
         var elapsed = DateTimeOffset.UtcNow - lastSyncedAt.Value;
-        LastSyncText = elapsed.TotalMinutes < 2 ? "Just now"
-                     : elapsed.TotalHours < 1 ? $"{(int)elapsed.TotalMinutes}m ago"
-                     : elapsed.TotalDays < 1 ? $"{(int)elapsed.TotalHours}h ago"
-                     : elapsed.TotalDays < 2 ? "Yesterday"
-                     : $"{(int)elapsed.TotalDays}d ago";
+        LastSyncText = elapsed.TotalMinutes < 2 ? _localizationService.GetLocal("Common.JustNow")
+                     : elapsed.TotalHours < 1 ? _localizationService.GetLocal("Common.MinutesAgo", (int)elapsed.TotalMinutes)
+                     : elapsed.TotalDays < 1 ? _localizationService.GetLocal("Common.HoursAgo", (int)elapsed.TotalHours)
+                     : elapsed.TotalDays < 2 ? _localizationService.GetLocal("Common.Yesterday")
+                     : _localizationService.GetLocal("Common.DaysAgo", (int)elapsed.TotalDays);
     }
 
     /// <summary>Returns the palette colour for the given index.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -11,6 +11,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
@@ -18,9 +19,10 @@ using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator, ILogger<AccountsViewModel> logger) : ObservableObject
+public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator, ILocalizationService localizationService, ILogger<AccountsViewModel> logger) : ObservableObject
 {
     private readonly ILogger<AccountsViewModel> _logger = logger;
+    private readonly ILocalizationService _localizationService = localizationService;
 
     public ObservableCollection<AccountCardViewModel> Accounts { get; } = [];
 
@@ -194,7 +196,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     private AccountCardViewModel BuildCard(OneDriveAccount account)
     {
-        var card = new AccountCardViewModel(account);
+        var card = new AccountCardViewModel(account, _localizationService);
         card.Selected += OnCardSelected;
         card.RemoveRequested += (_, accountCard) => RemoveAccountCommand.Execute(accountCard);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -113,6 +113,7 @@
   "Common.No": "No",
   "Common.Unknown": "Unknown",
   "Common.Never": "Never",
+  "Common.NeverSynced": "Never synced",
   "Common.JustNow": "Just now",
   "Common.MinutesAgo": "{0} minutes ago",
   "Common.HoursAgo": "{0} hours ago",


### PR DESCRIPTION
## Summary

- Inject `ILocalizationService` into `AccountCardViewModel` via constructor
- Replace all five hard-coded English time strings in `UpdateLastSyncText` with `_localizationService.GetLocal(key)` calls using `Common.JustNow`, `Common.MinutesAgo`, `Common.HoursAgo`, `Common.Yesterday`, `Common.DaysAgo`, `Common.NeverSynced`
- Add missing `Common.NeverSynced` key to `en-GB.json`
- Thread `ILocalizationService` through `AccountsViewModel.BuildCard` and all affected test helpers

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 959 passed, 0 failed
- [x] All `LastSyncText` tests assert `localization.Received(1).GetLocal("Common.*")` — not literal values
- [x] Boundary tests include `DidNotReceive` companions to verify correct time band selection
- [x] All other test helpers (`GivenAnAccountsViewModel...`, `GivenAStatusBarViewModel`, etc.) updated to pass mock `ILocalizationService`

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)