### PR TITLE
fix(apps/desktop): localise strings and fix locale-sensitive filter in DashboardViewModel (#343)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModelHasEverSynced.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModelHasEverSynced.cs
@@ -1,0 +1,34 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenADashboardAccountViewModelHasEverSynced
+{
+    private static DashboardAccountViewModel CreateSut(OneDriveAccount account) => new(account, Substitute.For<ISyncScheduler>(), Substitute.For<IAccountRepository>(), Substitute.For<ILocalizationService>());
+
+    [Fact]
+    public void when_account_has_no_last_synced_at_then_has_ever_synced_is_false()
+    {
+        var account = new OneDriveAccount { Id = new AccountId("acc-1"), LastSyncedAt = Option.None<DateTimeOffset>() };
+
+        var sut = CreateSut(account);
+
+        sut.HasEverSynced.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_account_has_last_synced_at_value_then_has_ever_synced_is_true()
+    {
+        var account = new OneDriveAccount { Id = new AccountId("acc-2"), LastSyncedAt = Option.Some(DateTimeOffset.UtcNow.AddHours(-1)) };
+
+        var sut = CreateSut(account);
+
+        sut.HasEverSynced.ShouldBeTrue();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModel.cs
@@ -1,0 +1,134 @@
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenADashboardViewModel
+{
+    private readonly ISyncScheduler _scheduler = Substitute.For<ISyncScheduler>();
+    private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    private DashboardViewModel CreateSut() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
+
+    private static OneDriveAccount NeverSyncedAccount(string id) => new() { Id = new AccountId(id) };
+
+    private static OneDriveAccount RecentlySyncedAccount(string id) => new() { Id = new AccountId(id), LastSyncedAt = DateTimeOffset.UtcNow.AddSeconds(-30) };
+
+    [Fact]
+    public void when_constructed_then_localization_service_receives_common_never_key_for_last_sync_text()
+    {
+        _ = CreateSut();
+
+        _localizationService.Received(1).GetLocal("Common.Never");
+    }
+
+    [Fact]
+    public void when_overall_status_text_accessed_while_syncing_then_status_bar_syncing_key_is_used()
+    {
+        var sut = CreateSut();
+        sut.AnySyncing = true;
+
+        _ = sut.OverallStatusText;
+
+        _localizationService.Received(1).GetLocal("StatusBar.Syncing");
+    }
+
+    [Fact]
+    public void when_overall_status_text_accessed_with_errors_then_status_bar_error_key_is_used()
+    {
+        var sut = CreateSut();
+        sut.AnyErrors = true;
+
+        _ = sut.OverallStatusText;
+
+        _localizationService.Received(1).GetLocal("StatusBar.Error");
+    }
+
+    [Fact]
+    public void when_overall_status_text_accessed_with_single_conflict_then_status_bar_conflict_key_is_used()
+    {
+        var sut = CreateSut();
+        sut.TotalConflicts = 1;
+
+        _ = sut.OverallStatusText;
+
+        _localizationService.Received(1).GetLocal("StatusBar.Conflict", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_overall_status_text_accessed_with_multiple_conflicts_then_status_bar_conflicts_key_is_used()
+    {
+        var sut = CreateSut();
+        sut.TotalConflicts = 3;
+
+        _ = sut.OverallStatusText;
+
+        _localizationService.Received(1).GetLocal("StatusBar.Conflicts", Arg.Any<object[]>());
+    }
+
+    [Fact]
+    public void when_overall_status_text_accessed_with_no_issues_then_dashboard_all_synced_key_is_used()
+    {
+        var sut = CreateSut();
+
+        _ = sut.OverallStatusText;
+
+        _localizationService.Received(1).GetLocal("Dashboard.AllSynced");
+    }
+
+    [Fact]
+    public void when_add_never_synced_account_then_recalculate_globals_uses_common_never_key_for_last_sync_text()
+    {
+        _localizationService.GetLocal("Common.NeverSynced").Returns("Never synced");
+        _localizationService.GetLocal("Common.Never").Returns("Never");
+        var sut = CreateSut();
+
+        sut.AddAccount(NeverSyncedAccount("acc-1"));
+
+        _localizationService.Received().GetLocal("Common.Never");
+    }
+
+    [Fact]
+    public void when_add_synced_account_then_last_sync_text_equals_synced_accounts_text()
+    {
+        _localizationService.GetLocal("Common.JustNow").Returns("Just now");
+        var sut = CreateSut();
+
+        sut.AddAccount(RecentlySyncedAccount("acc-1"));
+
+        sut.LastSyncText.ShouldBe("Just now");
+    }
+
+    [Fact]
+    public void when_one_account_synced_and_one_never_synced_then_last_sync_text_is_synced_accounts_text()
+    {
+        _localizationService.GetLocal("Common.NeverSynced").Returns("Never synced");
+        _localizationService.GetLocal("Common.JustNow").Returns("Just now");
+        var sut = CreateSut();
+
+        sut.AddAccount(RecentlySyncedAccount("acc-synced"));
+        sut.AddAccount(NeverSyncedAccount("acc-never"));
+
+        sut.LastSyncText.ShouldBe("Just now");
+    }
+
+    [Fact]
+    public void when_all_accounts_have_never_synced_then_last_sync_text_comes_from_common_never_key()
+    {
+        _localizationService.GetLocal("Common.NeverSynced").Returns("Never synced");
+        _localizationService.GetLocal("Common.Never").Returns("Never");
+        var sut = CreateSut();
+
+        sut.AddAccount(NeverSyncedAccount("acc-1"));
+        sut.AddAccount(NeverSyncedAccount("acc-2"));
+
+        _localizationService.Received().GetLocal("Common.Never");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Localization/GivenTheEnGbJsonFile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Localization/GivenTheEnGbJsonFile.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using System.Text.Json;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Localization;
+
+public sealed class GivenTheEnGbJsonFile
+{
+    [Fact]
+    public void when_read_then_dashboard_all_synced_key_is_present()
+    {
+        var assembly = typeof(LocalizationService).Assembly;
+        using var stream = assembly.GetManifestResourceStream("AStar.Dev.OneDrive.Sync.Client.Assets.Localization.en-GB.json");
+        stream.ShouldNotBeNull();
+        using var document = JsonDocument.Parse(stream!);
+
+        document.RootElement.TryGetProperty("Dashboard.AllSynced", out _).ShouldBeTrue();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -130,5 +130,6 @@
   "Common.DaysAgo": "{0} days ago",
   "Sync.Starting": "Starting sync... this could take some time...",
   "Dashboard.NoSyncPath": "No local sync path configured",
-  "Dashboard.Pending": "Pending"
+  "Dashboard.Pending": "Pending",
+  "Dashboard.AllSynced": "All synced"
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -54,6 +54,7 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
     public partial bool IsSyncing { get; set; }
 
     public bool IsHealthy => SyncState is SyncState.Idle && ConflictCount == 0;
+    public bool HasEverSynced => _account.LastSyncedAt?.Match(_ => true, () => false) ?? false;
     public string StatusLabel => (SyncState, ConflictCount) switch
     {
         (SyncState.Syncing, _) => _localizationService.GetLocal("StatusBar.Syncing"),

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -26,7 +26,7 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
     public partial int TotalConflicts { get; set; }
 
     [ObservableProperty]
-    public partial string LastSyncText { get; set; } = "Never";
+    public partial string LastSyncText { get; set; } = localizationService.GetLocal("Common.Never");
 
     [ObservableProperty]
     public partial bool AnyErrors { get; set; }
@@ -38,10 +38,12 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
 
     public string OverallStatusText => (AnySyncing, AnyErrors, TotalConflicts) switch
     {
-        (true, _, _) => "Syncing ...",
-        (_, true, _) => "Error",
-        (_, _, > 0) => $"{TotalConflicts} conflict{(TotalConflicts == 1 ? "" : "s")}",
-        _ => "All synced"
+        (true, _, _) => localizationService.GetLocal("StatusBar.Syncing"),
+        (_, true, _) => localizationService.GetLocal("StatusBar.Error"),
+        (_, _, > 0) => TotalConflicts == 1
+            ? localizationService.GetLocal("StatusBar.Conflict", TotalConflicts)
+            : localizationService.GetLocal("StatusBar.Conflicts", TotalConflicts),
+        _ => localizationService.GetLocal("Dashboard.AllSynced")
     };
 
     public void SubscribeToSyncEvents()
@@ -158,9 +160,9 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
         AnyErrors = AccountSections.Any(s => s.SyncState == SyncState.Error);
         AnySyncing = AccountSections.Any(s => s.SyncState == SyncState.Syncing);
 
-        var mostRecent = AccountSections.FirstOrDefault(s => s.LastSyncText != "Never synced");
+        var mostRecent = AccountSections.FirstOrDefault(s => s.HasEverSynced);
 
-        LastSyncText = mostRecent?.LastSyncText ?? "Never";
+        LastSyncText = mostRecent?.LastSyncText ?? localizationService.GetLocal("Common.Never");
         OnPropertyChanged(nameof(OverallStatusText));
     }
 }


### PR DESCRIPTION
## Summary

- Replace all hard-coded display strings in `DashboardViewModel` (`"Never"`, `"Error"`, `"All synced"`, conflict plurals) with `localizationService.GetLocal(...)` calls
- Add `"Dashboard.AllSynced": "All synced"` to `en-GB.json`
- Add `HasEverSynced` boolean property to `DashboardAccountViewModel` — derived from the typed `LastSyncedAt` option, not from the localised string
- Fix `RecalculateGlobals` to filter accounts via `HasEverSynced` instead of comparing `LastSyncText` against a hard-coded English string (which would silently break under any non-English locale)

## Test plan

- [x] `GivenADashboardViewModel` — verifies each `GetLocal` key is called for `OverallStatusText` and `LastSyncText` init/fallback
- [x] `GivenADashboardAccountViewModelHasEverSynced` — verifies `HasEverSynced` is `false` for null/None and `true` for `Some(date)`
- [x] `GivenTheEnGbJsonFile.when_read_then_dashboard_all_synced_key_is_present` — verifies the JSON key exists in the embedded resource
- [x] Selection logic: mixed synced/never-synced account scenarios covered
- [x] Build: 0 errors, 0 warnings
- [x] All 1035 tests pass

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)