### PR TITLE
fix(apps/desktop): localise hard-coded status and sync-state strings in DashboardAccountViewModel (#342)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Assets/GivenTheEnGbJson.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Assets/GivenTheEnGbJson.cs
@@ -43,4 +43,12 @@ public sealed class GivenTheEnGbJson
     [Fact]
     public void when_read_then_files_include_tooltip_key_exists() =>
         RootElement().TryGetProperty("Files.Include.Tooltip", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_dashboard_no_sync_path_key_exists() =>
+        RootElement().TryGetProperty("Dashboard.NoSyncPath", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_dashboard_pending_key_exists() =>
+        RootElement().TryGetProperty("Dashboard.Pending", out _).ShouldBeTrue();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -10,12 +11,15 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
 
 public sealed class GivenADashboardAccountViewModel
 {
-    private static DashboardAccountViewModel CreateSut(ISyncScheduler scheduler)
+    private static DashboardAccountViewModel CreateSut(ISyncScheduler scheduler, ILocalizationService? localization = null)
         => new(
             new OneDriveAccount { Id = new AccountId("test-account") },
             scheduler,
             Substitute.For<IAccountRepository>(),
-            Substitute.For<ILocalizationService>());
+            localization ?? Substitute.For<ILocalizationService>());
+
+    private static DashboardAccountViewModel CreateSutWithAccount(OneDriveAccount account, ILocalizationService localization)
+        => new(account, Substitute.For<ISyncScheduler>(), Substitute.For<IAccountRepository>(), localization);
 
     [Fact]
     public async Task when_cancel_sync_command_invoked_then_scheduler_cancel_account_called_with_correct_id()
@@ -26,5 +30,167 @@ public sealed class GivenADashboardAccountViewModel
         await ((IAsyncRelayCommand)sut.CancelSyncCommand).ExecuteAsync(null);
 
         await mockScheduler.Received(1).CancelAccountSyncAsync("test-account");
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_syncing_state_then_localization_receives_status_bar_syncing_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Syncing;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("StatusBar.Syncing");
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_error_state_then_localization_receives_status_bar_error_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Error;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("StatusBar.Error");
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_one_conflict_then_localization_receives_status_bar_conflict_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Conflict;
+        sut.ConflictCount = 1;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("StatusBar.Conflict", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_multiple_conflicts_then_localization_receives_status_bar_conflicts_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Conflict;
+        sut.ConflictCount = 3;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("StatusBar.Conflicts", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_pending_state_then_localization_receives_dashboard_pending_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Pending;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("Dashboard.Pending");
+    }
+
+    [Fact]
+    public void when_status_label_accessed_with_idle_and_no_conflicts_then_localization_receives_status_bar_synced_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.SyncState = SyncState.Idle;
+        _ = sut.StatusLabel;
+
+        localization.Received(1).GetLocal("StatusBar.Synced");
+    }
+
+    [Fact]
+    public void when_storage_quota_total_is_zero_then_localization_receives_common_unknown_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        _ = sut.StorageText;
+
+        localization.Received(1).GetLocal("Common.Unknown");
+    }
+
+    [Fact]
+    public void when_constructed_with_no_sync_history_then_localization_receives_common_never_synced_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = null };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.NeverSynced");
+    }
+
+    [Fact]
+    public void when_update_sync_state_called_with_no_sync_path_configured_then_localization_receives_dashboard_no_sync_path_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var sut = CreateSut(Substitute.For<ISyncScheduler>(), localization);
+
+        sut.UpdateSyncState(SyncState.NoSyncPathConfigured, 0);
+
+        localization.Received(1).GetLocal("Dashboard.NoSyncPath");
+    }
+
+    [Fact]
+    public void when_constructed_with_sync_within_sixty_seconds_then_localization_receives_common_just_now_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.JustNow");
+    }
+
+    [Fact]
+    public void when_constructed_with_sync_thirty_minutes_ago_then_localization_receives_common_minutes_ago_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = DateTimeOffset.UtcNow.AddMinutes(-30) };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.MinutesAgo", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_constructed_with_sync_three_hours_ago_then_localization_receives_common_hours_ago_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-3) };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.HoursAgo", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_constructed_with_sync_one_day_ago_then_localization_receives_common_yesterday_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = DateTimeOffset.UtcNow.AddHours(-24) };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.Yesterday");
+    }
+
+    [Fact]
+    public void when_constructed_with_sync_five_days_ago_then_localization_receives_common_days_ago_key()
+    {
+        var localization = Substitute.For<ILocalizationService>();
+        var account = new OneDriveAccount { Id = new AccountId("test-account"), LastSyncedAt = DateTimeOffset.UtcNow.AddDays(-5) };
+
+        _ = CreateSutWithAccount(account, localization);
+
+        localization.Received(1).GetLocal("Common.DaysAgo", Arg.Any<object[]>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -128,5 +128,7 @@
   "Common.HoursAgo": "{0} hours ago",
   "Common.Yesterday": "Yesterday",
   "Common.DaysAgo": "{0} days ago",
-  "Sync.Starting": "Starting sync... this could take some time..."
+  "Sync.Starting": "Starting sync... this could take some time...",
+  "Dashboard.NoSyncPath": "No local sync path configured",
+  "Dashboard.Pending": "Pending"
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -29,7 +29,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public double StorageFraction => _account.Quota.Fraction();
     public string StorageText => _account.Quota.TotalBytes > 0
         ? $"{_account.Quota.UsedBytes.FileSizeToText()} / {_account.Quota.TotalBytes.FileSizeToText()}"
-        : "Unknown";
+        : _localizationService.GetLocal("Common.Unknown");
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(StatusLabel))]
@@ -42,7 +42,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public partial int ConflictCount { get; set; }
 
     [ObservableProperty]
-    public partial string LastSyncText { get; set; } = "Never synced";
+    public partial string LastSyncText { get; set; } = string.Empty;
 
     [ObservableProperty]
     public partial int FolderCount { get; set; }
@@ -56,11 +56,13 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public bool IsHealthy => SyncState is SyncState.Idle && ConflictCount == 0;
     public string StatusLabel => (SyncState, ConflictCount) switch
     {
-        (SyncState.Syncing, _) => "Syncing ...",
-        (SyncState.Error, _) => "Error",
-        (_, > 0) => $"{ConflictCount} conflict{(ConflictCount == 1 ? "" : "s")}",
-        (SyncState.Pending, _) => "Pending",
-        _ => "Synced"
+        (SyncState.Syncing, _) => _localizationService.GetLocal("StatusBar.Syncing"),
+        (SyncState.Error, _) => _localizationService.GetLocal("StatusBar.Error"),
+        (_, > 0) => ConflictCount == 1
+            ? _localizationService.GetLocal("StatusBar.Conflict", ConflictCount)
+            : _localizationService.GetLocal("StatusBar.Conflicts", ConflictCount),
+        (SyncState.Pending, _) => _localizationService.GetLocal("Dashboard.Pending"),
+        _ => _localizationService.GetLocal("StatusBar.Synced")
     };
 
     [ObservableProperty]
@@ -112,9 +114,11 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
         ConflictCount = conflicts;
         IsSyncing = state == SyncState.Syncing;
 
-        if (state is not (SyncState.Idle or SyncState.Completed)) return;
+        if (state is not (SyncState.Idle or SyncState.Completed or SyncState.NoSyncPathConfigured)) return;
 
-        _account.LastSyncedAt = Option.Some(DateTimeOffset.UtcNow);
+        if (state is not SyncState.NoSyncPathConfigured)
+            _account.LastSyncedAt = Option.Some(DateTimeOffset.UtcNow);
+
         UpdateLastSyncText(state);
     }
 
@@ -127,16 +131,16 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
 
     private void UpdateLastSyncText(SyncState syncState)
         => LastSyncText =
-        syncState == SyncState.NoSyncPathConfigured ? "No local sync path configured" :
-        _account.LastSyncedAt is null ? "Never synced" :
+        syncState == SyncState.NoSyncPathConfigured ? _localizationService.GetLocal("Dashboard.NoSyncPath") :
+        _account.LastSyncedAt is null ? _localizationService.GetLocal("Common.NeverSynced") :
         _account.LastSyncedAt.Match(
             lastSyncedAt => (DateTimeOffset.UtcNow - lastSyncedAt) switch
             {
-                { TotalSeconds: < 60 } => "Just now",
-                { TotalMinutes: < 60 } td => $"{(int)td.TotalMinutes}m ago",
-                { TotalHours: < 24 } td => $"{(int)td.TotalHours}h ago",
-                { TotalDays: < 2 } => "Yesterday",
-                var td => $"{(int)td.TotalDays}d ago"
+                { TotalSeconds: < 60 } => _localizationService.GetLocal("Common.JustNow"),
+                { TotalMinutes: < 60 } td => _localizationService.GetLocal("Common.MinutesAgo", (int)td.TotalMinutes),
+                { TotalHours: < 24 } td => _localizationService.GetLocal("Common.HoursAgo", (int)td.TotalHours),
+                { TotalDays: < 2 } => _localizationService.GetLocal("Common.Yesterday"),
+                var td => _localizationService.GetLocal("Common.DaysAgo", (int)td.TotalDays)
             },
-            () => "Never synced");
+            () => _localizationService.GetLocal("Common.NeverSynced"));
 }


### PR DESCRIPTION
## Summary

- Replace all hard-coded English strings in `DashboardAccountViewModel` with `ILocalizationService.GetLocal(...)` calls — `StatusLabel` (all 5 branches), `StorageText` fallback, and `UpdateLastSyncText` (7 time/state branches)
- Add two missing keys to `en-GB.json`: `Dashboard.NoSyncPath` and `Dashboard.Pending`
- Extend `UpdateSyncState` to call `UpdateLastSyncText` for `SyncState.NoSyncPathConfigured` so the path is reachable and testable

## Test plan

- [x] TDD: 14 new `GivenADashboardAccountViewModel` tests verify `GetLocal` receives the correct key for each `StatusLabel` state, `StorageText` unknown fallback, and all `UpdateLastSyncText` time/state branches
- [x] 2 new `GivenTheEnGbJson` tests verify the new JSON keys are present
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1022/1022 passed

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)