### PR TITLE
fix(apps/desktop): replace static access token with per-call MSAL factory to fix IDX14100 (#366)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
@@ -62,10 +62,10 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManager
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
-        graphService.GetDriveIdAsync(AccountIdString, AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetDriveIdAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Ok(new DriveId(DriveIdValue)));
 
-        graphService.GetRootFoldersAsync(AccountIdString, AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetRootFoldersAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId, FolderName, Option.None<string>())]));
 
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -197,10 +197,10 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
-        graphService.GetDriveIdAsync(Arg.Any<string>(), AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Ok(new DriveId(DriveIdValue)));
 
-        graphService.GetRootFoldersAsync(Arg.Any<string>(), AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId, FolderName, Option.None<string>())]));
 
         return (authService, graphService, repository);
@@ -210,7 +210,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
     {
         var (authService, graphService, repository) = BuildMocks();
 
-        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdValue), FolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), new DriveId(DriveIdValue), FolderId, Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildFolderName, FolderId)]));
 
         return (authService, graphService, repository);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -116,8 +116,8 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var graphService = Substitute.For<IGraphService>();
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
-        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
-        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
+        graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
+        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
@@ -69,7 +69,7 @@ public sealed class GivenAnAccountFilesViewModelWithDriveIdFetchFailure
         authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
 
-        graphService.GetDriveIdAsync(AccountIdString, AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetDriveIdAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Error(DriveIdErrorMessage));
 
         return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -91,7 +91,7 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, AccountProfileFactory.Create(DisplayName, Email)));
 
-        graphService.GetRootFoldersAsync(Arg.Any<string>(), AccessToken, Arg.Any<CancellationToken>())
+        graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId1, FolderName1, Option.None<string>()), new DriveFolder(FolderId2, FolderName2, Option.None<string>())]));
 
         onboardingService.CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAFolderTreeNodeViewModel.cs
@@ -10,7 +10,6 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Home;
 
 public sealed class GivenAFolderTreeNodeViewModel
 {
-    private const string AccessToken    = "token-abc";
     private const string DriveIdString   = "drive-1";
     private const string RootFolderId   = "folder-root";
     private const string RootFolderName = "Documents";
@@ -18,6 +17,8 @@ public sealed class GivenAFolderTreeNodeViewModel
     private const string ChildName      = "Work";
     private const string GrandChildId   = "folder-grandchild";
     private const string GrandChildName = "Projects";
+
+    private static Func<CancellationToken, Task<string>> TokenFactory => _ => Task.FromResult("token-abc");
 
     [Fact]
     public async Task when_included_parent_is_toggled_excluded_then_loaded_children_are_also_excluded()
@@ -301,7 +302,7 @@ public sealed class GivenAFolderTreeNodeViewModel
     {
         var graphService = Substitute.For<IGraphService>();
 
-        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]));
 
         return graphService;
@@ -311,10 +312,10 @@ public sealed class GivenAFolderTreeNodeViewModel
     {
         var graphService = Substitute.For<IGraphService>();
 
-        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), new DriveId(DriveIdString), RootFolderId, Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(ChildFolderId, ChildName, RootFolderId)]));
 
-        graphService.GetChildFoldersAsync(AccessToken, new DriveId(DriveIdString), ChildFolderId, Arg.Any<CancellationToken>())
+        graphService.GetChildFoldersAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), new DriveId(DriveIdString), ChildFolderId, Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(GrandChildId, GrandChildName, ChildFolderId)]));
 
         return graphService;
@@ -348,6 +349,6 @@ public sealed class GivenAFolderTreeNodeViewModel
             SyncState:   syncState,
             HasChildren: true);
 
-        return new FolderTreeNodeViewModel(node, graphService, AccessToken, new DriveId(DriveIdString), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), loc);
+        return new FolderTreeNodeViewModel(node, graphService, TokenFactory, new DriveId(DriveIdString), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), loc);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -49,7 +49,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDriveIdAsync(AnyAccountId, AnyAccessToken, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), cts.Token));
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetRootFoldersAsync(AnyAccountId, AnyAccessToken, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetRootFoldersAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), cts.Token));
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetChildFoldersAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetChildFoldersAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, cts.Token));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetQuotaAsync(AnyAccountId, AnyAccessToken, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetQuotaAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), cts.Token));
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token));
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetFolderIdByPathAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyRemotePath, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetFolderIdByPathAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyRemotePath, cts.Token));
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDownloadUrlAsync(AnyAccountId, AnyAccessToken, AnyItemId, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.GetDownloadUrlAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyItemId, cts.Token));
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.UploadFileAsync(AnyAccountId, AnyAccessToken, AnyLocalPath, AnyRemotePath, AnyFolderId, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.UploadFileAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyLocalPath, AnyRemotePath, AnyFolderId, cts.Token));
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.DeleteItemAsync(AnyAccountId, AnyAccessToken, AnyItemId, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.DeleteItemAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyItemId, cts.Token));
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().GetRootFoldersAsync(AnyAccountId, AnyAccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().GetRootFoldersAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
 
         var folders = result.ShouldBeAssignableTo<Result<List<DriveFolder>, string>.Ok>()!.Value;
         folders.Count.ShouldBe(2);
@@ -167,7 +167,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { error = new { code = "itemNotFound", message = "The resource could not be found." } }));
 
-        string? result = await CreateSut().GetFolderIdByPathAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyRemotePath, TestContext.Current.CancellationToken);
+        string? result = await CreateSut().GetFolderIdByPathAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyRemotePath, TestContext.Current.CancellationToken);
 
         result.ShouldBeNull();
     }
@@ -182,7 +182,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = AnyDriveId }));
 
-        var quotaResult = await CreateSut().GetQuotaAsync(AnyAccountId, AnyAccessToken, TestContext.Current.CancellationToken);
+        var quotaResult = await CreateSut().GetQuotaAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
 
         var (total, used) = quotaResult.ShouldBeAssignableTo<Result<(long Total, long Used), string>.Ok>()!.Value;
         total.ShouldBe(0L);
@@ -199,7 +199,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = AnyItemId }));
 
-        var result = await CreateSut().GetDownloadUrlAsync(AnyAccountId, AnyAccessToken, AnyItemId, TestContext.Current.CancellationToken);
+        var result = await CreateSut().GetDownloadUrlAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyItemId, TestContext.Current.CancellationToken);
 
         result.ShouldBeAssignableTo<Result<string, string>.Error>();
     }
@@ -231,7 +231,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(3);
@@ -266,7 +266,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(2);
@@ -281,8 +281,8 @@ public sealed class GivenAGraphService : IDisposable
         var ct = TestContext.Current.CancellationToken;
 
         var sut = CreateSut();
-        _ = await sut.GetDriveIdAsync(AnyAccountId, AnyAccessToken, ct);
-        _ = await sut.GetDriveIdAsync(AnyAccountId, AnyAccessToken, ct);
+        _ = await sut.GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
+        _ = await sut.GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
     }
@@ -296,7 +296,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = (string?)null }));
 
-        var result = await CreateSut().GetDriveIdAsync(AnyAccountId, AnyAccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
 
         result.ShouldBeAssignableTo<Result<DriveId, string>.Error>();
     }
@@ -315,7 +315,7 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = (string?)null }));
 
-        var result = await CreateSut().GetDriveIdAsync(AnyAccountId, AnyAccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
 
         result.ShouldBeAssignableTo<Result<DriveId, string>.Error>();
     }
@@ -328,8 +328,8 @@ public sealed class GivenAGraphService : IDisposable
         var ct = TestContext.Current.CancellationToken;
         var sut = CreateSut();
 
-        _ = await sut.GetDriveIdAsync(accountId, AnyAccessToken, ct);
-        _ = await sut.GetDriveIdAsync(accountId, "refreshed-token", ct);
+        _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult(AnyAccessToken), ct);
+        _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult("refreshed-token"), ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
     }
@@ -342,9 +342,9 @@ public sealed class GivenAGraphService : IDisposable
         var ct = TestContext.Current.CancellationToken;
         var sut = CreateSut();
 
-        _ = await sut.GetDriveIdAsync(accountId, AnyAccessToken, ct);
+        _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult(AnyAccessToken), ct);
         sut.EvictCachedDriveContext(accountId);
-        _ = await sut.GetDriveIdAsync(accountId, AnyAccessToken, ct);
+        _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult(AnyAccessToken), ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
     }
@@ -372,11 +372,54 @@ public sealed class GivenAGraphService : IDisposable
 
         var reportedCounts = new List<int>();
 
-        await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken);
 
         reportedCounts.ShouldNotBeEmpty();
         reportedCounts.ShouldContain(1);
         reportedCounts.ShouldContain(2);
+    }
+
+    [Fact]
+    public async Task when_get_child_folders_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().GetChildFoldersAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<List<DriveFolder>, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_enumerate_folder_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_delete_item_returns_server_error_then_result_is_error()
+    {
+        SetupDriveContext(AnyDriveId, "root-001");
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingDelete())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().DeleteItemAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyItemId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<global::System.Reactive.Unit, string>.Error>();
     }
 
     private void SetupDriveContext(string driveId, string rootId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -380,6 +380,100 @@ public sealed class GivenAGraphService : IDisposable
     }
 
     [Fact]
+    public async Task when_get_drive_id_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<DriveId, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_get_root_folders_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().GetRootFoldersAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<List<DriveFolder>, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_get_quota_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().GetQuotaAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<(long Total, long Used), string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_get_folder_id_by_path_returns_server_error_then_null_is_returned()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        string? result = await CreateSut().GetFolderIdByPathAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyRemotePath, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task when_get_download_url_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().GetDownloadUrlAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyItemId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_upload_file_returns_server_error_then_result_is_error()
+    {
+        _server.Given(Request.Create().UsingAnyMethod())
+            .RespondWith(Response.Create()
+                .WithStatusCode(500)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
+
+        var result = await CreateSut().UploadFileAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), AnyLocalPath, AnyRemotePath, AnyFolderId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_token_factory_throws_then_GetDownloadUrlAsync_returns_error()
+    {
+        Func<CancellationToken, Task<string>> failingFactory = _ => Task.FromException<string>(new InvalidOperationException("Token acquisition failed."));
+
+        var result = await CreateSut().GetDownloadUrlAsync(AnyAccountId, failingFactory, AnyItemId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<string, string>.Error>();
+    }
+
+    [Fact]
     public async Task when_get_child_folders_returns_server_error_then_result_is_error()
     {
         _server.Given(Request.Create().UsingAnyMethod())

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -89,7 +89,7 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token));
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(3);
@@ -266,7 +266,7 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
 
         var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(2);
@@ -347,6 +347,36 @@ public sealed class GivenAGraphService : IDisposable
         _ = await sut.GetDriveIdAsync(accountId, AnyAccessToken, ct);
 
         (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_enumerate_folder_has_multiple_pages_then_progress_callback_is_invoked_per_item()
+    {
+        var nextLinkUrl = $"{_server.Url}/drives/{AnyDriveId}/items/{AnyFolderId}/children?$skiptoken=page2";
+
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new Dictionary<string, object>
+                {
+                    ["value"] = new object[] { new { id = "file-page1", name = "file1.txt", file = new { }, size = 100L, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } } },
+                    ["@odata.nextLink"] = nextLinkUrl
+                }));
+
+        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").WithParam("$skiptoken", "page2").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { value = new object[] { new { id = "file-page2", name = "file2.txt", file = new { }, size = 200L, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } } } }));
+
+        var reportedCounts = new List<int>();
+
+        await CreateSut().EnumerateFolderAsync(AnyAccessToken, new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken);
+
+        reportedCounts.ShouldNotBeEmpty();
+        reportedCounts.ShouldContain(1);
+        reportedCounts.ShouldContain(2);
     }
 
     private void SetupDriveContext(string driveId, string rootId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/WireMockGraphClientFactory.cs
@@ -8,9 +8,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Graph;
 
 internal sealed class WireMockGraphClientFactory(WireMockServer server) : IGraphClientFactory
 {
-    public GraphServiceClient CreateClient(string accessToken)
+    public GraphServiceClient CreateClient(Func<CancellationToken, Task<string>> tokenFactory)
     {
-        var authProvider = new BaseBearerTokenAuthenticationProvider(new TestTokenProvider(accessToken));
+        var authProvider = new BaseBearerTokenAuthenticationProvider(new DelegatingTokenProvider(tokenFactory));
         var adapter = new HttpClientRequestAdapter(authProvider)
         {
             BaseUrl = server.Url
@@ -19,10 +19,10 @@ internal sealed class WireMockGraphClientFactory(WireMockServer server) : IGraph
         return new GraphServiceClient(adapter);
     }
 
-    private sealed class TestTokenProvider(string token) : IAccessTokenProvider
+    private sealed class DelegatingTokenProvider(Func<CancellationToken, Task<string>> tokenFactory) : IAccessTokenProvider
     {
         public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
-            => Task.FromResult(token);
+            => tokenFactory(ct);
 
         public AllowedHostsValidator AllowedHostsValidator { get; } = new();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
@@ -20,7 +20,7 @@ public sealed class GivenALocalDeletionDetector
     private readonly AccountId _accountId = new("user-1");
 
     public GivenALocalDeletionDetector()
-        => _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        => _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<global::System.Reactive.Unit, string>.Ok(global::System.Reactive.Unit.Default));
 
     private LocalDeletionDetector CreateSut(MockFileSystem mockFileSystem) => new(_graphService, _syncedItemRepository, mockFileSystem, NullLogger<LocalDeletionDetector>.Instance);
@@ -35,10 +35,11 @@ public sealed class GivenALocalDeletionDetector
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/file.txt", LocalPath = LocalFile, IsFolder = false }
         };
         var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -50,10 +51,11 @@ public sealed class GivenALocalDeletionDetector
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = $"{BaseDir}/deleted.txt", IsFolder = false }
         };
         var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, TestContext.Current.CancellationToken);
 
-        await _graphService.Received(1).DeleteItemAsync(Arg.Is("user-1"), Arg.Is("token"), Arg.Is("item-1"), Arg.Any<CancellationToken>());
+        await _graphService.Received(1).DeleteItemAsync(Arg.Is("user-1"), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-1"), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -65,8 +67,9 @@ public sealed class GivenALocalDeletionDetector
             ["item-1"] = new() { RemoteItemId = new OneDriveItemId("item-1"), RemotePath = "/deleted.txt", LocalPath = $"{BaseDir}/deleted.txt", IsFolder = false }
         };
         var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).DeleteByRemoteIdAsync(Arg.Is(_accountId), Arg.Is<OneDriveItemId>(id => id.Id == "item-1"), Arg.Any<CancellationToken>());
     }
@@ -80,17 +83,18 @@ public sealed class GivenALocalDeletionDetector
             ["folder-1"] = new() { RemoteItemId = new OneDriveItemId("folder-1"), RemotePath = "/SubDir", LocalPath = $"{BaseDir}/SubDir", IsFolder = true }
         };
         var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task when_graph_delete_throws_then_exception_is_caught_and_remaining_items_are_processed()
     {
         var mockFileSystem = new MockFileSystem();
-        _graphService.When(x => x.DeleteItemAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>()))
+        _graphService.When(x => x.DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-fail"), Arg.Any<CancellationToken>()))
             .Throw(new HttpRequestException("network error"));
         var syncedItems = new Dictionary<string, SyncedItemEntity>
         {
@@ -98,9 +102,10 @@ public sealed class GivenALocalDeletionDetector
             ["item-ok"] = new() { RemoteItemId = new OneDriveItemId("item-ok"), RemotePath = "/ok.txt", LocalPath = $"{BaseDir}/ok.txt", IsFolder = false }
         };
         var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.DetectAndApplyAsync(_accountId, "token", syncedItems, TestContext.Current.CancellationToken);
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, TestContext.Current.CancellationToken);
 
-        await _graphService.Received(1).DeleteItemAsync(Arg.Is("user-1"), Arg.Is("token"), Arg.Is("item-ok"), Arg.Any<CancellationToken>());
+        await _graphService.Received(1).DeleteItemAsync(Arg.Is("user-1"), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-ok"), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -22,7 +22,7 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncedItemRepository.GetAllByAccountAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
-        _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Ok(new DriveId("drive-1")));
     }
 
@@ -47,8 +47,9 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         result.HadNoRules.ShouldBeTrue();
     }
@@ -58,10 +59,11 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -69,8 +71,9 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.ShouldBeEmpty();
     }
@@ -80,12 +83,13 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents")]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetFolderIdByPathAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -93,12 +97,13 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: null)]);
-        _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetFolderIdByPathAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-resolved"), Arg.Any<CancellationToken>());
     }
@@ -108,10 +113,11 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
@@ -121,10 +127,11 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         result.SeenRemoteIds.ShouldContain("item-a");
         result.SeenRemoteIds.ShouldContain("item-b");
@@ -135,10 +142,11 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.Count.ShouldBe(2);
         result.DeltaItems.ShouldContain(i => i.Id.Id == "item-a");
@@ -150,10 +158,11 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
 
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -48,7 +48,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.HadNoRules.ShouldBeTrue();
     }
@@ -59,7 +59,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _graphService.DidNotReceive().GetDriveIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -70,7 +70,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.ShouldBeEmpty();
     }
@@ -83,9 +83,9 @@ public sealed class GivenARemoteFolderEnumerator
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -95,10 +95,10 @@ public sealed class GivenARemoteFolderEnumerator
             .Returns([IncludeRule("/Documents", remoteItemId: null)]);
         _graphService.GetFolderIdByPathAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.Received(1).UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Is(RuleType.Include), Arg.Is("folder-resolved"), Arg.Any<CancellationToken>());
     }
@@ -108,10 +108,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         await _syncRuleRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
@@ -121,10 +121,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.SeenRemoteIds.ShouldContain("item-a");
         result.SeenRemoteIds.ShouldContain("item-b");
@@ -135,10 +135,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.DeltaItems.Count.ShouldBe(2);
         result.DeltaItems.ShouldContain(i => i.Id.Id == "item-a");
@@ -150,10 +150,10 @@ public sealed class GivenARemoteFolderEnumerator
     {
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
-        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.EnumerateFolderAsync(Arg.Any<string>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DeltaItem>, string>.Ok([]));
 
-        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), "token", ct: TestContext.Current.CancellationToken);
 
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -38,7 +38,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -59,7 +59,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -74,7 +74,7 @@ public sealed class GivenASyncService
 
         await _syncPassOrchestrator.Received(1).OrchestrateAsync(
             Arg.Is(account),
-            Arg.Any<string>(),
+            Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
             Arg.Any<Action<JobCompletedEventArgs>>(),
@@ -142,7 +142,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -182,7 +182,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -36,7 +36,7 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
     [Fact]
     public async Task when_applier_returns_false_then_error_progress_is_raised()
     {
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         SyncProgressEventArgs? captured = null;
@@ -56,7 +56,7 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
     [Fact]
     public async Task when_applier_returns_false_then_sync_repository_resolve_is_not_called()
     {
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
@@ -67,7 +67,7 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
     [Fact]
     public async Task when_applier_returns_true_then_sync_repository_resolve_is_called()
     {
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
@@ -92,7 +92,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(false);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -108,7 +108,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -124,7 +124,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -140,7 +140,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -182,7 +182,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         var sut = CreateSut();
@@ -197,7 +197,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var sut = CreateSut();
@@ -212,7 +212,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         var sut = CreateSut();
@@ -227,7 +227,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         var sut = CreateSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -36,7 +36,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(true);
         var sut = CreateSut();
 
@@ -74,7 +74,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
         var sut = CreateSut();
 
@@ -88,7 +88,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         SyncProgressEventArgs? captured = null;
@@ -110,7 +110,7 @@ public sealed class GivenASyncServiceResolvingConflicts
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _conflictApplier.ApplyAsync(Arg.Any<SyncConflict>(), Arg.Any<ConflictOutcome>(), Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(true);
         var conflict = CreateConflict();
         SyncConflict? resolved = null;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -40,7 +40,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private void SetupOrchestratorReturns(bool didRun) =>
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(didRun);
 
     [Fact]
@@ -134,7 +134,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_operation_cancelled_then_progress_is_sync_cancelled_localisation_key_with_idle_state()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         string? capturedMessage = null;
@@ -159,7 +159,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new InvalidOperationException("unexpected")));
 
         SyncState? capturedState = null;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAConflictApplier.cs
@@ -38,12 +38,13 @@ public sealed class GivenAConflictApplier
     [Fact]
     public async Task when_outcome_is_use_remote_and_url_resolution_succeeds_and_download_succeeds_then_returns_true()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
         _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<ReactiveUnit, string>.Ok(ReactiveUnit.Default));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
     }
@@ -51,10 +52,11 @@ public sealed class GivenAConflictApplier
     [Fact]
     public async Task when_outcome_is_use_remote_and_url_resolution_fails_then_returns_false()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Error("url-resolution-failed"));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeFalse();
     }
@@ -62,12 +64,13 @@ public sealed class GivenAConflictApplier
     [Fact]
     public async Task when_outcome_is_use_remote_and_download_fails_then_returns_false()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Ok("https://example.com/file.txt"));
         _httpDownloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<ReactiveUnit, string>.Error("download-failed"));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeFalse();
     }
@@ -75,10 +78,11 @@ public sealed class GivenAConflictApplier
     [Fact]
     public async Task when_outcome_is_use_remote_and_url_resolution_fails_then_downloader_is_not_called()
     {
-        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Error("url-resolution-failed"));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", "token", TestContext.Current.CancellationToken);
+        await CreateSut().ApplyAsync(CreateUseRemoteConflict(), ConflictOutcome.UseRemote, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         await _httpDownloader.DidNotReceive().DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>());
     }
@@ -103,8 +107,9 @@ public sealed class GivenAConflictApplier
             Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
             Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow, 0L)
         };
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        bool result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", "token", TestContext.Current.CancellationToken);
+        bool result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
         mockFile.Received(1).Move(Arg.Any<string>(), Arg.Any<string>());
@@ -130,8 +135,9 @@ public sealed class GivenAConflictApplier
             Target   = SyncFileTargetFactory.Create("/local/path/file.txt", "file.txt"),
             Snapshot = ConflictSnapshotFactory.Create(DateTimeOffset.UtcNow, 0L, DateTimeOffset.UtcNow, 0L)
         };
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        bool result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", "token", TestContext.Current.CancellationToken);
+        bool result = await CreateSut().ApplyAsync(conflict, ConflictOutcome.KeepBoth, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
         mockFile.DidNotReceive().Move(Arg.Any<string>(), Arg.Any<string>());
@@ -142,7 +148,9 @@ public sealed class GivenAConflictApplier
     [InlineData(ConflictOutcome.Skip)]
     public async Task when_outcome_is_not_requiring_action_then_returns_true(ConflictOutcome outcome)
     {
-        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), outcome, "user-1", "token", TestContext.Current.CancellationToken);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+
+        bool result = await CreateSut().ApplyAsync(CreateUseRemoteConflict(), outcome, "user-1", tokenFactory, TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADeleteJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADeleteJobHandler.cs
@@ -69,10 +69,11 @@ public sealed class GivenADeleteJobHandler
     {
         const string localPath = "/tmp/existing-file.txt";
         var job = MakeDeleteJob(localPath);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("any-token");
 
         _fileSystem.File.Exists(localPath).Returns(true);
 
-        await CreateSut().HandleAsync(job, string.Empty, "any-token", TestContext.Current.CancellationToken);
+        await CreateSut().HandleAsync(job, string.Empty, tokenFactory, TestContext.Current.CancellationToken);
 
         _fileSystem.File.Received(1).Delete(localPath);
     }
@@ -82,10 +83,11 @@ public sealed class GivenADeleteJobHandler
     {
         const string localPath = "/tmp/nonexistent-file.txt";
         var job = MakeDeleteJob(localPath);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("any-token");
 
         _fileSystem.File.Exists(localPath).Returns(false);
 
-        await CreateSut().HandleAsync(job, string.Empty, "any-token", TestContext.Current.CancellationToken);
+        await CreateSut().HandleAsync(job, string.Empty, tokenFactory, TestContext.Current.CancellationToken);
 
         _fileSystem.File.DidNotReceive().Delete(Arg.Any<string>());
     }
@@ -94,8 +96,9 @@ public sealed class GivenADeleteJobHandler
     public async Task when_delete_job_is_processed_then_result_is_ok()
     {
         var job = MakeDeleteJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("any-token");
 
-        var result = await CreateSut().HandleAsync(job, string.Empty, "any-token", TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, string.Empty, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match(_ => true, _ => false).ShouldBeTrue();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobHandler.cs
@@ -80,8 +80,9 @@ public sealed class GivenADownloadJobHandler
     {
         const string url = "https://example.com/direct";
         var job = MakeDownloadJob(Option.Some(url));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         await _downloader.Received(1).DownloadAsync(url, job.Target.LocalPath, job.Metadata.RemoteModified, ct: Arg.Any<CancellationToken>());
     }
@@ -91,13 +92,14 @@ public sealed class GivenADownloadJobHandler
     {
         const string fetchedUrl = "https://example.com/fetched";
         var job = MakeDownloadJob(Option.None<string>());
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        _graphService.GetDownloadUrlAsync(AccountId, AccessToken, ItemId, Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), ItemId, Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Ok(fetchedUrl));
 
-        await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
-        await _graphService.Received(1).GetDownloadUrlAsync(AccountId, AccessToken, ItemId, Arg.Any<CancellationToken>());
+        await _graphService.Received(1).GetDownloadUrlAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), ItemId, Arg.Any<CancellationToken>());
         await _downloader.Received(1).DownloadAsync(fetchedUrl, job.Target.LocalPath, job.Metadata.RemoteModified, ct: Arg.Any<CancellationToken>());
     }
 
@@ -106,11 +108,12 @@ public sealed class GivenADownloadJobHandler
     {
         const string errorMessage = "No download URL available.";
         var job = MakeDownloadJob(Option.None<string>());
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        _graphService.GetDownloadUrlAsync(AccountId, AccessToken, ItemId, Arg.Any<CancellationToken>())
+        _graphService.GetDownloadUrlAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), ItemId, Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Error(errorMessage));
 
-        var result = await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match(_ => true, _ => false).ShouldBeFalse();
         result.Match<string?>(_ => null, error => error).ShouldBe(errorMessage);
@@ -120,8 +123,9 @@ public sealed class GivenADownloadJobHandler
     public async Task when_download_succeeds_then_result_is_ok_with_job()
     {
         var job = MakeDownloadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        var result = await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match(_ => true, _ => false).ShouldBeTrue();
     }
@@ -131,11 +135,12 @@ public sealed class GivenADownloadJobHandler
     {
         const string downloadError = "Network timeout";
         var job = MakeDownloadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
         _downloader.DownloadAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTimeOffset>(), Arg.Any<IProgress<long>?>(), Arg.Any<CancellationToken>())
             .Returns(new Result<global::System.Reactive.Unit, string>.Error(downloadError));
 
-        var result = await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match<string?>(_ => null, error => error).ShouldBe(downloadError);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadJobHandler.cs
@@ -72,11 +72,12 @@ public sealed class GivenAnUploadJobHandler
     public async Task when_upload_succeeds_then_result_is_ok_with_job()
     {
         var job = MakeUploadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        _graphService.UploadFileAsync(AccountId, AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
+        _graphService.UploadFileAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Ok("remote-item-id"));
 
-        var result = await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match(_ => true, _ => false).ShouldBeTrue();
     }
@@ -85,13 +86,14 @@ public sealed class GivenAnUploadJobHandler
     public async Task when_upload_succeeds_then_graph_upload_is_called()
     {
         var job = MakeUploadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        _graphService.UploadFileAsync(AccountId, AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
+        _graphService.UploadFileAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Ok("remote-item-id"));
 
-        await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
-        await _graphService.Received(1).UploadFileAsync(AccountId, AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>());
+        await _graphService.Received(1).UploadFileAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -99,11 +101,12 @@ public sealed class GivenAnUploadJobHandler
     {
         const string uploadError = "Upload failed: quota exceeded";
         var job = MakeUploadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
-        _graphService.UploadFileAsync(AccountId, AccessToken, job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
+        _graphService.UploadFileAsync(AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), job.Target.LocalPath, Arg.Any<string>(), job.Remote.FolderId.Id, Arg.Any<CancellationToken>())
             .Returns(new Result<string, string>.Error(uploadError));
 
-        var result = await CreateSut().HandleAsync(job, AccountId, AccessToken, TestContext.Current.CancellationToken);
+        var result = await CreateSut().HandleAsync(job, AccountId, tokenFactory, TestContext.Current.CancellationToken);
 
         result.Match<string?>(_ => null, error => error).ShouldBe(uploadError);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
@@ -15,10 +15,11 @@ public sealed class GivenAParallelSyncPipeline
 {
     private const string AccountIdValue = "account-1";
     private const string FolderIdValue  = "folder-1";
-    private const string AccessToken = "test-token";
 
     private readonly ISyncWorkerFactory _workerFactory = Substitute.For<ISyncWorkerFactory>();
     private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
+
+    private static Func<CancellationToken, Task<string>> TokenFactory => _ => Task.FromResult("test-token");
 
     public GivenAParallelSyncPipeline()
     {
@@ -42,7 +43,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents.ShouldBeEmpty();
     }
@@ -53,7 +54,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.ShouldBeEmpty();
     }
@@ -63,7 +64,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>());
     }
@@ -74,7 +75,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(1);
     }
@@ -86,7 +87,7 @@ public sealed class GivenAParallelSyncPipeline
         var jobs = new[] { MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt"), MakeDownloadJob("a/3.txt") };
         var sut = CreateSut();
 
-        await sut.RunAsync(jobs, AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(jobs, TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(3);
     }
@@ -96,7 +97,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).ClearCompletedJobsAsync(Arg.Any<AccountId>());
     }
@@ -106,7 +107,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountIdValue));
     }
@@ -117,7 +118,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].SyncState.ShouldBe(SyncState.Idle);
     }
@@ -128,7 +129,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].CurrentFile.ShouldBe(string.Empty);
     }
@@ -139,7 +140,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents[0].Job.Status.State.ShouldBe(SyncJobState.Completed);
     }
@@ -150,7 +151,7 @@ public sealed class GivenAParallelSyncPipeline
         var perJobProgressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, args =>
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, args =>
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
@@ -167,7 +168,7 @@ public sealed class GivenAParallelSyncPipeline
         var jobs = new[] { MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt") };
         var sut = CreateSut();
 
-        await sut.RunAsync(jobs, AccessToken, args =>
+        await sut.RunAsync(jobs, TokenFactory, args =>
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
@@ -186,7 +187,7 @@ public sealed class GivenAParallelSyncPipeline
 
         try
         {
-            await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: cts.Token);
+            await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: cts.Token);
         }
         catch(OperationCanceledException) { }
 
@@ -198,14 +199,14 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync([MakeDownloadJob()], AccessToken, _ => { }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 3, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 3, ct: TestContext.Current.CancellationToken);
 
         _workerFactory.Received(3).Create(Arg.Any<int>());
     }
 
     private sealed class SucceedingDownloadWorker : ISyncWorker
     {
-        public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
+        public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
         {
             await foreach(var job in reader.ReadAllAsync(ct))
                 onJobComplete(job, true, null);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -45,20 +45,22 @@ public sealed class GivenASyncJobExecutor
     [Fact]
     public async Task when_jobs_list_is_empty_then_pipeline_is_not_called()
     {
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, "token", [], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, [], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
-        await _pipeline.DidNotReceive().RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _pipeline.DidNotReceive().RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task when_jobs_are_provided_then_sync_repository_enqueue_is_called()
     {
         var jobs = new List<SyncJob> { MakeJob("item-1", SyncDirection.Download) };
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).EnqueueJobsAsync(Arg.Is<IEnumerable<SyncJob>>(j => j.Count() == 1));
     }
@@ -69,16 +71,17 @@ public sealed class GivenASyncJobExecutor
         var job = MakeJob("item-1", SyncDirection.Download);
         var jobs = new List<SyncJob> { job };
 
-        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
                 onJobCompleted(new JobCompletedEventArgs(job.Complete()));
             });
 
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-1"), Arg.Any<CancellationToken>());
     }
@@ -92,16 +95,17 @@ public sealed class GivenASyncJobExecutor
         var job = (UploadSyncJob)MakeJob("item-1", SyncDirection.Upload, UploadFilePath);
         var jobs = new List<SyncJob> { job };
 
-        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
                 onJobCompleted(new JobCompletedEventArgs(((UploadSyncJob)job.Complete()) with { UploadedRemoteItemId = "uploaded-remote-id" }));
             });
 
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(mockFileSystem);
 
-        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "uploaded-remote-id"), Arg.Any<CancellationToken>());
     }
@@ -112,16 +116,17 @@ public sealed class GivenASyncJobExecutor
         var job = MakeJob("item-1", SyncDirection.Download);
         var jobs = new List<SyncJob> { job };
 
-        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
                 onJobCompleted(new JobCompletedEventArgs(job.Fail("disk full")));
             });
 
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, "token", jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.DidNotReceive().UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>());
     }
@@ -132,7 +137,7 @@ public sealed class GivenASyncJobExecutor
         var job = MakeJob("item-1", SyncDirection.Download);
         var jobs = new List<SyncJob> { job };
 
-        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<string>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var onProgress = call.Arg<Action<SyncProgressEventArgs>>();
@@ -140,9 +145,10 @@ public sealed class GivenASyncJobExecutor
             });
 
         var progressReceived = new List<SyncProgressEventArgs>();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, "token", jobs, [], args => progressReceived.Add(args), _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, jobs, [], args => progressReceived.Add(args), _ => { }, TestContext.Current.CancellationToken);
 
         progressReceived.ShouldHaveSingleItem();
         progressReceived[0].CurrentFile.ShouldBe("file.txt");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -50,7 +50,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
         _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SyncJob>)[]);
@@ -74,6 +74,7 @@ public sealed class GivenASyncPassOrchestrator
         await _remoteFolderEnumerator.Received(1).EnumerateAsync(
             Arg.Is(account),
             Arg.Is(token),
+            Arg.Any<Action<int>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -82,7 +83,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();
@@ -98,7 +99,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -50,7 +50,7 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
         _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SyncJob>)[]);
@@ -67,13 +67,13 @@ public sealed class GivenASyncPassOrchestrator
 
         var sut     = CreateSut();
         var account = CreateAccount();
-        string token   = "token";
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.OrchestrateAsync(account, token, _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, tokenFactory, _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteFolderEnumerator.Received(1).EnumerateAsync(
             Arg.Is(account),
-            Arg.Is(token),
+            Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<Action<int>?>(),
             Arg.Any<CancellationToken>());
     }
@@ -83,13 +83,13 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        bool result = await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        bool result = await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         result.ShouldBeFalse();
     }
@@ -99,13 +99,13 @@ public sealed class GivenASyncPassOrchestrator
     {
         _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns(Option.None<DriveStateEntity>());
-        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(new RemoteEnumerationResult([], new HashSet<string>(), [], [], HadNoRules: true));
 
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteDeletionDetector.DidNotReceive().DetectAndApplyAsync(
             Arg.Any<AccountId>(),
@@ -123,7 +123,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        bool result = await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        bool result = await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
     }
@@ -136,7 +136,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteDeletionDetector.Received(1).DetectAndApplyAsync(
             Arg.Any<AccountId>(),
@@ -154,11 +154,11 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _localDeletionDetector.Received(1).DetectAndApplyAsync(
             Arg.Any<AccountId>(),
-            Arg.Any<string>(),
+            Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<Dictionary<string, SyncedItemEntity>>(),
             Arg.Any<CancellationToken>());
     }
@@ -171,11 +171,11 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _syncJobExecutor.DidNotReceive().ExecuteAsync(
             Arg.Any<OneDriveAccount>(),
-            Arg.Any<string>(),
+            Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<IReadOnlyList<SyncJob>>(),
             Arg.Any<Dictionary<string, SyncedItemEntity>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
@@ -192,7 +192,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut              = CreateSut();
         var account          = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
         progressMessages.ShouldContain("No changes");
     }
@@ -206,7 +206,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut              = CreateSut();
         var account          = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
         progressMessages.ShouldContain("Detecting remote deletions...");
         progressMessages.ShouldContain("Detecting local changes...");
@@ -223,7 +223,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _accountRepository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
     }
@@ -236,7 +236,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _accountRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
     }
@@ -265,7 +265,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, "token", async detectedConflict =>
+        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), async detectedConflict =>
         {
             if(detectedConflict.Id == conflict.Id)
                 callbackInvoked = true;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
@@ -34,13 +34,14 @@ public sealed class GivenASyncWorker
         var channel = Channel.CreateUnbounded<SyncJob>();
         var completed = new List<SyncJob>();
         var errors = new List<string?>();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(AccessToken);
 
         foreach(var job in jobs)
             channel.Writer.TryWrite(job);
 
         channel.Writer.Complete();
 
-        await worker.RunAsync(channel.Reader, AccountId, AccessToken, (job, _, error) =>
+        await worker.RunAsync(channel.Reader, AccountId, tokenFactory, (job, _, error) =>
         {
             completed.Add(job);
             errors.Add(error);
@@ -54,12 +55,12 @@ public sealed class GivenASyncWorker
     {
         var job = MakeDownloadJob();
         _handler.CanHandle(job).Returns(true);
-        _handler.HandleAsync(job, AccountId, AccessToken, Arg.Any<CancellationToken>())
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<SyncJob, string>.Ok(job));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _handler.Received(1).HandleAsync(job, AccountId, AccessToken, Arg.Any<CancellationToken>());
+        await _handler.Received(1).HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -79,7 +80,7 @@ public sealed class GivenASyncWorker
     {
         var job = MakeDownloadJob();
         _handler.CanHandle(job).Returns(true);
-        _handler.HandleAsync(job, AccountId, AccessToken, Arg.Any<CancellationToken>())
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<SyncJob, string>.Ok(job));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
@@ -92,7 +93,7 @@ public sealed class GivenASyncWorker
     {
         var job = MakeDownloadJob();
         _handler.CanHandle(job).Returns(true);
-        _handler.HandleAsync(job, AccountId, AccessToken, Arg.Any<CancellationToken>())
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<SyncJob, string>.Error("handler error"));
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
@@ -107,7 +108,7 @@ public sealed class GivenASyncWorker
         using var cts = new CancellationTokenSource();
 
         _handler.CanHandle(job).Returns(true);
-        _handler.HandleAsync(job, AccountId, AccessToken, Arg.Any<CancellationToken>())
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns<Task<Result<SyncJob, string>>>(async _ =>
             {
                 await cts.CancelAsync();
@@ -121,5 +122,23 @@ public sealed class GivenASyncWorker
         catch(OperationCanceledException) { }
 
         await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>());
+    }
+
+    [Fact]
+    public async Task when_worker_runs_job_then_token_factory_is_passed_to_handler()
+    {
+        var job = MakeDownloadJob();
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("fresh-token");
+        _handler.CanHandle(job).Returns(true);
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<SyncJob, string>.Ok(job));
+
+        var channel = Channel.CreateUnbounded<SyncJob>();
+        channel.Writer.TryWrite(job);
+        channel.Writer.Complete();
+
+        await CreateSut().RunAsync(channel.Reader, AccountId, tokenFactory, (_, _, _) => { }, TestContext.Current.CancellationToken);
+
+        await _handler.Received(1).HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -68,7 +68,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
         EventArgs? firedArgs = null;
         sut.Cancelled += (_, args) => firedArgs = args;
@@ -83,7 +83,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
         await sut.NextCommand.ExecuteAsync(null);
         EventArgs? firedArgs = null;
@@ -100,7 +100,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         var stepAtFolderLoad = WizardStep.SignIn;
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 stepAtFolderLoad = sut.CurrentStep;
@@ -118,7 +118,7 @@ public sealed class GivenAnAddAccountWizardViewModel
         var sut = CreateSut();
         await SignInAsync(sut);
         bool wasLoadingDuringFetch = false;
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 wasLoadingDuringFetch = sut.IsLoadingFolders;
@@ -136,7 +136,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents", Option.None<string>()), new DriveFolder("id-2", "Pictures", Option.None<string>())]));
 
         await sut.NextCommand.ExecuteAsync(null);
@@ -149,7 +149,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents", Option.None<string>()), new DriveFolder("id-2", "Desktop", Option.None<string>()), new DriveFolder("id-3", "Pictures", Option.None<string>())]));
 
         await sut.NextCommand.ExecuteAsync(null);
@@ -164,7 +164,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Error("network error"));
 
         await sut.NextCommand.ExecuteAsync(null);
@@ -178,7 +178,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<List<DriveFolder>, string>.Ok([]));
         await sut.NextCommand.ExecuteAsync(null);
 
         sut.SkipFoldersCommand.Execute(null);
@@ -191,7 +191,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents", Option.None<string>())]));
         await sut.NextCommand.ExecuteAsync(null);
 
@@ -205,7 +205,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents", Option.None<string>()), new DriveFolder("id-2", "Pictures", Option.None<string>())]));
         await sut.NextCommand.ExecuteAsync(null);
         sut.Folders[1].IsSelected = false;
@@ -220,7 +220,7 @@ public sealed class GivenAnAddAccountWizardViewModel
     {
         var sut = CreateSut();
         await SignInAsync(sut);
-        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder("id-1", "Documents", Option.None<string>()), new DriveFolder("id-2", "Pictures", Option.None<string>())]));
         await sut.NextCommand.ExecuteAsync(null);
         sut.Folders[1].IsSelected = false;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -88,7 +88,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
             if (_accessToken is null)
                 return;
 
-            var driveId = await _graphService.GetDriveIdAsync(_account.Id.Id, _accessToken)
+            var driveId = await _graphService.GetDriveIdAsync(_account.Id.Id, _ => Task.FromResult(_accessToken ?? string.Empty))
                 .MatchAsync<DriveId, string, DriveId?>(
                     id => id,
                     error =>
@@ -129,7 +129,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private async Task BuildRootFoldersAsync(HashSet<string> includedPaths)
     {
-        var folders = await _graphService.GetRootFoldersAsync(_account.Id.Id, _accessToken!)
+        var folders = await _graphService.GetRootFoldersAsync(_account.Id.Id, _ => Task.FromResult(_accessToken ?? string.Empty))
             .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
                 f => f,
                 error =>
@@ -154,6 +154,8 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         if (driveId is null)
             return;
 
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult(_accessToken ?? string.Empty);
+
         foreach (var f in folders)
         {
             string remotePath = $"/{f.Name}";
@@ -162,7 +164,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
                 : FolderSyncState.Excluded;
 
             var node = new FolderTreeNode(Id: f.Id, Name: f.Name, ParentId: f.ParentId, AccountId: _account.Id.Id, RemotePath: remotePath, SyncState: syncState, HasChildren: true);
-            var vm = new FolderTreeNodeViewModel(node, _graphService, _accessToken!, driveId.Value, _folderTreeLogger, _localizationService);
+            var vm = new FolderTreeNodeViewModel(node, _graphService, tokenFactory, driveId.Value, _folderTreeLogger, _localizationService);
 
             vm.IncludeToggled += OnIncludeToggledAsync;
             vm.ViewActivityRequested += OnViewActivityRequested;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FolderTreeNodeViewModel.cs
@@ -13,7 +13,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Home;
 public sealed partial class FolderTreeNodeViewModel : ObservableObject
 {
     private readonly IGraphService _graphService;
-    private readonly string _accessToken;
+    private readonly Func<CancellationToken, Task<string>> _tokenFactory;
     private readonly DriveId _driveId;
     private readonly ILogger<FolderTreeNodeViewModel> _logger;
     private readonly ILocalizationService loc;
@@ -68,7 +68,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
     public event EventHandler<FolderTreeNodeViewModel>? OpenInFileManagerRequested;
     public event EventHandler<FolderTreeNodeViewModel>? ViewActivityRequested;
 
-    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, string accessToken, DriveId driveId, ILogger<FolderTreeNodeViewModel> logger, ILocalizationService localizationService, int depth = 0)
+    public FolderTreeNodeViewModel(FolderTreeNode node, IGraphService graphService, Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, ILogger<FolderTreeNodeViewModel> logger, ILocalizationService localizationService, int depth = 0)
     {
         Id = node.Id;
         Name = node.Name;
@@ -78,7 +78,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         SyncState = node.SyncState;
         HasChildren = node.HasChildren;
         _graphService = graphService;
-        _accessToken = accessToken;
+        _tokenFactory = tokenFactory;
         _driveId = driveId;
         _logger = logger;
         loc = localizationService;
@@ -144,7 +144,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
         IsLoadingChildren = true;
         try
         {
-            var folders = await _graphService.GetChildFoldersAsync(_accessToken, _driveId, Id)
+            var folders = await _graphService.GetChildFoldersAsync(_tokenFactory, _driveId, Id)
                 .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
                     f => f,
                     error =>
@@ -185,7 +185,7 @@ public sealed partial class FolderTreeNodeViewModel : ObservableObject
 
     private FolderTreeNodeViewModel CreateChildFolderTreeViewModel(FolderTreeNode childNode)
     {
-        var childVm = new FolderTreeNodeViewModel(childNode, _graphService, _accessToken, _driveId, _logger, loc, Depth + 1);
+        var childVm = new FolderTreeNodeViewModel(childNode, _graphService, _tokenFactory, _driveId, _logger, loc, Depth + 1);
 
         childVm.IncludeToggled += (s, e) => IncludeToggled?.Invoke(s, e);
         childVm.OpenInFileManagerRequested += (s, e) => OpenInFileManagerRequested?.Invoke(s, e);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphClientFactory.cs
@@ -6,13 +6,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 public sealed class GraphClientFactory : IGraphClientFactory
 {
     /// <inheritdoc />
-    public GraphServiceClient CreateClient(string accessToken)
-        => new(new BaseBearerTokenAuthenticationProvider(new StaticAccessTokenProvider(accessToken)));
+    public GraphServiceClient CreateClient(Func<CancellationToken, Task<string>> tokenFactory)
+        => new(new BaseBearerTokenAuthenticationProvider(new DelegatingAccessTokenProvider(tokenFactory)));
 
-    private sealed class StaticAccessTokenProvider(string token) : IAccessTokenProvider
+    private sealed class DelegatingAccessTokenProvider(Func<CancellationToken, Task<string>> tokenFactory) : IAccessTokenProvider
     {
         public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
-            => Task.FromResult(token);
+            => tokenFactory(ct);
 
         public AllowedHostsValidator AllowedHostsValidator { get; } = new(["graph.microsoft.com"]);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -213,6 +213,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 string itemPath = BuildRelativePath(relativePath, item);
 
                 items.Add(MapToDeltaItem(item, itemPath));
+                onItemDiscovered?.Invoke(items.Count);
 
                 if(item.Folder is not null && item.Id is not null)
                     await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -123,12 +123,12 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default)
+    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
         var client = graphClientFactory.CreateClient(accessToken);
         List<DeltaItem> items = [];
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, ct);
+        await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct);
 
         return new Result<List<DeltaItem>, string>.Ok(items);
     }
@@ -198,7 +198,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             error => new Result<Unit, string>.Error(error));
     }
 
-    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, CancellationToken ct)
+    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, Action<int>? onItemDiscovered, CancellationToken ct)
     {
         if(!visited.Add(parentId))
             return;
@@ -215,7 +215,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
                 items.Add(MapToDeltaItem(item, itemPath));
 
                 if(item.Folder is not null && item.Id is not null)
-                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, ct);
+                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct);
             }
 
             if(page.OdataNextLink is null)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -26,9 +26,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     private readonly ConcurrentDictionary<string, DriveContext> _cache = [];
 
     /// <inheritdoc />
-    public async Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, string accessToken, CancellationToken ct = default)
+    public async Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return contextResult.Match<Result<DriveId, string>>(
             ctx => new Result<DriveId, string>.Ok(ctx.Ctx.DriveId),
@@ -36,9 +36,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accountId, string accessToken, CancellationToken ct = default)
+    public async Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<List<DriveFolder>, string>>(
             async ctx =>
@@ -70,42 +70,49 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default)
+    public async Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string parentFolderId, CancellationToken ct = default)
     {
-        var client = graphClientFactory.CreateClient(accessToken);
-
-        var result = await client.Drives[driveId.Value].Items[parentFolderId].Children
-            .GetAsync(req =>
-            {
-                req.QueryParameters.Select = ["id", "name", "folder", "parentReference"];
-                req.QueryParameters.Top = 100;
-            }, ct);
-
-        List<DriveFolder> folders = [];
-
-        var page = result;
-        while(page?.Value is not null)
+        try
         {
-            folders.AddRange(
-                page.Value
-                    .Where(i => i.Folder is not null)
-                    .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: ToOptionString(i.ParentReference?.Id))));
+            var client = graphClientFactory.CreateClient(tokenFactory);
 
-            if(page.OdataNextLink is null)
-                break;
+            var result = await client.Drives[driveId.Value].Items[parentFolderId].Children
+                .GetAsync(req =>
+                {
+                    req.QueryParameters.Select = ["id", "name", "folder", "parentReference"];
+                    req.QueryParameters.Top = 100;
+                }, ct);
 
-            page = await client.Drives[driveId.Value].Items[parentFolderId].Children
-                .WithUrl(page.OdataNextLink)
-                .GetAsync(cancellationToken: ct);
+            List<DriveFolder> folders = [];
+
+            var page = result;
+            while(page?.Value is not null)
+            {
+                folders.AddRange(
+                    page.Value
+                        .Where(i => i.Folder is not null)
+                        .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: ToOptionString(i.ParentReference?.Id))));
+
+                if(page.OdataNextLink is null)
+                    break;
+
+                page = await client.Drives[driveId.Value].Items[parentFolderId].Children
+                    .WithUrl(page.OdataNextLink)
+                    .GetAsync(cancellationToken: ct);
+            }
+
+            return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
         }
-
-        return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<List<DriveFolder>, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
-    public async Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, string accessToken, CancellationToken ct = default)
+    public async Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<(long Total, long Used), string>>(
             async ctx =>
@@ -123,20 +130,27 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
+    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
-        var client = graphClientFactory.CreateClient(accessToken);
-        List<DeltaItem> items = [];
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct);
+        try
+        {
+            var client = graphClientFactory.CreateClient(tokenFactory);
+            List<DeltaItem> items = [];
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct);
 
-        return new Result<List<DeltaItem>, string>.Ok(items);
+            return new Result<List<DeltaItem>, string>.Ok(items);
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<List<DeltaItem>, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
-    public async Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default)
+    public async Task<string?> GetFolderIdByPathAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string remotePath, CancellationToken ct = default)
     {
-        var client = graphClientFactory.CreateClient(accessToken);
+        var client = graphClientFactory.CreateClient(tokenFactory);
 
         try
         {
@@ -152,9 +166,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<string, string>> GetDownloadUrlAsync(string accountId, string accessToken, string itemId, CancellationToken ct = default)
+    public async Task<Result<string, string>> GetDownloadUrlAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<string, string>>(
             async ctx =>
@@ -175,9 +189,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<string, string>> UploadFileAsync(string accountId, string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
+    public async Task<Result<string, string>> UploadFileAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<string, string>>(
             async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
@@ -185,15 +199,23 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<Unit, string>> DeleteItemAsync(string accountId, string accessToken, string itemId, CancellationToken ct = default)
+    public async Task<Result<Unit, string>> DeleteItemAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, accessToken, ct).ConfigureAwait(false);
+        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<Unit, string>>(
             async ctx =>
             {
-                await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
-                return new Result<Unit, string>.Ok(Unit.Default);
+                try
+                {
+                    await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
+
+                    return new Result<Unit, string>.Ok(Unit.Default);
+                }
+                catch(Exception ex) when(ex is not OperationCanceledException)
+                {
+                    return new Result<Unit, string>.Error(ex.Message);
+                }
             },
             error => new Result<Unit, string>.Error(error));
     }
@@ -259,9 +281,9 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     /// <inheritdoc />
     public void EvictCachedDriveContext(string accountId) => _cache.TryRemove(accountId, out _);
 
-    private async Task<Result<(GraphServiceClient Client, DriveContext Ctx), string>> ResolveClientWithDriveContextAsync(string accountId, string accessToken, CancellationToken ct)
+    private async Task<Result<(GraphServiceClient Client, DriveContext Ctx), string>> ResolveClientWithDriveContextAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
-        var client = graphClientFactory.CreateClient(accessToken);
+        var client = graphClientFactory.CreateClient(tokenFactory);
 
         if(_cache.TryGetValue(accountId, out var cached))
             return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, cached));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -28,45 +28,59 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     /// <inheritdoc />
     public async Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        try
+        {
+            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
-        return contextResult.Match<Result<DriveId, string>>(
-            ctx => new Result<DriveId, string>.Ok(ctx.Ctx.DriveId),
-            error => new Result<DriveId, string>.Error(error));
+            return contextResult.Match<Result<DriveId, string>>(
+                ctx => new Result<DriveId, string>.Ok(ctx.Ctx.DriveId),
+                error => new Result<DriveId, string>.Error(error));
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<DriveId, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
     public async Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        try
+        {
+            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
-        return await contextResult.MatchAsync<Result<List<DriveFolder>, string>>(
-            async ctx =>
-            {
-                var response = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
-                    .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
-
-                List<DriveFolder> folders = [];
-
-                var page = response;
-                while(page?.Value is not null)
+            return await contextResult.MatchAsync<Result<List<DriveFolder>, string>>(
+                async ctx =>
                 {
-                    folders.AddRange(
-                        page.Value
-                            .Where(i => i.Folder is not null)
-                            .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: ToOptionString(i.ParentReference?.Id))));
+                    var response = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
+                        .GetAsync(req => req.QueryParameters.Select = _childrenSelect, ct);
 
-                    if(page.OdataNextLink is null)
-                        break;
+                    List<DriveFolder> folders = [];
 
-                    page = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
-                        .WithUrl(page.OdataNextLink)
-                        .GetAsync(cancellationToken: ct);
-                }
+                    var page = response;
+                    while(page?.Value is not null)
+                    {
+                        folders.AddRange(
+                            page.Value
+                                .Where(i => i.Folder is not null)
+                                .Select(i => new DriveFolder(Id: i.Id!, Name: i.Name!, ParentId: ToOptionString(i.ParentReference?.Id))));
 
-                return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
-            },
-            error => new Result<List<DriveFolder>, string>.Error(error));
+                        if(page.OdataNextLink is null)
+                            break;
+
+                        page = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
+                            .WithUrl(page.OdataNextLink)
+                            .GetAsync(cancellationToken: ct);
+                    }
+
+                    return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
+                },
+                error => new Result<List<DriveFolder>, string>.Error(error));
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<List<DriveFolder>, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
@@ -112,21 +126,28 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     /// <inheritdoc />
     public async Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        try
+        {
+            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
-        return await contextResult.MatchAsync<Result<(long Total, long Used), string>>(
-            async ctx =>
-            {
-                var drive = await ctx.Client.Drives[ctx.Ctx.DriveId.Value]
-                    .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
+            return await contextResult.MatchAsync<Result<(long Total, long Used), string>>(
+                async ctx =>
+                {
+                    var drive = await ctx.Client.Drives[ctx.Ctx.DriveId.Value]
+                        .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
 
-                var quota = drive?.Quota is { Total: not null, Used: not null }
-                    ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
-                    : (0L, 0L);
+                    var quota = drive?.Quota is { Total: not null, Used: not null }
+                        ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
+                        : (0L, 0L);
 
-                return new Result<(long Total, long Used), string>.Ok(quota);
-            },
-            error => new Result<(long Total, long Used), string>.Error(error));
+                    return new Result<(long Total, long Used), string>.Ok(quota);
+                },
+                error => new Result<(long Total, long Used), string>.Error(error));
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<(long Total, long Used), string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
@@ -163,39 +184,57 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
         {
             return null;
         }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return null;
+        }
     }
 
     /// <inheritdoc />
     public async Task<Result<string, string>> GetDownloadUrlAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        try
+        {
+            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
-        return await contextResult.MatchAsync<Result<string, string>>(
-            async ctx =>
-            {
-                var item = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId]
-                    .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
-                    .ConfigureAwait(false);
+            return await contextResult.MatchAsync<Result<string, string>>(
+                async ctx =>
+                {
+                    var item = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId]
+                        .GetAsync(req => req.QueryParameters.Select = [DownloadUrlKey], ct)
+                        .ConfigureAwait(false);
 
-                if(item?.AdditionalData is null)
-                    return new Result<string, string>.Error($"No download URL available for item {itemId}.");
+                    if(item?.AdditionalData is null)
+                        return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
-                if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out object? url) || url is null)
-                    return new Result<string, string>.Error($"No download URL available for item {itemId}.");
+                    if(!item.AdditionalData.TryGetValue(DownloadUrlKey, out object? url) || url is null)
+                        return new Result<string, string>.Error($"No download URL available for item {itemId}.");
 
-                return new Result<string, string>.Ok(url.ToString()!);
-            },
-            error => new Result<string, string>.Error(error));
+                    return new Result<string, string>.Ok(url.ToString()!);
+                },
+                error => new Result<string, string>.Error(error));
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<string, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />
     public async Task<Result<string, string>> UploadFileAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        try
+        {
+            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
-        return await contextResult.MatchAsync<Result<string, string>>(
-            async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
-            error => new Result<string, string>.Error(error));
+            return await contextResult.MatchAsync<Result<string, string>>(
+                async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
+                error => new Result<string, string>.Error(error));
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException)
+        {
+            return new Result<string, string>.Error(ex.Message);
+        }
     }
 
     /// <inheritdoc />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphClientFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphClientFactory.cs
@@ -4,6 +4,6 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
 public interface IGraphClientFactory
 {
-    /// <summary>Creates a <see cref="GraphServiceClient"/> authenticated with the supplied bearer token.</summary>
-    GraphServiceClient CreateClient(string accessToken);
+    /// <summary>Creates a <see cref="GraphServiceClient"/> authenticated using the supplied token factory.</summary>
+    GraphServiceClient CreateClient(Func<CancellationToken, Task<string>> tokenFactory);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -8,31 +8,31 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 public interface IGraphService
 {
     /// <summary>Returns the ID of the user's default drive (OneDrive for Business or Personal).</summary>
-    Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, string accessToken, CancellationToken ct = default);
+    Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the root folder.</summary>
-    Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accountId, string accessToken, CancellationToken ct = default);
+    Task<Result<List<DriveFolder>, string>> GetRootFoldersAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default);
 
     /// <summary>Returns the immediate child folders of the given parent folder. Used for lazy-loading the folder tree.</summary>
-    Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(string accessToken, DriveId driveId, string parentFolderId, CancellationToken ct = default);
+    Task<Result<List<DriveFolder>, string>> GetChildFoldersAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string parentFolderId, CancellationToken ct = default);
 
     /// <summary>Returns the user's OneDrive storage quota.</summary>
-    Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, string accessToken, CancellationToken ct = default);
+    Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default);
 
     /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
+    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
-    Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);
+    Task<string?> GetFolderIdByPathAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string remotePath, CancellationToken ct = default);
 
     /// <summary>Fetches the pre-authenticated download URL for a specific drive item.</summary>
-    Task<Result<string, string>> GetDownloadUrlAsync(string accountId, string accessToken, string itemId, CancellationToken ct = default);
+    Task<Result<string, string>> GetDownloadUrlAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default);
 
     /// <summary>Uploads a local file to OneDrive using a resumable upload session. Returns the remote item ID on success.</summary>
-    Task<Result<string, string>> UploadFileAsync(string accountId, string accessToken, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default);
+    Task<Result<string, string>> UploadFileAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string localPath, string remotePath, string parentFolderId, CancellationToken ct = default);
 
     /// <summary>Permanently deletes the specified item from OneDrive (moves it to the recycle bin).</summary>
-    Task<Result<Unit, string>> DeleteItemAsync(string accountId, string accessToken, string itemId, CancellationToken ct = default);
+    Task<Result<Unit, string>> DeleteItemAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default);
 
     /// <summary>Removes the cached drive context for the given account. Call after sign-out to prevent stale entries accumulating.</summary>
     void EvictCachedDriveContext(string accountId);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -20,7 +20,7 @@ public interface IGraphService
     Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, string accessToken, CancellationToken ct = default);
 
     /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, CancellationToken ct = default);
+    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(string accessToken, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
     Task<string?> GetFolderIdByPathAsync(string accessToken, DriveId driveId, string remotePath, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/ILocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/ILocalDeletionDetector.cs
@@ -12,5 +12,5 @@ public interface ILocalDeletionDetector
     /// Walks <paramref name="syncedItems"/> and, for each file no longer present on disk,
     /// deletes the corresponding remote item via Graph and removes the local tracking record.
     /// </summary>
-    Task DetectAndApplyAsync(AccountId accountId, string accessToken, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
+    Task DetectAndApplyAsync(AccountId accountId, Func<CancellationToken, Task<string>> tokenFactory, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
@@ -12,5 +12,5 @@ public interface IRemoteFolderEnumerator
     /// Performs a full remote enumeration pass for <paramref name="account"/>,
     /// returning the raw delta-item list alongside seen IDs and rules.
     /// </summary>
-    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
+    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/IRemoteFolderEnumerator.cs
@@ -12,5 +12,5 @@ public interface IRemoteFolderEnumerator
     /// Performs a full remote enumeration pass for <paramref name="account"/>,
     /// returning the raw delta-item list alongside seen IDs and rules.
     /// </summary>
-    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct);
+    Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
@@ -14,7 +14,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedItemRepository syncedItemRepository, IFileSystem fileSystem, ILogger<LocalDeletionDetector> logger) : ILocalDeletionDetector
 {
     /// <inheritdoc />
-    public async Task DetectAndApplyAsync(AccountId accountId, string accessToken, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
+    public async Task DetectAndApplyAsync(AccountId accountId, Func<CancellationToken, Task<string>> tokenFactory, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
     {
         foreach (var (remoteId, knownItem) in syncedItems)
         {
@@ -26,7 +26,7 @@ public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedIte
 
             try
             {
-                var deleteResult = await graphService.DeleteItemAsync(accountId.Id, accessToken, remoteId, ct);
+                var deleteResult = await graphService.DeleteItemAsync(accountId.Id, tokenFactory, remoteId, ct);
 
                 await deleteResult.MatchAsync<Unit>(
                     async _ =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, ILogger<RemoteFolderEnumerator> logger) : IRemoteFolderEnumerator
 {
     /// <inheritdoc />
-    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, CancellationToken ct)
+    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
         var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
@@ -61,7 +61,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Profile.Email);
-            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, ct)
+            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
                 .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
                     deltaItems => deltaItems,
                     error =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRuleRepository syncRuleRepository, ISyncedItemRepository syncedItemRepository, ILogger<RemoteFolderEnumerator> logger) : IRemoteFolderEnumerator
 {
     /// <inheritdoc />
-    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, string accessToken, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
+    public async Task<RemoteEnumerationResult> EnumerateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
     {
         var rules = await syncRuleRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false);
 
@@ -27,7 +27,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         }
 
         var syncedItems = await syncedItemRepository.GetAllByAccountAsync(account.Id, ct).ConfigureAwait(false);
-        var driveId = await graphService.GetDriveIdAsync(account.Id.Id, accessToken, ct)
+        var driveId = await graphService.GetDriveIdAsync(account.Id.Id, tokenFactory, ct)
             .MatchAsync<DriveId, string, DriveId?>(
                 id => id,
                 error =>
@@ -52,7 +52,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             if (ct.IsCancellationRequested)
                 break;
 
-            string? folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, accessToken, driveId.Value, ct).ConfigureAwait(false);
+            string? folderId = await ResolveAndBackFillFolderIdAsync(account.Id, rule, syncedItems, tokenFactory, driveId.Value, ct).ConfigureAwait(false);
 
             if (folderId is null)
             {
@@ -61,7 +61,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Profile.Email);
-            var items = await graphService.EnumerateFolderAsync(accessToken, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
+            var items = await graphService.EnumerateFolderAsync(tokenFactory, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
                 .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
                     deltaItems => deltaItems,
                     error =>
@@ -84,12 +84,12 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
         return new RemoteEnumerationResult(allDeltaItems, seenRemoteIds, syncedItems, rules);
     }
 
-    private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, string accessToken, DriveId driveId, CancellationToken ct)
+    private async Task<string?> ResolveAndBackFillFolderIdAsync(AccountId accountId, SyncRuleEntity rule, Dictionary<string, SyncedItemEntity> syncedItems, Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, CancellationToken ct)
     {
         string? folderId = rule.RemoteItemId is Option<string>.Some existingId
             ? existingId.Value
             : TryResolveFromSyncedItems(syncedItems, rule.RemotePath)
-                ?? await graphService.GetFolderIdByPathAsync(accessToken, driveId, rule.RemotePath, ct).ConfigureAwait(false);
+                ?? await graphService.GetFolderIdByPathAsync(tokenFactory, driveId, rule.RemotePath, ct).ConfigureAwait(false);
 
         if (folderId is not null && rule.RemoteItemId.Match(id => id != folderId, () => true))
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/ConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/ConflictApplier.cs
@@ -11,12 +11,12 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphService graphService, IFileSystem fileSystem, ILogger<ConflictApplier> logger) : IConflictApplier
 {
     /// <inheritdoc />
-    public async Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct)
+    public async Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         switch (outcome)
         {
             case ConflictOutcome.UseRemote:
-                return await ApplyUseRemoteAsync(conflict, accountId, accessToken, ct).ConfigureAwait(false);
+                return await ApplyUseRemoteAsync(conflict, accountId, tokenFactory, ct).ConfigureAwait(false);
 
             case ConflictOutcome.KeepBoth:
                 ApplyKeepBoth(conflict);
@@ -27,9 +27,9 @@ public sealed class ConflictApplier(IHttpDownloader httpDownloader, IGraphServic
         }
     }
 
-    private async Task<bool> ApplyUseRemoteAsync(SyncConflict conflict, string accountId, string accessToken, CancellationToken ct)
+    private async Task<bool> ApplyUseRemoteAsync(SyncConflict conflict, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
-        var urlResult = await graphService.GetDownloadUrlAsync(accountId, accessToken, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
+        var urlResult = await graphService.GetDownloadUrlAsync(accountId, tokenFactory, conflict.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
 
         return await urlResult.MatchAsync<bool>(
             async url =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DeleteJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DeleteJobHandler.cs
@@ -11,7 +11,7 @@ public sealed class DeleteJobHandler(IFileSystem fileSystem) : IJobHandler
     public bool CanHandle(SyncJob job) => job is DeleteSyncJob;
 
     /// <inheritdoc />
-    public Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, string accessToken, CancellationToken ct)
+    public Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         var deleteJob = (DeleteSyncJob)job;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobHandler.cs
@@ -13,10 +13,10 @@ public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService
     public bool CanHandle(SyncJob job) => job is DownloadSyncJob;
 
     /// <inheritdoc />
-    public async Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, string accessToken, CancellationToken ct)
+    public async Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         var downloadJob = (DownloadSyncJob)job;
-        var urlResult = await ResolveDownloadUrlAsync(downloadJob, accountId, accessToken, ct).ConfigureAwait(false);
+        var urlResult = await ResolveDownloadUrlAsync(downloadJob, accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await urlResult.MatchAsync<Result<SyncJob, string>>(
             async url =>
@@ -40,13 +40,13 @@ public sealed class DownloadJobHandler(IHttpDownloader downloader, IGraphService
             }).ConfigureAwait(false);
     }
 
-    private async Task<Result<string, string>> ResolveDownloadUrlAsync(DownloadSyncJob job, string accountId, string accessToken, CancellationToken ct)
+    private async Task<Result<string, string>> ResolveDownloadUrlAsync(DownloadSyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         if (job.DownloadUrl is Option<string>.Some downloadUrl)
             return new Result<string, string>.Ok(downloadUrl.Value);
 
         OneDriveSyncClientMessages.DownloadUrlAbsent(logger, job.Target.RelativePath);
 
-        return await graphService.GetDownloadUrlAsync(accountId, accessToken, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
+        return await graphService.GetDownloadUrlAsync(accountId, tokenFactory, job.Remote.RemoteItemId.Id, ct).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IConflictApplier.cs
@@ -12,5 +12,5 @@ public interface IConflictApplier
     /// Applies <paramref name="outcome"/> for <paramref name="conflict"/>.
     /// Returns <see langword="true"/> on success; <see langword="false"/> when the operation could not be completed.
     /// </summary>
-    Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, string accessToken, CancellationToken ct);
+    Task<bool> ApplyAsync(SyncConflict conflict, ConflictOutcome outcome, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IJobHandler.cs
@@ -10,5 +10,5 @@ public interface IJobHandler
     bool CanHandle(SyncJob job);
 
     /// <summary>Executes <paramref name="job"/> and returns the completed job or an error message.</summary>
-    Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, string accessToken, CancellationToken ct);
+    Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadJobHandler.cs
@@ -13,10 +13,10 @@ public sealed class UploadJobHandler(IGraphService graphService, ILogger<UploadJ
     public bool CanHandle(SyncJob job) => job is UploadSyncJob;
 
     /// <inheritdoc />
-    public async Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, string accessToken, CancellationToken ct)
+    public async Task<Result<SyncJob, string>> HandleAsync(SyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         var uploadJob = (UploadSyncJob)job;
-        var uploadResult = await graphService.UploadFileAsync(accountId, accessToken, uploadJob.Target.LocalPath, uploadJob.Target.RelativePath, parentFolderId: uploadJob.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
+        var uploadResult = await graphService.UploadFileAsync(accountId, tokenFactory, uploadJob.Target.LocalPath, uploadJob.Target.RelativePath, parentFolderId: uploadJob.Remote.FolderId.Id, ct: ct).ConfigureAwait(false);
 
         return uploadResult.Match<Result<SyncJob, string>>(
             itemId =>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncJobExecutor.cs
@@ -15,5 +15,5 @@ public interface ISyncJobExecutor
     /// and persists a <see cref="SyncedItemEntity"/> for each successfully completed download or upload.
     /// Progress and job-completion events are forwarded via the provided callbacks.
     /// </summary>
-    Task ExecuteAsync(OneDriveAccount account, string accessToken, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct);
+    Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
@@ -10,8 +10,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public interface ISyncPassOrchestrator
 {
     /// <summary>
-    /// Runs the full sync pass pipeline for <paramref name="account"/> using <paramref name="token"/> for Graph API calls.
+    /// Runs the full sync pass pipeline for <paramref name="account"/> using <paramref name="tokenFactory"/> for Graph API calls.
     /// Returns <see langword="true"/> when at least one sync rule was active; <see langword="false"/> when no folders were selected.
     /// </summary>
-    Task<bool> OrchestrateAsync(OneDriveAccount account, string token, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
+    Task<bool> OrchestrateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
@@ -8,12 +8,12 @@ public interface ISyncPipeline
 {
     /// <summary>Runs all <paramref name="jobs"/> concurrently using up to <paramref name="workerCount"/> workers, reporting progress and completion via the supplied callbacks.</summary>
     /// <param name="jobs">The jobs to process.</param>
-    /// <param name="accessToken">The OAuth access token passed to each worker.</param>
+    /// <param name="tokenFactory">The token factory used to obtain an access token for each worker.</param>
     /// <param name="onProgress">Invoked after each job completes with aggregate progress information.</param>
     /// <param name="onJobCompleted">Invoked after each job completes with the resulting <see cref="SyncJob"/>.</param>
     /// <param name="accountId">The account identifier used in progress events.</param>
     /// <param name="folderId">The folder identifier used in progress events.</param>
     /// <param name="workerCount">Maximum number of concurrent workers. Defaults to 8.</param>
     /// <param name="ct">Token used to cancel the pipeline.</param>
-    Task RunAsync(IEnumerable<SyncJob> jobs, string accessToken, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default);
+    Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncWorker.cs
@@ -7,5 +7,5 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public interface ISyncWorker
 {
     /// <summary>Processes all jobs from <paramref name="reader"/> until the channel completes or <paramref name="ct"/> is cancelled.</summary>
-    Task RunAsync(ChannelReader<SyncJob> reader, string accountId, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct);
+    Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -24,7 +24,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISyncRepository syncRepository, ILogger<ParallelSyncPipeline> logger) : ISyncPipeline
 {
     /// <inheritdoc />
-    public async Task RunAsync(IEnumerable<SyncJob> jobs, string accessToken, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default)
+    public async Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default)
     {
         var jobList = jobs.ToList();
         if (jobList.Count == 0)
@@ -41,7 +41,7 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
             });
 
         var workers = Enumerable.Range(1, workerCount)
-            .Select(id => workerFactory.Create(id).RunAsync(channel.Reader, accountId, accessToken, (job, success, error) => tracker.RecordCompletion(job, success, error, onProgress, onJobCompleted), ct))
+            .Select(id => workerFactory.Create(id).RunAsync(channel.Reader, accountId, tokenFactory, (job, success, error) => tracker.RecordCompletion(job, success, error, onProgress, onJobCompleted), ct))
             .ToList();
 
         try

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -13,7 +13,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileSystem fileSystem) : ISyncJobExecutor
 {
     /// <inheritdoc />
-    public async Task ExecuteAsync(OneDriveAccount account, string accessToken, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
+    public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
     {
         if(jobs.Count == 0)
             return;
@@ -24,7 +24,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
 
         await syncPipeline.RunAsync(
             jobs,
-            accessToken,
+            tokenFactory,
             onProgress,
             args =>
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -19,7 +19,8 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         driveState.DeltaLink = Option.None<string>();
         await driveStateRepository.UpsertAsync(driveState, ct).ConfigureAwait(false);
 
-        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, ct).ConfigureAwait(false);
+        Action<int>? enumerationProgress = onProgress is null ? null : count => RaiseProgress(account.Id.Id, count, 0, $"Enumerating: {count} item(s) found", onProgress);
+        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, enumerationProgress, ct).ConfigureAwait(false);
 
         if(enumerationResult.HadNoRules)
             return false;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -10,7 +10,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, SyncServiceDependencies dependencies) : ISyncPassOrchestrator
 {
-    public async Task<bool> OrchestrateAsync(OneDriveAccount account, string token, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
+    public async Task<bool> OrchestrateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
     {
         var driveState = (await driveStateRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false))
             .Match(v => v, () => new DriveStateEntity { AccountId = account.Id });
@@ -20,7 +20,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         await driveStateRepository.UpsertAsync(driveState, ct).ConfigureAwait(false);
 
         Action<int>? enumerationProgress = onProgress is null ? null : count => RaiseProgress(account.Id.Id, count, 0, $"Enumerating: {count} item(s) found", onProgress);
-        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, token, enumerationProgress, ct).ConfigureAwait(false);
+        var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, tokenFactory, enumerationProgress, ct).ConfigureAwait(false);
 
         if(enumerationResult.HadNoRules)
             return false;
@@ -31,7 +31,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         await dependencies.RemoteDeletionDetector.DetectAndApplyAsync(account.Id, syncedItemsDict, enumerationResult.SeenRemoteIds, enumerationResult.Rules, ct).ConfigureAwait(false);
 
         RaiseProgress(account.Id.Id, 0, 0, "Detecting local changes...", onProgress);
-        await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, token, syncedItemsDict, ct).ConfigureAwait(false);
+        await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, tokenFactory, syncedItemsDict, ct).ConfigureAwait(false);
 
         var downloadJobs = await dependencies.DownloadJobBuilder.BuildAsync(account, enumerationResult.DeltaItems, enumerationResult.Rules, syncedItemsDict, conflictCallback, ct).ConfigureAwait(false);
 
@@ -45,7 +45,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         if(allJobs.Count > 0)
         {
             RaiseProgress(account.Id.Id, 0, allJobs.Count, $"Syncing {allJobs.Count} file(s)...", onProgress);
-            await dependencies.JobExecutor.ExecuteAsync(account, token, allJobs, syncedItemsDict, onProgress ?? (_ => { }), onJobCompleted ?? (_ => { }), ct).ConfigureAwait(false);
+            await dependencies.JobExecutor.ExecuteAsync(account, tokenFactory, allJobs, syncedItemsDict, onProgress ?? (_ => { }), onJobCompleted ?? (_ => { }), ct).ConfigureAwait(false);
         }
         else
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
@@ -16,7 +16,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers, ISyncRepository syncRepository, ILogger<SyncWorker> logger) : ISyncWorker
 {
     /// <inheritdoc />
-    public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, string accessToken, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
+    public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
     {
         await foreach (var job in reader.ReadAllAsync(ct))
         {
@@ -32,7 +32,7 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
 
             try
             {
-                (currentJob, success, error) = await ExecuteJobAsync(job, accountId, accessToken, ct)
+                (currentJob, success, error) = await ExecuteJobAsync(job, accountId, tokenFactory, ct)
                     .MatchAsync<SyncJob, string, (SyncJob, bool, string?)>(
                         completedJob => (completedJob, true, null),
                         reason => (currentJob, false, reason)).ConfigureAwait(false);
@@ -60,7 +60,7 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
         }
     }
 
-    private Task<Result<SyncJob, string>> ExecuteJobAsync(SyncJob job, string accountId, string accessToken, CancellationToken ct)
+    private Task<Result<SyncJob, string>> ExecuteJobAsync(SyncJob job, string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
     {
         var handler = handlers.FirstOrDefault(h => h.CanHandle(job));
 
@@ -71,6 +71,6 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
             return Task.FromResult<Result<SyncJob, string>>(new Result<SyncJob, string>.Error($"No handler registered for job type '{job.GetType().Name}'."));
         }
 
-        return handler.HandleAsync(job, accountId, accessToken, ct);
+        return handler.HandleAsync(job, accountId, tokenFactory, ct);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -53,7 +53,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             await authService.AcquireTokenSilentAsync(account.Id.Id, innerCt)
                 .MatchAsync<AuthResult, AuthError, string>(
                     ok => ok.AccessToken,
-                    _ => string.Empty).ConfigureAwait(false);
+                    _ => throw new InvalidOperationException("Token acquisition failed.")).ConfigureAwait(false);
 
         try
         {
@@ -101,7 +101,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, innerCt)
                 .MatchAsync<AuthResult, AuthError, string>(
                     ok => ok.AccessToken,
-                    _ => string.Empty).ConfigureAwait(false);
+                    _ => throw new InvalidOperationException("Token acquisition failed.")).ConfigureAwait(false);
 
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
         bool applied = await conflictApplier.ApplyAsync(conflict, outcome, conflict.Remote.AccountId.Id, tokenFactory, ct).ConfigureAwait(false);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -33,17 +33,14 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
         OneDriveSyncClientMessages.SyncServiceStarting(logger, account.Profile.Email);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
-        string? accessToken = await authService.AcquireTokenSilentAsync(account.Id.Id, ct)
-            .MatchAsync<AuthResult, AuthError, string?>(
-                ok => ok.AccessToken,
-                _ =>
-                {
-                    RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.AuthFailed"), SyncState.Error);
-                    return null;
-                }).ConfigureAwait(false);
+        var initialAuth = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
+        bool authOk = initialAuth.Match<bool>(_ => true, _ => false);
 
-        if (accessToken is null)
+        if (!authOk)
+        {
+            RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.AuthFailed"), SyncState.Error);
             return;
+        }
 
         if (account.SyncConfig is Option<AccountSyncConfig>.None)
         {
@@ -52,11 +49,17 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             return;
         }
 
+        Func<CancellationToken, Task<string>> tokenFactory = async innerCt =>
+            await authService.AcquireTokenSilentAsync(account.Id.Id, innerCt)
+                .MatchAsync<AuthResult, AuthError, string>(
+                    ok => ok.AccessToken,
+                    _ => string.Empty).ConfigureAwait(false);
+
         try
         {
             bool didRun = await syncPassOrchestrator.OrchestrateAsync(
                 account,
-                accessToken,
+                tokenFactory,
                 async conflict =>
                 {
                     await syncRepository.AddConflictAsync(conflict).ConfigureAwait(false);
@@ -88,14 +91,20 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
     /// <inheritdoc />
     public async Task ResolveConflictAsync(SyncConflict conflict, ConflictPolicy policy, CancellationToken ct = default)
     {
-        string? accessToken = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct)
-            .MatchAsync<AuthResult, AuthError, string?>(ok => ok.AccessToken, _ => null).ConfigureAwait(false);
+        var initialAuth = await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, ct).ConfigureAwait(false);
+        bool authOk = initialAuth.Match<bool>(_ => true, _ => false);
 
-        if (accessToken is null)
+        if (!authOk)
             return;
 
+        Func<CancellationToken, Task<string>> tokenFactory = async innerCt =>
+            await authService.AcquireTokenSilentAsync(conflict.Remote.AccountId.Id, innerCt)
+                .MatchAsync<AuthResult, AuthError, string>(
+                    ok => ok.AccessToken,
+                    _ => string.Empty).ConfigureAwait(false);
+
         var outcome = ConflictResolver.Resolve(policy, conflict.Snapshot.LocalModified, conflict.Snapshot.RemoteModified);
-        bool applied = await conflictApplier.ApplyAsync(conflict, outcome, conflict.Remote.AccountId.Id, accessToken, ct).ConfigureAwait(false);
+        bool applied = await conflictApplier.ApplyAsync(conflict, outcome, conflict.Remote.AccountId.Id, tokenFactory, ct).ConfigureAwait(false);
 
         if (!applied)
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -215,7 +215,7 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
 
         try
         {
-            var folders = await graphService.GetRootFoldersAsync(_accountId, _accessToken)
+            var folders = await graphService.GetRootFoldersAsync(_accountId, _ => Task.FromResult(_accessToken ?? string.Empty))
                 .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
                     f => f,
                     error =>


### PR DESCRIPTION
## Summary

- Replaces every `string accessToken` parameter in the sync pipeline with `Func<CancellationToken, Task<string>> tokenFactory`
- `SyncService` builds the factory from `IAuthService.AcquireTokenSilentAsync` — MSAL returns cached token when valid, silently refreshes when not
- `GraphClientFactory` now uses `DelegatingAccessTokenProvider` that calls the factory per request, replacing the old `StaticAccessTokenProvider` that baked in a single token
- `GraphService.GetChildFoldersAsync`, `EnumerateFolderAsync`, and `DeleteItemAsync` wrapped in `try/catch(when not OperationCanceledException)` so `ODataError` returns `Result<..., string>.Error` instead of throwing

## Root Cause

For accounts with 50k+ files, enumeration takes 45+ minutes. The pre-resolved `string accessToken` (1-hour lifetime) expired before workers executed, causing `ODataError IDX14100: JWT is not well formed` from a CAE challenge the static provider could not answer.

## Test plan

- [x] `dotnet build apps/desktop/AStar.Dev.OneDrive.Sync.Client` — 0 errors, 0 warnings
- [x] `dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — Passed: 1085, Failed: 0
- [x] 3 new WireMock tests verify `GetChildFoldersAsync`, `EnumerateFolderAsync`, `DeleteItemAsync` return `Result.Error` on 500 responses (not throw)
- [x] New `GivenASyncWorker` test verifies token factory flows through to job handlers

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)