### PR TITLE
fix(apps/desktop): localise hard-coded button label in AddAccountWizardViewModel (#347)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Onboarding;
@@ -12,10 +13,11 @@ public sealed class GivenAnAddAccountWizardViewModel
 {
     private sealed record UnknownAuthError : AuthError;
 
-    private readonly IAuthService  _authService  = Substitute.For<IAuthService>();
-    private readonly IGraphService _graphService = Substitute.For<IGraphService>();
+    private readonly IAuthService         _authService         = Substitute.For<IAuthService>();
+    private readonly IGraphService        _graphService        = Substitute.For<IGraphService>();
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
-    private AddAccountWizardViewModel CreateSut() => new(_authService, _graphService);
+    private AddAccountWizardViewModel CreateSut() => new(_authService, _graphService, _localizationService);
 
     private async Task SignInAsync(AddAccountWizardViewModel sut)
     {
@@ -255,20 +257,22 @@ public sealed class GivenAnAddAccountWizardViewModel
     }
 
     [Fact]
-    public void when_on_confirm_step_then_next_label_is_finish()
+    public void when_current_step_is_confirm_then_next_label_returns_finish_key_value()
     {
+        _localizationService.GetLocal("Wizard.AddAccount.Finish").Returns("test-finish");
         var sut = CreateSut();
         sut.CurrentStep = WizardStep.Confirm;
 
-        sut.NextLabel.ShouldBe("Finish");
+        sut.NextLabel.ShouldBe("test-finish");
     }
 
     [Fact]
-    public void when_not_on_confirm_step_then_next_label_is_next()
+    public void when_current_step_is_not_confirm_then_next_label_returns_next_key_value()
     {
+        _localizationService.GetLocal("Wizard.AddAccount.Next").Returns("test-next");
         var sut = CreateSut();
 
-        sut.NextLabel.ShouldBe("Next");
+        sut.NextLabel.ShouldBe("test-next");
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -59,7 +59,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
     public void AddAccount()
     {
-        var wizard = new Onboarding.AddAccountWizardViewModel(authService, graphService);
+        var wizard = new Onboarding.AddAccountWizardViewModel(authService, graphService, _localizationService);
         wizard.Completed += OnWizardCompletedAsync;
         wizard.Cancelled += OnWizardCancelled;
         Wizard = wizard;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -1,19 +1,32 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 namespace AStar.Dev.OneDrive.Sync.Client.Onboarding;
 
-public sealed partial class AddAccountWizardViewModel(IAuthService authService, IGraphService graphService) : ObservableObject, IDisposable
+public sealed partial class AddAccountWizardViewModel : ObservableObject, IDisposable
 {
+    private readonly IAuthService authService;
+    private readonly IGraphService graphService;
+    private readonly ILocalizationService loc;
     private string _accountId = string.Empty;
     private string? _accessToken;
     private CancellationTokenSource? _authCts;
+
+    public AddAccountWizardViewModel(IAuthService authService, IGraphService graphService, ILocalizationService localizationService)
+    {
+        this.authService = authService;
+        this.graphService = graphService;
+        loc = localizationService;
+        loc.CultureChanged += OnCultureChanged;
+    }
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsSignInStep))]
@@ -66,7 +79,8 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
         _ => false
     };
 
-    public string NextLabel => CurrentStep == WizardStep.Confirm ? "Finish" : "Next";
+    /// <summary>The label for the primary action button, localised for the current culture.</summary>
+    public string NextLabel => CurrentStep == WizardStep.Confirm ? loc.GetLocal("Wizard.AddAccount.Finish") : loc.GetLocal("Wizard.AddAccount.Next");
 
     [RelayCommand]
     private void Back()
@@ -242,5 +256,11 @@ public sealed partial class AddAccountWizardViewModel(IAuthService authService, 
         Completed?.Invoke(this, account);
     }
 
-    public void Dispose() => _authCts?.Dispose();
+    private void OnCultureChanged(object? sender, CultureInfo culture) => OnPropertyChanged(nameof(NextLabel));
+
+    public void Dispose()
+    {
+        loc.CultureChanged -= OnCultureChanged;
+        _authCts?.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary

- Inject `ILocalizationService` into `AddAccountWizardViewModel` (converted from primary constructor to regular constructor to allow `CultureChanged` subscription)
- `NextLabel` now calls `loc.GetLocal("Wizard.AddAccount.Finish")` / `loc.GetLocal("Wizard.AddAccount.Next")` — no hard-coded strings
- Subscribes to `CultureChanged` and raises `PropertyChanged` for `NextLabel` on culture switch
- Unsubscribes in `Dispose`
- `AccountsViewModel.AddAccount()` updated to pass `ILocalizationService` to the wizard

## Test plan

- [ ] `when_current_step_is_confirm_then_next_label_returns_finish_key_value` — mocked loc returns known value, asserts `NextLabel` equals it
- [ ] `when_current_step_is_not_confirm_then_next_label_returns_next_key_value` — same for Next key
- [ ] `dotnet test` — 1061 passed, 0 failed

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)