### PR TITLE
fix(apps/desktop): localise hard-coded ConflictPolicy option strings in ConflictItemViewModel (#339)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
@@ -67,4 +67,33 @@ public sealed class GivenAConflictItemViewModel
         loc.Received(1).GetLocal("ConflictPolicy.LocalWins");
         loc.Received(1).GetLocal("ConflictPolicy.RemoteWins");
     }
+
+    [Fact]
+    public void when_culture_changed_then_policy_options_descriptions_are_rebuilt()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc);
+        loc.ClearReceivedCalls();
+
+        loc.CultureChanged += Raise.Event<EventHandler<CultureInfo>>(new object(), CultureInfo.GetCultureInfo("fr-FR"));
+
+        loc.Received(1).GetLocal("ConflictPolicy.Ignore.Description");
+        loc.Received(1).GetLocal("ConflictPolicy.KeepBoth.Description");
+        loc.Received(1).GetLocal("ConflictPolicy.LastWriteWins.Description");
+        loc.Received(1).GetLocal("ConflictPolicy.LocalWins.Description");
+        loc.Received(1).GetLocal("ConflictPolicy.RemoteWins.Description");
+    }
+
+    [Fact]
+    public void when_culture_changed_then_property_changed_fires_for_policy_options()
+    {
+        var loc = BuildLocalizationService();
+        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc);
+        var firedProperties = new List<string?>();
+        sut.PropertyChanged += (_, args) => firedProperties.Add(args.PropertyName);
+
+        loc.CultureChanged += Raise.Event<EventHandler<CultureInfo>>(new object(), CultureInfo.GetCultureInfo("fr-FR"));
+
+        firedProperties.ShouldContain(nameof(sut.PolicyOptions));
+    }
 }


### PR DESCRIPTION
## Summary

- Production code (ILocalizationService injection, ConflictPolicyOptionFactory.Create, CultureChanged subscription) already landed in #351
- Adds two missing test cases to `GivenAConflictItemViewModel`:
  - `when_culture_changed_then_policy_options_descriptions_are_rebuilt` — verifies all `.Description` keys re-fetched on culture change (existing test only checked label keys)
  - `when_culture_changed_then_property_changed_fires_for_policy_options` — verifies `PropertyChanged` fires for `PolicyOptions` so the Avalonia binding updates

Closes #339

## Test plan

- [ ] `dotnet test` — 992 passed, 0 failed (full desktop test suite)
- [ ] `GivenAConflictItemViewModel` — 5/5 pass including 2 new tests
- [ ] No hard-coded strings in `ConflictItemViewModel.cs` — all via `en-GB.json` keys through `ConflictPolicyOptionFactory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)