### PR TITLE
feat(apps/desktop): add Hacker theme (phosphor green on black)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using Microsoft.Extensions.Logging;
 using Testably.Abstractions.Testing;
 
@@ -65,5 +66,20 @@ public sealed class GivenASettingsService
         await service.SaveAsync();
 
         capturedSender.ShouldBeSameAs(service);
+    }
+
+    [Fact]
+    public async Task when_hacker_serialized_then_round_trips_correctly()
+    {
+        var fileSystem = CreateMockFileSystem();
+        var writeService = new SettingsService(fileSystem, Substitute.For<ILogger<SettingsService>>(), SettingsPath);
+        writeService.Current.Theme = AppTheme.Hacker;
+
+        await writeService.SaveAsync();
+
+        var readService = new SettingsService(fileSystem, Substitute.For<ILogger<SettingsService>>(), SettingsPath);
+        await readService.LoadAsync();
+
+        readService.Current.Theme.ShouldBe(AppTheme.Hacker);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Theme/GivenAThemeService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Theme/GivenAThemeService.cs
@@ -61,10 +61,21 @@ public sealed class GivenAThemeService
         raisedTheme.ShouldBe(AppTheme.Dark);
     }
 
+    [Fact]
+    public void when_apply_called_with_hacker_theme_then_current_theme_is_hacker()
+    {
+        var service = new ThemeService();
+
+        service.Apply(AppTheme.Hacker);
+
+        service.CurrentTheme.ShouldBe(AppTheme.Hacker);
+    }
+
     [Theory]
     [InlineData(AppTheme.Light)]
     [InlineData(AppTheme.Dark)]
     [InlineData(AppTheme.System)]
+    [InlineData(AppTheme.Hacker)]
     public void when_apply_called_with_any_theme_then_event_is_raised(AppTheme theme)
     {
         var service = new ThemeService();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
@@ -57,6 +57,16 @@ public sealed class GivenASettingsViewModel
     };
 
     [Fact]
+    public void when_constructed_then_settings_are_not_saved()
+    {
+        var settingsService = BuildSettingsService();
+
+        _ = BuildSut(settingsService: settingsService);
+
+        settingsService.DidNotReceive().SaveAsync();
+    }
+
+    [Fact]
     public void when_constructed_then_theme_is_read_from_settings_service_current()
     {
         var settings = new AppSettings { Theme = AppTheme.Dark };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
@@ -84,15 +84,15 @@ public sealed class GivenASettingsViewModel
     }
 
     [Fact]
-    public void when_constructed_then_theme_options_contains_exactly_three_entries()
+    public void when_constructed_then_theme_options_contains_exactly_four_entries()
     {
         var sut = BuildSut();
 
-        sut.ThemeOptions.Count.ShouldBe(3);
+        sut.ThemeOptions.Count.ShouldBe(4);
     }
 
     [Fact]
-    public void when_constructed_then_theme_options_covers_light_dark_and_system()
+    public void when_constructed_then_theme_options_covers_light_dark_system_and_hacker()
     {
         var sut = BuildSut();
 
@@ -100,6 +100,7 @@ public sealed class GivenASettingsViewModel
         themes.ShouldContain(AppTheme.Light);
         themes.ShouldContain(AppTheme.Dark);
         themes.ShouldContain(AppTheme.System);
+        themes.ShouldContain(AppTheme.Hacker);
     }
 
     [Fact]
@@ -147,6 +148,30 @@ public sealed class GivenASettingsViewModel
         loc.Received(1).GetLocal("Settings.Theme.Light");
         loc.Received(1).GetLocal("Settings.Theme.Dark");
         loc.Received(1).GetLocal("Settings.Theme.System");
+        loc.Received(1).GetLocal("Settings.Theme.Hacker");
+    }
+
+    [Fact]
+    public void when_building_theme_options_then_hacker_uses_correct_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = BuildSut(localizationService: loc);
+
+        var hackerOption = sut.ThemeOptions.Single(option => option.Theme == AppTheme.Hacker);
+
+        hackerOption.Label.ShouldBe("Settings.Theme.Hacker");
+    }
+
+    [Fact]
+    public void when_culture_changed_then_theme_options_rebuild_includes_hacker_key()
+    {
+        var loc = BuildLocalizationService();
+        var sut = BuildSut(localizationService: loc);
+        loc.ClearReceivedCalls();
+
+        loc.CultureChanged += Raise.Event<EventHandler<CultureInfo>>(new object(), CultureInfo.GetCultureInfo("fr-FR"));
+
+        loc.Received(1).GetLocal("Settings.Theme.Hacker");
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenAThemeOptionFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenAThemeOptionFactory.cs
@@ -1,0 +1,50 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Settings;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Settings;
+
+public sealed class GivenAThemeOptionFactory
+{
+    private static ILocalizationService BuildLocalizationService()
+    {
+        var loc = Substitute.For<ILocalizationService>();
+        loc.GetLocal(Arg.Any<string>()).Returns(x => x.ArgAt<string>(0));
+
+        return loc;
+    }
+
+    [Fact]
+    public void when_create_called_then_returns_four_options()
+    {
+        var loc = BuildLocalizationService();
+
+        var options = ThemeOptionFactory.Create(loc);
+
+        options.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public void when_create_called_then_all_theme_enum_values_are_covered()
+    {
+        var loc = BuildLocalizationService();
+
+        var options = ThemeOptionFactory.Create(loc);
+
+        var themes = options.Select(option => option.Theme).ToList();
+        themes.ShouldContain(AppTheme.Light);
+        themes.ShouldContain(AppTheme.Dark);
+        themes.ShouldContain(AppTheme.System);
+        themes.ShouldContain(AppTheme.Hacker);
+    }
+
+    [Fact]
+    public void when_create_called_then_hacker_uses_correct_localisation_key()
+    {
+        var loc = BuildLocalizationService();
+
+        _ = ThemeOptionFactory.Create(loc);
+
+        loc.Received(1).GetLocal("Settings.Theme.Hacker");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -94,6 +94,7 @@
   "Settings.Theme.Light": "Light",
   "Settings.Theme.Dark": "Dark",
   "Settings.Theme.System": "System",
+  "Settings.Theme.Hacker": "Hacker",
   "Settings.Language": "Language",
   "Settings.DefaultConflictPolicy": "Default conflict resolution",
   "Settings.DeltaSyncInterval": "Delta sync interval",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/AppTheme.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/AppTheme.cs
@@ -1,3 +1,3 @@
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 
-public enum AppTheme { Light, Dark, System }
+public enum AppTheme { Light, Dark, System, Hacker }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/ThemeService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Theme/ThemeService.cs
@@ -6,18 +6,14 @@ using Avalonia.Threading;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 
 /// <summary>
-/// Switches between Light, Dark and System themes at runtime by replacing
+/// Switches between Light, Dark, System and Hacker themes at runtime by replacing
 /// the theme resource dictionary in Application.Current.Resources.
-///
-/// Expects two ResourceInclude entries already present in App.axaml under
-/// the keys "LightThemeInclude" and "DarkThemeInclude" — only one is active
-/// at a time.  On System mode it watches
-/// <see cref="Application.ActualThemeVariant"/> for OS-level changes.
 /// </summary>
 public sealed class ThemeService : IThemeService, IDisposable
 {
-    private static readonly Uri _lightUri = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Light.axaml");
-    private static readonly Uri _darkUri = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Dark.axaml");
+    private static readonly Uri _lightUri  = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Light.axaml");
+    private static readonly Uri _darkUri   = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Dark.axaml");
+    private static readonly Uri _hackerUri = new("avares://AStar.Dev.OneDrive.Sync.Client/Themes/Hacker.axaml");
     private Disposable? _systemWatcher;
 
     ///<inheritdoc />
@@ -60,6 +56,7 @@ public sealed class ThemeService : IThemeService, IDisposable
     private static bool GetSystemIsDark()
     {
         var app = Application.Current;
+
         return app is not null && app.ActualThemeVariant == ThemeVariant.Dark;
     }
 
@@ -88,18 +85,24 @@ public sealed class ThemeService : IThemeService, IDisposable
         if (app is null)
             return;
 
-        var targetUri = resolved == AppTheme.Dark ? _darkUri : _lightUri;
+        var targetUri = ResolveUri(resolved);
         var merged = app.Resources.MergedDictionaries;
-
         var existing = merged
             .OfType<ResourceInclude>()
-            .FirstOrDefault(r => r.Source == _lightUri || r.Source == _darkUri);
+            .FirstOrDefault(r => r.Source == _lightUri || r.Source == _darkUri || r.Source == _hackerUri);
 
         if (existing is not null)
             _ = merged.Remove(existing);
 
         merged.Add(new ResourceInclude(targetUri) { Source = targetUri });
     }
+
+    private static Uri ResolveUri(AppTheme resolved) => resolved switch
+    {
+        AppTheme.Dark   => _darkUri,
+        AppTheme.Hacker => _hackerUri,
+        _               => _lightUri,
+    };
 
     public void Dispose() => _systemWatcher?.Dispose();
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
@@ -31,34 +31,32 @@
                             <TextBlock Text="Theme"
                                        FontSize="{StaticResource FontSizeMd}"
                                        Foreground="{DynamicResource TextPrimaryBrush}"/>
-                            <TextBlock Text="Choose light, dark or follow the system setting."
+                            <TextBlock Text="Choose a colour theme for the application."
                                        FontSize="{StaticResource FontSizeSm}"
                                        Foreground="{DynamicResource TextTertiaryBrush}"/>
                         </StackPanel>
 
-                        <StackPanel Grid.Column="1"
-                                    Orientation="Horizontal"
-                                    Spacing="6"
-                                    VerticalAlignment="Center">
-                            <Button Content="Light"
-                                    Padding="12,6"
-                                    CornerRadius="{StaticResource RadiusMd}"
-                                    BorderThickness="1"
-                                    FontSize="{StaticResource FontSizeSm}"
-                                    Click="OnThemeLightClick"/>
-                            <Button Content="Dark"
-                                    Padding="12,6"
-                                    CornerRadius="{StaticResource RadiusMd}"
-                                    BorderThickness="1"
-                                    FontSize="{StaticResource FontSizeSm}"
-                                    Click="OnThemeDarkClick"/>
-                            <Button Content="System"
-                                    Padding="12,6"
-                                    CornerRadius="{StaticResource RadiusMd}"
-                                    BorderThickness="1"
-                                    FontSize="{StaticResource FontSizeSm}"
-                                    Click="OnThemeSystemClick"/>
-                        </StackPanel>
+                        <ItemsControl Grid.Column="1"
+                                      ItemsSource="{Binding ThemeOptions}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" Spacing="6"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="settings:ThemeOption">
+                                    <Button Padding="12,6"
+                                            CornerRadius="{StaticResource RadiusMd}"
+                                            BorderThickness="1"
+                                            FontSize="{StaticResource FontSizeSm}"
+                                            Click="OnThemeClick"
+                                            Tag="{Binding Theme}">
+                                        <TextBlock Text="{Binding Label}"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}"/>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </Grid>
                 </Border>
             </StackPanel>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml.cs
@@ -10,22 +10,10 @@ public partial class SettingsView : UserControl
 {
     public SettingsView() => InitializeComponent();
 
-    private void OnThemeLightClick(object? sender, RoutedEventArgs e)
+    private void OnThemeClick(object? sender, RoutedEventArgs e)
     {
-        if(DataContext is SettingsViewModel vm)
-            vm.Theme = AppTheme.Light;
-    }
-
-    private void OnThemeDarkClick(object? sender, RoutedEventArgs e)
-    {
-        if(DataContext is SettingsViewModel vm)
-            vm.Theme = AppTheme.Dark;
-    }
-
-    private void OnThemeSystemClick(object? sender, RoutedEventArgs e)
-    {
-        if(DataContext is SettingsViewModel vm)
-            vm.Theme = AppTheme.System;
+        if(sender is Button { Tag: AppTheme theme } && DataContext is SettingsViewModel vm)
+            vm.Theme = theme;
     }
 
     private void OnPolicyClick(object? sender, RoutedEventArgs e)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
@@ -18,6 +18,7 @@ public sealed partial class SettingsViewModel : ObservableObject
     private readonly ISyncScheduler scheduler;
     private readonly IAccountRepository repository;
     private readonly ILocalizationService loc;
+    private bool isLoaded;
 
     public SettingsViewModel(ISettingsService settingsService, IThemeService themeService, ISyncScheduler scheduler, IAccountRepository repository, ILocalizationService loc)
     {
@@ -33,6 +34,7 @@ public sealed partial class SettingsViewModel : ObservableObject
         IntervalOptions = BuildIntervalOptions();
         PolicyOptions = ConflictPolicyOptionFactory.Create(loc);
         loc.CultureChanged += OnCultureChanged;
+        isLoaded = true;
     }
 
     [ObservableProperty]
@@ -40,6 +42,9 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnThemeChanged(AppTheme value)
     {
+        if (!isLoaded)
+            return;
+
         themeService.Apply(value);
         settingsService.Current.Theme = value;
         _ = settingsService.SaveAsync();
@@ -53,6 +58,9 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnDefaultConflictPolicyChanged(ConflictPolicy value)
     {
+        if (!isLoaded)
+            return;
+
         settingsService.Current.DefaultConflictPolicy = value;
         _ = settingsService.SaveAsync();
     }
@@ -62,6 +70,9 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnSyncIntervalMinutesChanged(int value)
     {
+        if (!isLoaded)
+            return;
+
         settingsService.Current.SyncIntervalMinutes = value;
         scheduler.SetInterval(TimeSpan.FromMinutes(value));
         _ = settingsService.SaveAsync();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
@@ -29,7 +29,7 @@ public sealed partial class SettingsViewModel : ObservableObject
         Theme = settingsService.Current.Theme;
         DefaultConflictPolicy = settingsService.Current.DefaultConflictPolicy;
         SyncIntervalMinutes = settingsService.Current.SyncIntervalMinutes;
-        ThemeOptions = BuildThemeOptions();
+        ThemeOptions = ThemeOptionFactory.Create(loc);
         IntervalOptions = BuildIntervalOptions();
         PolicyOptions = ConflictPolicyOptionFactory.Create(loc);
         loc.CultureChanged += OnCultureChanged;
@@ -96,13 +96,6 @@ public sealed partial class SettingsViewModel : ObservableObject
             _ = AccountSettings.Remove(vm);
     }
 
-    private IReadOnlyList<ThemeOption> BuildThemeOptions() =>
-    [
-        new(AppTheme.Light,  loc.GetLocal("Settings.Theme.Light")),
-        new(AppTheme.Dark,   loc.GetLocal("Settings.Theme.Dark")),
-        new(AppTheme.System, loc.GetLocal("Settings.Theme.System")),
-    ];
-
     private IReadOnlyList<SyncIntervalOption> BuildIntervalOptions() =>
     [
         new(5,   loc.GetLocal("Settings.DeltaSyncInterval.Minutes", 5)),
@@ -114,7 +107,7 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     private void OnCultureChanged(object? sender, System.Globalization.CultureInfo culture)
     {
-        ThemeOptions = BuildThemeOptions();
+        ThemeOptions = ThemeOptionFactory.Create(loc);
         OnPropertyChanged(nameof(ThemeOptions));
         IntervalOptions = BuildIntervalOptions();
         OnPropertyChanged(nameof(IntervalOptions));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/ThemeOptionFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/ThemeOptionFactory.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Settings;
+
+public static class ThemeOptionFactory
+{
+    /// <summary>Creates the localised list of ThemeOption instances.</summary>
+    public static IReadOnlyList<ThemeOption> Create(ILocalizationService loc) =>
+    [
+        new(AppTheme.Light,  loc.GetLocal("Settings.Theme.Light")),
+        new(AppTheme.Dark,   loc.GetLocal("Settings.Theme.Dark")),
+        new(AppTheme.System, loc.GetLocal("Settings.Theme.System")),
+        new(AppTheme.Hacker, loc.GetLocal("Settings.Theme.Hacker")),
+    ];
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Themes/Hacker.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Themes/Hacker.axaml
@@ -1,0 +1,58 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Color x:Key="BackgroundPrimary">#0A0A0A</Color>
+    <Color x:Key="BackgroundSecondary">#0F140F</Color>
+    <Color x:Key="BackgroundTertiary">#141A14</Color>
+    <Color x:Key="BackgroundRail">#080A08</Color>
+    <Color x:Key="BackgroundAccountPanel">#0D120D</Color>
+    <Color x:Key="BackgroundStatusBar">#060806</Color>
+    <Color x:Key="BackgroundHover">#1A221A</Color>
+    <Color x:Key="BackgroundActive">#1E281E</Color>
+    <Color x:Key="BackgroundSelected">#0A200A</Color>
+
+    <Color x:Key="TextPrimary">#00FF41</Color>
+    <Color x:Key="TextSecondary">#00C832</Color>
+    <Color x:Key="TextTertiary">#008F11</Color>
+    <Color x:Key="TextDisabled">#004A00</Color>
+    <Color x:Key="TextAccent">#39FF14</Color>
+
+    <Color x:Key="BorderSubtle">#0F1F0F</Color>
+    <Color x:Key="BorderDefault">#1A301A</Color>
+    <Color x:Key="BorderStrong">#2A4A2A</Color>
+    <Color x:Key="BorderAccent">#00FF41</Color>
+
+    <SolidColorBrush x:Key="BackgroundPrimaryBrush"      Color="{StaticResource BackgroundPrimary}"/>
+    <SolidColorBrush x:Key="BackgroundSecondaryBrush"    Color="{StaticResource BackgroundSecondary}"/>
+    <SolidColorBrush x:Key="BackgroundTertiaryBrush"     Color="{StaticResource BackgroundTertiary}"/>
+    <SolidColorBrush x:Key="BackgroundRailBrush"         Color="{StaticResource BackgroundRail}"/>
+    <SolidColorBrush x:Key="BackgroundAccountPanelBrush" Color="{StaticResource BackgroundAccountPanel}"/>
+    <SolidColorBrush x:Key="BackgroundStatusBarBrush"    Color="{StaticResource BackgroundStatusBar}"/>
+    <SolidColorBrush x:Key="BackgroundHoverBrush"        Color="{StaticResource BackgroundHover}"/>
+    <SolidColorBrush x:Key="BackgroundActiveBrush"       Color="{StaticResource BackgroundActive}"/>
+    <SolidColorBrush x:Key="BackgroundSelectedBrush"     Color="{StaticResource BackgroundSelected}"/>
+
+    <SolidColorBrush x:Key="TextPrimaryBrush"    Color="{StaticResource TextPrimary}"/>
+    <SolidColorBrush x:Key="TextSecondaryBrush"  Color="{StaticResource TextSecondary}"/>
+    <SolidColorBrush x:Key="TextTertiaryBrush"   Color="{StaticResource TextTertiary}"/>
+    <SolidColorBrush x:Key="TextDisabledBrush"   Color="{StaticResource TextDisabled}"/>
+    <SolidColorBrush x:Key="TextAccentBrush"     Color="{StaticResource TextAccent}"/>
+
+    <SolidColorBrush x:Key="BorderSubtleBrush"   Color="{StaticResource BorderSubtle}"/>
+    <SolidColorBrush x:Key="BorderDefaultBrush"  Color="{StaticResource BorderDefault}"/>
+    <SolidColorBrush x:Key="BorderStrongBrush"   Color="{StaticResource BorderStrong}"/>
+    <SolidColorBrush x:Key="BorderAccentBrush"   Color="{StaticResource BorderAccent}"/>
+
+    <SolidColorBrush x:Key="BackgroundWarningBrush" Color="#1A1500"/>
+    <SolidColorBrush x:Key="TextWarningBrush"       Color="#FFFF00"/>
+    <SolidColorBrush x:Key="BackgroundSuccessBrush" Color="#001A00"/>
+    <SolidColorBrush x:Key="TextSuccessBrush"       Color="#00FF41"/>
+    <SolidColorBrush x:Key="StatusSyncedBrush"      Color="#00FF41"/>
+    <SolidColorBrush x:Key="StatusPendingBrush"     Color="#FFFF00"/>
+    <SolidColorBrush x:Key="StatusConflictBrush"    Color="#FF4400"/>
+    <SolidColorBrush x:Key="StatusExcludedBrush"    Color="#3A6A3A"/>
+    <SolidColorBrush x:Key="StatusErrorBrush"       Color="#FF0040"/>
+
+    <SolidColorBrush x:Key="RailActiveIndicatorBrush" Color="{StaticResource BorderAccent}"/>
+
+</ResourceDictionary>


### PR DESCRIPTION
## Summary

- Adds `AppTheme.Hacker` enum value (appended last as value `3` — existing serialised `settings.json` files with `0/1/2` are unaffected)
- New `Themes/Hacker.axaml` resource dictionary: phosphor green (`#00FF41`) on black (`#0A0A0A`) with full palette of surface, text, border, status, and warning brushes
- New `Settings/ThemeOptionFactory.cs` static factory — mirrors `ConflictPolicyOptionFactory`, produces four `ThemeOption` entries via `ILocalizationService`
- `ThemeService` extended: `_hackerUri`, `ResolveUri` switch expression, and updated existing-include predicate
- `SettingsView.axaml` theme buttons refactored from three hard-coded `<Button>` elements to a data-bound `<ItemsControl ItemsSource="{Binding ThemeOptions}">` (mirrors `PolicyOptions` pattern); description text updated
- `SettingsView.axaml.cs` three click handlers replaced with single `OnThemeClick` reading `Button.Tag` as `AppTheme`
- `SettingsViewModel.cs` `BuildThemeOptions()` replaced with `ThemeOptionFactory.Create(loc)`; private method deleted
- `en-GB.json` gains `"Settings.Theme.Hacker": "Hacker"`

### Bug fix: theme (and other settings) not persisted across restarts

`SettingsViewModel` constructor assigned `Theme`, `DefaultConflictPolicy`, and `SyncIntervalMinutes` via their property setters before `AppBootstrapper.BootstrapAsync` called `LoadAsync()`. Each assignment triggered the corresponding `OnXXXChanged` callback which called `SaveAsync()`, silently overwriting the persisted `settings.json` with defaults on every restart.

Fix: `private bool isLoaded` guard set to `true` at the end of the constructor. All three `OnXXXChanged` callbacks early-return until `isLoaded` is true.

## Test plan

- [x] New `GivenAThemeOptionFactory` test class (3 tests)
- [x] `GivenAThemeService` extended — Hacker state + `[InlineData(AppTheme.Hacker)]` in theory
- [x] `GivenASettingsViewModel` updated — count renamed to 4, coverage renamed to include Hacker, culture-changed assertions extended, 3 new tests
- [x] `GivenASettingsService` — `when_hacker_serialized_then_round_trips_correctly` round-trip test
- [x] `GivenASettingsViewModel` — `when_constructed_then_settings_are_not_saved` regression test for persistence bug
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1080 passed, 0 failed

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)