### PR TITLE
fix(apps/desktop): report UI progress during paged OneDrive folder enumeration

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -89,7 +89,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token));
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(3);
@@ -266,7 +266,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(2);
@@ -347,6 +347,36 @@ public sealed class GivenAGraphService : IDisposable
         _ = await sut.GetDriveIdAsync(accountId, AnyAccessToken, ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_enumerate_folder_has_multiple_pages_then_progress_callback_is_invoked_per_item()
+    {
+        var nextLinkUrl = $"{_server.Url}/drives/{AnyDriveId}/items/{AnyFolderId}/children?$skiptoken=page2";
+
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new Dictionary<string, object>
+                {
+                    ["value"] = new object[] { new { id = "file-page1", name = "file1.txt", file = new { }, size = 100L, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } } },
+                    ["@odata.nextLink"] = nextLinkUrl
+                }));
+
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").WithParam("$skiptoken", "page2").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { value = new object[] { new { id = "file-page2", name = "file2.txt", file = new { }, size = 200L, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } } } }));
+
+        var reportedCounts = new List<int>();
+
+        await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken);
+
+        reportedCounts.ShouldNotBeEmpty();
+        reportedCounts.ShouldContain(1);
+        reportedCounts.ShouldContain(2);
     }
 
     private void SetupDriveContext(string driveId, string rootId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -48,7 +48,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.HadNoRules.ShouldBeTrue();
     }
@@ -59,7 +59,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -70,7 +70,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.ShouldBeEmpty();
     }
@@ -83,9 +83,9 @@ public sealed class GivenARemoteFolderEnumerator
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -95,10 +95,10 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: null)]);
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-resolved"), Arg.Any<CancellationToken>());
     }
@@ -108,10 +108,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
@@ -121,10 +121,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.SeenRemoteIds.ShouldContain("item-a");
         result.SeenRemoteIds.ShouldContain("item-b");
@@ -135,10 +135,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.Count.ShouldBe(2);
         result.DeltaItems.ShouldContain(i => i.Id.Id == "item-a");
@@ -150,10 +150,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -50,7 +50,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
         _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SyncJob>)[]);
@@ -74,6 +74,7 @@ public sealed class GivenASyncPassOrchestrator
         await _remoteFolderEnumerator.Received(1).EnumerateAsync(
             Arg.Is(account),
             Arg.Is(token),
+            Arg.Any<Action<int>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -82,7 +83,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();
@@ -98,7 +99,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -213,6 +213,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 string itemPath = BuildRelativePath(relativePath, item);
 
                 items.Add(MapToDeltaItem(item, itemPath));
+                onItemDiscovered?.Invoke(items.Count);
 
                 if(item.Folder is not null && item.Id is not null)
                     await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -123,12 +123,12 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default)
+    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
         List<DeltaItem> items = [];
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, ct);
+        await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct);
 
         return new Result<List<DeltaItem>, string>.Ok(items);
     }
@@ -198,7 +198,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             error => new Result<Unit, string>.Error(error));
     }
 
-    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)
+    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, Action<int>? onItemDiscovered, CancellationToken ct)
     {
         if(!visited.Add(parentId))
             return;
@@ -215,7 +215,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 items.Add(MapToDeltaItem(item, itemPath));
 
                 if(item.Folder is not null && item.Id is not null)
-                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, ct);
+                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct);
             }
 
             if(page.OdataNextLink is null)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -20,7 +20,7 @@ public interface IGraphService
     Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, string accessToken, CancellationToken ct = default);
 
     /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default);
+    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
     Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
@@ -12,5 +12,5 @@ public interface IRemoteFolderEnumerator
     /// Performs a full remote enumeration pass for <paramref name="account"/>,
     /// returning the raw delta-item list alongside seen IDs and rules.
     /// </summary>
-    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct);
+    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, ILogger<RemoteFolderEnumerator> logger) : IRemoteFolderEnumerator
 {
     /// <inheritdoc />
-    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct)
+    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
         var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
@@ -61,7 +61,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Profile.Email);
-            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, ct)
+            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
                 .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
                     deltaItems => deltaItems,
                     error =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -19,7 +19,8 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         driveState.DeltaLink = Option.None<string>();
         await driveStateRepository.UpsertAsync(driveState, ct).ConfigureAwait(false);
 
-        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, ct).ConfigureAwait(false);
+        Action<int>? enumerationProgress = onProgress is null ? null : count => RaiseProgress(account.Id.Id, count, 0, $"Enumerating: {count} item(s) found", onProgress);
+        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, enumerationProgress, ct).ConfigureAwait(false);
 
         if(enumerationResult.HadNoRules)
             return false;


### PR DESCRIPTION
## Summary

- **Bug**: UI froze with no feedback during sync of large folders (1000s of files). `EnumerateSubFolderAsync` silently accumulated all items across all Graph API pages before returning — no progress events fired during the entire enumeration phase.
- **Root cause**: `onItemDiscovered` callback was not threaded through the call chain: `SyncPassOrchestrator` → `IRemoteFolderEnumerator.EnumerateAsync` → `IGraphService.EnumerateFolderAsync` → `EnumerateSubFolderAsync`.
- **Fix**: Added `Action<int>? onItemDiscovered` to both interfaces (with `CancellationToken` kept last per CA1068). `EnumerateSubFolderAsync` now invokes the callback after each item is added. `SyncPassOrchestrator` converts it to `SyncProgressEventArgs` and fires the existing `onProgress` delegate, so the dashboard updates in real time throughout enumeration.

## Test plan

- [x] New failing test committed first: `when_enumerate_folder_has_multiple_pages_then_progress_callback_is_invoked_per_item` — uses WireMock paged response (`@odata.nextLink`), asserts callback receives counts 1 and 2
- [x] Fix applied — single line `onItemDiscovered?.Invoke(items.Count)` after each `items.Add`
- [x] All 1081 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)