### PR TITLE
fix(apps/desktop): localise hard-coded strings in ActivityItemViewModel (#338)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityItemViewModel.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
@@ -15,6 +16,14 @@ public sealed class GivenAnActivityItemViewModel
     private const string FileNameValue = "report.pdf";
     private const string ErrorMessageValue = "Network timeout";
     private const long FileSizeValue = 2048L;
+
+    private static ILocalizationService BuildLocalizationService()
+    {
+        var loc = Substitute.For<ILocalizationService>();
+        loc.GetLocal(Arg.Any<string>()).Returns(callInfo => (string)callInfo[0]);
+
+        return loc;
+    }
 
     private static SyncJob BuildSyncJob(SyncDirection direction = SyncDirection.Download, string relativePath = RelativePathValue, DateTimeOffset? completedAt = null, string? errorMessage = null)
     {
@@ -43,65 +52,142 @@ public sealed class GivenAnActivityItemViewModel
     };
 
     [Fact]
-    public void when_type_is_downloaded_then_type_label_returns_downloaded() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Downloaded }.TypeLabel.ShouldBe("downloaded");
+    public void when_type_is_downloaded_then_type_label_returns_activity_downloaded_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Downloaded }.TypeLabel.ShouldBe("Activity.Downloaded");
 
     [Fact]
-    public void when_type_is_uploaded_then_type_label_returns_uploaded() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Uploaded }.TypeLabel.ShouldBe("uploaded");
+    public void when_type_is_uploaded_then_type_label_returns_activity_uploaded_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Uploaded }.TypeLabel.ShouldBe("Activity.Uploaded");
 
     [Fact]
-    public void when_type_is_deleted_then_type_label_returns_deleted() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Deleted }.TypeLabel.ShouldBe("deleted");
+    public void when_type_is_deleted_then_type_label_returns_activity_deleted_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Deleted }.TypeLabel.ShouldBe("Activity.Deleted");
 
     [Fact]
-    public void when_type_is_conflict_then_type_label_returns_conflict() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Conflict }.TypeLabel.ShouldBe("conflict");
+    public void when_type_is_conflict_then_type_label_returns_activity_conflict_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Conflict }.TypeLabel.ShouldBe("Activity.Conflict");
 
     [Fact]
-    public void when_type_is_error_then_type_label_returns_error() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Error }.TypeLabel.ShouldBe("error");
+    public void when_type_is_error_then_type_label_returns_activity_error_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Error }.TypeLabel.ShouldBe("Activity.Error");
 
     [Fact]
-    public void when_type_is_info_then_type_label_returns_info() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Info }.TypeLabel.ShouldBe("info");
+    public void when_type_is_info_then_type_label_returns_activity_info_key() =>
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Info }.TypeLabel.ShouldBe("Activity.Info");
+
+    [Fact]
+    public void when_type_is_downloaded_then_type_label_calls_get_local_with_activity_downloaded_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Downloaded };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Downloaded");
+    }
+
+    [Fact]
+    public void when_type_is_uploaded_then_type_label_calls_get_local_with_activity_uploaded_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Uploaded };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Uploaded");
+    }
+
+    [Fact]
+    public void when_type_is_deleted_then_type_label_calls_get_local_with_activity_deleted_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Deleted };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Deleted");
+    }
+
+    [Fact]
+    public void when_type_is_conflict_then_type_label_calls_get_local_with_activity_conflict_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Conflict };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Conflict");
+    }
+
+    [Fact]
+    public void when_type_is_error_then_type_label_calls_get_local_with_activity_error_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Error };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Error");
+    }
+
+    [Fact]
+    public void when_type_is_info_then_type_label_calls_get_local_with_activity_info_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { Type = ActivityItemType.Info };
+
+        _ = sut.TypeLabel;
+
+        loc.Received(1).GetLocal("Activity.Info");
+    }
 
     [Fact]
     public void when_type_is_downloaded_then_type_icon_returns_down_arrow() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Downloaded }.TypeIcon.ShouldBe("↓");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Downloaded }.TypeIcon.ShouldBe("↓");
 
     [Fact]
     public void when_type_is_uploaded_then_type_icon_returns_up_arrow() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Uploaded }.TypeIcon.ShouldBe("↑");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Uploaded }.TypeIcon.ShouldBe("↑");
 
     [Fact]
     public void when_type_is_deleted_then_type_icon_returns_multiplication_sign() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Deleted }.TypeIcon.ShouldBe("×");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Deleted }.TypeIcon.ShouldBe("×");
 
     [Fact]
     public void when_type_is_conflict_then_type_icon_returns_warning_sign() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Conflict }.TypeIcon.ShouldBe("⚠");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Conflict }.TypeIcon.ShouldBe("⚠");
 
     [Fact]
     public void when_type_is_error_then_type_icon_returns_warning_sign() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Error }.TypeIcon.ShouldBe("⚠");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Error }.TypeIcon.ShouldBe("⚠");
 
     [Fact]
     public void when_type_is_info_then_type_icon_returns_bullet() =>
-        new ActivityItemViewModel { Type = ActivityItemType.Info }.TypeIcon.ShouldBe("•");
+        new ActivityItemViewModel(BuildLocalizationService()) { Type = ActivityItemType.Info }.TypeIcon.ShouldBe("•");
 
     [Fact]
-    public void when_occurred_at_is_30_seconds_ago_then_time_ago_text_returns_just_now()
+    public void when_occurred_at_is_30_seconds_ago_then_time_ago_text_returns_common_just_now_key()
     {
-        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { OccurredAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
 
-        sut.TimeAgoText.ShouldBe("just now");
+        sut.TimeAgoText.ShouldBe("Common.JustNow");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_under_60s_then_time_ago_text_calls_get_local_with_common_just_now_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { OccurredAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
+
+        _ = sut.TimeAgoText;
+
+        loc.Received(1).GetLocal("Common.JustNow");
     }
 
     [Fact]
     public void when_occurred_at_is_5_minutes_ago_then_time_ago_text_returns_minutes_ago()
     {
-        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddMinutes(-5) };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { OccurredAt = DateTimeOffset.UtcNow.AddMinutes(-5) };
 
         sut.TimeAgoText.ShouldBe("5m ago");
     }
@@ -109,23 +195,34 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_occurred_at_is_3_hours_ago_then_time_ago_text_returns_hours_ago()
     {
-        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddHours(-3) };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { OccurredAt = DateTimeOffset.UtcNow.AddHours(-3) };
 
         sut.TimeAgoText.ShouldBe("3h ago");
     }
 
     [Fact]
-    public void when_occurred_at_is_25_hours_ago_then_time_ago_text_returns_yesterday()
+    public void when_occurred_at_is_25_hours_ago_then_time_ago_text_returns_common_yesterday_key()
     {
-        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddHours(-25) };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { OccurredAt = DateTimeOffset.UtcNow.AddHours(-25) };
 
-        sut.TimeAgoText.ShouldBe("yesterday");
+        sut.TimeAgoText.ShouldBe("Common.Yesterday");
+    }
+
+    [Fact]
+    public void when_occurred_at_is_between_1_and_2_days_then_time_ago_text_calls_get_local_with_common_yesterday_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ActivityItemViewModel(loc) { OccurredAt = DateTimeOffset.UtcNow.AddHours(-25) };
+
+        _ = sut.TimeAgoText;
+
+        loc.Received(1).GetLocal("Common.Yesterday");
     }
 
     [Fact]
     public void when_occurred_at_is_5_days_ago_then_time_ago_text_returns_days_ago()
     {
-        var sut = new ActivityItemViewModel { OccurredAt = DateTimeOffset.UtcNow.AddDays(-5) };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { OccurredAt = DateTimeOffset.UtcNow.AddDays(-5) };
 
         sut.TimeAgoText.ShouldBe("5d ago");
     }
@@ -133,7 +230,7 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_file_size_is_non_zero_then_file_size_text_returns_non_empty_string()
     {
-        var sut = new ActivityItemViewModel { FileSize = FileSizeValue };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { FileSize = FileSizeValue };
 
         sut.FileSizeText.ShouldNotBeNullOrEmpty();
     }
@@ -141,7 +238,7 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_file_size_is_zero_then_file_size_text_returns_non_null_string()
     {
-        var sut = new ActivityItemViewModel { FileSize = 0L };
+        var sut = new ActivityItemViewModel(BuildLocalizationService()) { FileSize = 0L };
 
         sut.FileSizeText.ShouldNotBeNull();
     }
@@ -151,7 +248,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(direction: SyncDirection.Download);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.Type.ShouldBe(ActivityItemType.Downloaded);
     }
@@ -161,7 +258,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(direction: SyncDirection.Upload);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.Type.ShouldBe(ActivityItemType.Uploaded);
     }
@@ -171,7 +268,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(direction: SyncDirection.Delete);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.Type.ShouldBe(ActivityItemType.Deleted);
     }
@@ -181,7 +278,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob();
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.AccountId.ShouldBe(AccountIdValue);
     }
@@ -191,7 +288,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob();
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.AccountEmail.ShouldBe(AccountEmailValue);
     }
@@ -201,7 +298,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob();
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.FolderName.ShouldBe(FolderNameValue);
     }
@@ -211,7 +308,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(relativePath: RelativePathValue);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.FileName.ShouldBe(FileNameValue);
     }
@@ -221,7 +318,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(relativePath: RelativePathValue);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.RelativePath.ShouldBe(RelativePathValue);
     }
@@ -231,7 +328,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob();
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.FileSize.ShouldBe(FileSizeValue);
     }
@@ -241,7 +338,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob(errorMessage: ErrorMessageValue);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.ErrorMessage.ShouldBe(ErrorMessageValue);
     }
@@ -252,7 +349,7 @@ public sealed class GivenAnActivityItemViewModel
         var completedAt = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
         var job = BuildSyncJob(completedAt: completedAt);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.OccurredAt.ShouldBe(completedAt);
     }
@@ -263,7 +360,7 @@ public sealed class GivenAnActivityItemViewModel
         var before = DateTimeOffset.UtcNow;
         var job = BuildSyncJob(completedAt: null);
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         var after = DateTimeOffset.UtcNow;
         result.OccurredAt.ShouldBeInRange(before, after);
@@ -274,7 +371,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var job = BuildSyncJob();
 
-        var result = ActivityItemViewModel.FromJob(job, AccountEmailValue);
+        var result = ActivityItemViewModel.FromJob(job, BuildLocalizationService(), AccountEmailValue);
 
         result.FolderName.ShouldBe(string.Empty);
     }
@@ -284,7 +381,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict();
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.Type.ShouldBe(ActivityItemType.Conflict);
     }
@@ -294,7 +391,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict();
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.AccountId.ShouldBe(AccountIdValue);
     }
@@ -304,7 +401,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict();
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.AccountEmail.ShouldBe(AccountEmailValue);
     }
@@ -314,7 +411,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict();
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.FolderName.ShouldBe(FolderNameValue);
     }
@@ -324,7 +421,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict(relativePath: RelativePathValue);
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.FileName.ShouldBe(FileNameValue);
     }
@@ -334,7 +431,7 @@ public sealed class GivenAnActivityItemViewModel
     {
         var conflict = BuildSyncConflict(relativePath: RelativePathValue);
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.RelativePath.ShouldBe(RelativePathValue);
     }
@@ -345,7 +442,7 @@ public sealed class GivenAnActivityItemViewModel
         var detectedAt = new DateTimeOffset(2026, 3, 10, 8, 0, 0, TimeSpan.Zero);
         var conflict = BuildSyncConflict(detectedAt: detectedAt);
 
-        var result = ActivityItemViewModel.FromConflict(conflict, AccountEmailValue, FolderNameValue);
+        var result = ActivityItemViewModel.FromConflict(conflict, BuildLocalizationService(), AccountEmailValue, FolderNameValue);
 
         result.OccurredAt.ShouldBe(detectedAt);
     }
@@ -353,7 +450,7 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_error_factory_is_called_then_type_is_error()
     {
-        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+        var result = ActivityItemViewModel.Error(AccountIdValue, BuildLocalizationService(), AccountEmailValue, ErrorMessageValue);
 
         result.Type.ShouldBe(ActivityItemType.Error);
     }
@@ -361,7 +458,7 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_error_factory_is_called_then_account_id_is_set_correctly()
     {
-        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+        var result = ActivityItemViewModel.Error(AccountIdValue, BuildLocalizationService(), AccountEmailValue, ErrorMessageValue);
 
         result.AccountId.ShouldBe(AccountIdValue);
     }
@@ -369,7 +466,7 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_error_factory_is_called_then_account_email_is_set_correctly()
     {
-        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+        var result = ActivityItemViewModel.Error(AccountIdValue, BuildLocalizationService(), AccountEmailValue, ErrorMessageValue);
 
         result.AccountEmail.ShouldBe(AccountEmailValue);
     }
@@ -377,16 +474,26 @@ public sealed class GivenAnActivityItemViewModel
     [Fact]
     public void when_error_factory_is_called_then_error_message_is_set_correctly()
     {
-        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+        var result = ActivityItemViewModel.Error(AccountIdValue, BuildLocalizationService(), AccountEmailValue, ErrorMessageValue);
 
         result.ErrorMessage.ShouldBe(ErrorMessageValue);
     }
 
     [Fact]
-    public void when_error_factory_is_called_then_file_name_is_sync_error()
+    public void when_error_factory_is_called_then_file_name_is_activity_sync_error_key()
     {
-        var result = ActivityItemViewModel.Error(AccountIdValue, AccountEmailValue, ErrorMessageValue);
+        var result = ActivityItemViewModel.Error(AccountIdValue, BuildLocalizationService(), AccountEmailValue, ErrorMessageValue);
 
-        result.FileName.ShouldBe("Sync error");
+        result.FileName.ShouldBe("Activity.SyncError");
+    }
+
+    [Fact]
+    public void when_error_factory_is_called_then_file_name_calls_get_local_with_activity_sync_error_key()
+    {
+        var loc = BuildLocalizationService();
+
+        var result = ActivityItemViewModel.Error(AccountIdValue, loc, AccountEmailValue, ErrorMessageValue);
+
+        loc.Received(1).GetLocal("Activity.SyncError");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenTheEnGbLocalisationFile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenTheEnGbLocalisationFile.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Activity;
+
+public sealed class GivenTheEnGbLocalisationFile
+{
+    private static readonly string JsonFilePath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json"));
+
+    [Fact]
+    public void when_en_gb_json_is_read_then_activity_info_key_exists()
+    {
+        var json = File.ReadAllText(JsonFilePath);
+        var document = JsonDocument.Parse(json);
+
+        document.RootElement.TryGetProperty("Activity.Info", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_en_gb_json_is_read_then_activity_sync_error_key_exists()
+    {
+        var json = File.ReadAllText(JsonFilePath);
+        var document = JsonDocument.Parse(json);
+
+        document.RootElement.TryGetProperty("Activity.SyncError", out _).ShouldBeTrue();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityItemViewModel.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -9,6 +10,10 @@ public enum ActivityItemType { Downloaded, Uploaded, Deleted, Conflict, Error, I
 
 public sealed partial class ActivityItemViewModel : ObservableObject
 {
+    private readonly ILocalizationService _loc;
+
+    public ActivityItemViewModel(ILocalizationService loc) => _loc = loc;
+
     public Guid Id { get; init; } = Guid.NewGuid();
     public string AccountId { get; init; } = string.Empty;
     public string AccountEmail { get; init; } = string.Empty;
@@ -22,22 +27,22 @@ public sealed partial class ActivityItemViewModel : ObservableObject
 
     public string TypeLabel => Type switch
     {
-        ActivityItemType.Downloaded => "downloaded",
-        ActivityItemType.Uploaded => "uploaded",
-        ActivityItemType.Deleted => "deleted",
-        ActivityItemType.Conflict => "conflict",
-        ActivityItemType.Error => "error",
-        _ => "info"
+        ActivityItemType.Downloaded => _loc.GetLocal("Activity.Downloaded"),
+        ActivityItemType.Uploaded   => _loc.GetLocal("Activity.Uploaded"),
+        ActivityItemType.Deleted    => _loc.GetLocal("Activity.Deleted"),
+        ActivityItemType.Conflict   => _loc.GetLocal("Activity.Conflict"),
+        ActivityItemType.Error      => _loc.GetLocal("Activity.Error"),
+        _                           => _loc.GetLocal("Activity.Info")
     };
 
     public string TypeIcon => Type switch
     {
         ActivityItemType.Downloaded => "↓",
-        ActivityItemType.Uploaded => "↑",
-        ActivityItemType.Deleted => "×",
-        ActivityItemType.Conflict => "⚠",
-        ActivityItemType.Error => "⚠",
-        _ => "•"
+        ActivityItemType.Uploaded   => "↑",
+        ActivityItemType.Deleted    => "×",
+        ActivityItemType.Conflict   => "⚠",
+        ActivityItemType.Error      => "⚠",
+        _                           => "•"
     };
 
     public string TimeAgoText
@@ -45,20 +50,21 @@ public sealed partial class ActivityItemViewModel : ObservableObject
         get
         {
             var elapsed = DateTimeOffset.UtcNow - OccurredAt;
+
             return elapsed switch
             {
-                { TotalSeconds: < 60 } => "just now",
+                { TotalSeconds: < 60 }  => _loc.GetLocal("Common.JustNow"),
                 { TotalMinutes: < 60 } td => $"{(int)td.TotalMinutes}m ago",
-                { TotalHours: < 24 } td => $"{(int)td.TotalHours}h ago",
-                { TotalDays: < 2 } => "yesterday",
-                var td => $"{(int)td.TotalDays}d ago"
+                { TotalHours: < 24 } td  => $"{(int)td.TotalHours}h ago",
+                { TotalDays: < 2 }       => _loc.GetLocal("Common.Yesterday"),
+                var td                   => $"{(int)td.TotalDays}d ago"
             };
         }
     }
 
     public string FileSizeText => FileSize.FileSizeToText();
 
-    public static ActivityItemViewModel FromJob(SyncJob job, string accountEmail, string folderName = "") => new()
+    public static ActivityItemViewModel FromJob(SyncJob job, ILocalizationService loc, string accountEmail, string folderName = "") => new(loc)
     {
         AccountId = job.Remote.AccountId.Id,
         AccountEmail = accountEmail,
@@ -77,7 +83,7 @@ public sealed partial class ActivityItemViewModel : ObservableObject
         ErrorMessage = job.Status.ErrorMessage.Match<string?>(v => v, () => null)
     };
 
-    public static ActivityItemViewModel FromConflict(SyncConflict conflict, string accountEmail, string folderName) => new()
+    public static ActivityItemViewModel FromConflict(SyncConflict conflict, ILocalizationService loc, string accountEmail, string folderName) => new(loc)
     {
         AccountId = conflict.Remote.AccountId.Id,
         AccountEmail = accountEmail,
@@ -88,12 +94,12 @@ public sealed partial class ActivityItemViewModel : ObservableObject
         OccurredAt = conflict.DetectedAt
     };
 
-    public static ActivityItemViewModel Error(string accountId, string accountEmail, string message) => new()
+    public static ActivityItemViewModel Error(string accountId, ILocalizationService loc, string accountEmail, string message) => new(loc)
     {
         AccountId = accountId,
         AccountEmail = accountEmail,
         Type = ActivityItemType.Error,
-        FileName = "Sync error",
+        FileName = loc.GetLocal("Activity.SyncError"),
         ErrorMessage = message
     };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
@@ -139,7 +139,7 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
 
     private void OnJobCompleted(object? sender, JobCompletedEventArgs args)
     {
-        var item = ActivityItemViewModel.FromJob(args.Job, _activeAccountEmail);
+        var item = ActivityItemViewModel.FromJob(args.Job, loc, _activeAccountEmail);
         AddActivityItem(item);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -68,6 +68,8 @@
   "Activity.Conflict": "Conflict",
   "Activity.Error": "Error",
   "Activity.Deleted": "Deleted",
+  "Activity.Info": "Info",
+  "Activity.SyncError": "Sync error",
   "Conflict.Title": "Resolve conflict",
   "Conflict.LocalFile": "Local file",
   "Conflict.RemoteFile": "Remote file",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -90,7 +90,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     [RelayCommand]
     private async Task SyncNowAsync()
     {
-        AddRecentActivity(new ActivityItemViewModel { FileName = _localizationService.GetLocal("Sync.Starting") });
+        AddRecentActivity(new ActivityItemViewModel(_localizationService) { FileName = _localizationService.GetLocal("Sync.Starting") });
 
         await _repository.GetByIdAsync(_account.Id, CancellationToken.None)
             .TapAsync(async entity =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -113,7 +113,7 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
         section.UpdateSyncState(args.SyncState, section.ConflictCount);
 
         if(args.Total == 0 && !string.IsNullOrEmpty(args.CurrentFile))
-            AddActivityItem(new ActivityItemViewModel { AccountId = args.AccountId, FileName = args.CurrentFile, Type = ActivityItemType.Info });
+            AddActivityItem(new ActivityItemViewModel(localizationService) { AccountId = args.AccountId, FileName = args.CurrentFile, Type = ActivityItemType.Info });
 
         RecalculateGlobals();
     }
@@ -122,7 +122,7 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
     {
         var section = AccountSections.FirstOrDefault(s => s.AccountId == args.Job.Remote.AccountId.Id);
         string accountEmail = section?.Email ?? args.Job.Remote.AccountId.Id;
-        var item = ActivityItemViewModel.FromJob(args.Job, accountEmail);
+        var item = ActivityItemViewModel.FromJob(args.Job, localizationService, accountEmail);
         AddActivityItem(item);
     }
 


### PR DESCRIPTION
## Summary

- Injected `ILocalizationService` into `ActivityItemViewModel` via constructor; all three static factory methods (`FromJob`, `FromConflict`, `Error`) now accept `ILocalizationService loc` as their second parameter
- `TypeLabel` delegates to `_loc.GetLocal("Activity.*")` for each `ActivityItemType` including the new `Activity.Info` default case
- `TimeAgoText` uses `_loc.GetLocal("Common.JustNow")` and `_loc.GetLocal("Common.Yesterday")`; interpolated minute/hour/day branches unchanged
- `Error` factory sets `FileName = loc.GetLocal("Activity.SyncError")` replacing the hard-coded `"Sync error"`
- Added `"Activity.Info": "Info"` and `"Activity.SyncError": "Sync error"` to `en-GB.json`
- Updated all call sites: `ActivityViewModel`, `DashboardViewModel`, `DashboardAccountViewModel`

Closes #338

## Test plan

- [x] `GivenAnActivityItemViewModel` — all existing tests updated to pass mock `ILocalizationService`; `TypeLabel`/`TimeAgoText`/`FileName` assertions now verify localisation keys are returned
- [x] 9 new `Received(1).GetLocal(key)` interaction tests — one per localised string, covering all 6 `TypeLabel` keys, both `TimeAgoText` localised branches, and the `Error` factory `FileName` key
- [x] `GivenTheEnGbLocalisationFile` (new) — asserts `Activity.Info` and `Activity.SyncError` keys exist in `en-GB.json`
- [x] `dotnet test` — 990 passed, 0 failed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)