### PR TITLE
fix(apps/desktop): fetch and display OneDrive storage quota on dashboard

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -27,8 +27,8 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     [Fact]
     public async Task when_wizard_completes_then_account_onboarding_service_is_called()
     {
-        var (authService, graphService, repository, onboardingService) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, onboardingService);
+        var (authService, graphService, repository, onboardingService, quotaRefreshService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService, quotaRefreshService);
 
         await DriveWizardToCompletionAsync(sut);
 
@@ -38,8 +38,8 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     [Fact]
     public async Task when_wizard_completes_then_account_is_added_to_accounts_collection()
     {
-        var (authService, graphService, repository, onboardingService) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, onboardingService);
+        var (authService, graphService, repository, onboardingService, quotaRefreshService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService, quotaRefreshService);
 
         await DriveWizardToCompletionAsync(sut);
 
@@ -47,14 +47,36 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
     }
 
     [Fact]
+    public async Task when_wizard_completes_then_quota_refresh_service_is_called_for_new_account()
+    {
+        var (authService, graphService, repository, onboardingService, quotaRefreshService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService, quotaRefreshService);
+
+        await DriveWizardToCompletionAsync(sut);
+
+        await quotaRefreshService.Received(1).TryRefreshAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task when_wizard_is_cancelled_then_account_onboarding_service_is_not_called()
     {
-        var (authService, graphService, repository, onboardingService) = BuildMocks();
-        var sut = BuildSut(authService, graphService, repository, onboardingService);
+        var (authService, graphService, repository, onboardingService, quotaRefreshService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService, quotaRefreshService);
 
         await DriveWizardToCancellationAsync(sut);
 
         await onboardingService.DidNotReceive().CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_wizard_is_cancelled_then_quota_refresh_service_is_not_called()
+    {
+        var (authService, graphService, repository, onboardingService, quotaRefreshService) = BuildMocks();
+        var sut = BuildSut(authService, graphService, repository, onboardingService, quotaRefreshService);
+
+        await DriveWizardToCancellationAsync(sut);
+
+        await quotaRefreshService.DidNotReceive().TryRefreshAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
     }
 
     private static async Task DriveWizardToCompletionAsync(AccountsViewModel sut)
@@ -81,12 +103,13 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         await Task.Delay(50);
     }
 
-    private static (IAuthService AuthService, IGraphService GraphService, IAccountRepository Repository, IAccountOnboardingService OnboardingService) BuildMocks()
+    private static (IAuthService AuthService, IGraphService GraphService, IAccountRepository Repository, IAccountOnboardingService OnboardingService, IQuotaRefreshService QuotaRefreshService) BuildMocks()
     {
-        var authService       = Substitute.For<IAuthService>();
-        var graphService      = Substitute.For<IGraphService>();
-        var repository        = Substitute.For<IAccountRepository>();
-        var onboardingService = Substitute.For<IAccountOnboardingService>();
+        var authService          = Substitute.For<IAuthService>();
+        var graphService         = Substitute.For<IGraphService>();
+        var repository           = Substitute.For<IAccountRepository>();
+        var onboardingService    = Substitute.For<IAccountOnboardingService>();
+        var quotaRefreshService  = Substitute.For<IQuotaRefreshService>();
 
         authService.SignInInteractiveAsync(Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success(AccessToken, AccountIdStr, AccountProfileFactory.Create(DisplayName, Email)));
@@ -97,9 +120,9 @@ public sealed class GivenAnAccountsViewModelWithACompletingWizard
         onboardingService.CompleteOnboardingAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
             .Returns(callInfo => callInfo.Arg<OneDriveAccount>());
 
-        return (authService, graphService, repository, onboardingService);
+        return (authService, graphService, repository, onboardingService, quotaRefreshService);
     }
 
-    private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService onboardingService)
-        => new(authService, graphService, repository, onboardingService, Substitute.For<ISyncEventAggregator>(), Substitute.For<ILocalizationService>(), Substitute.For<ILogger<AccountsViewModel>>());
+    private static AccountsViewModel BuildSut(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService onboardingService, IQuotaRefreshService quotaRefreshService)
+        => new(authService, graphService, repository, onboardingService, quotaRefreshService, Substitute.For<ISyncEventAggregator>(), Substitute.For<ILocalizationService>(), Substitute.For<ILogger<AccountsViewModel>>());
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelWithQuotaUpdate.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelWithQuotaUpdate.cs
@@ -1,0 +1,68 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenADashboardViewModelWithQuotaUpdate
+{
+    private readonly ISyncScheduler _scheduler = Substitute.For<ISyncScheduler>();
+    private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    private DashboardViewModel CreateSut() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
+
+    private static OneDriveAccount BuildAccount(string id) => new() { Id = new AccountId(id) };
+
+    [Fact]
+    public void when_update_quota_called_for_known_account_then_quota_total_is_updated()
+    {
+        var account = BuildAccount("acc-1");
+        var sut = CreateSut();
+        sut.AddAccount(account);
+
+        sut.UpdateQuota("acc-1", StorageQuotaFactory.Create(1_073_741_824L, 536_870_912L));
+
+        sut.AccountSections.Single().QuotaTotal.ShouldBe(1_073_741_824L);
+    }
+
+    [Fact]
+    public void when_update_quota_called_for_known_account_then_quota_used_is_updated()
+    {
+        var account = BuildAccount("acc-1");
+        var sut = CreateSut();
+        sut.AddAccount(account);
+
+        sut.UpdateQuota("acc-1", StorageQuotaFactory.Create(1_073_741_824L, 536_870_912L));
+
+        sut.AccountSections.Single().QuotaUsed.ShouldBe(536_870_912L);
+    }
+
+    [Fact]
+    public void when_update_quota_called_for_known_account_then_storage_fraction_is_updated()
+    {
+        var account = BuildAccount("acc-1");
+        var sut = CreateSut();
+        sut.AddAccount(account);
+
+        sut.UpdateQuota("acc-1", StorageQuotaFactory.Create(1_073_741_824L, 536_870_912L));
+
+        sut.AccountSections.Single().StorageFraction.ShouldBe(0.5);
+    }
+
+    [Fact]
+    public void when_update_quota_called_for_unknown_account_then_no_exception_is_thrown()
+    {
+        var sut = CreateSut();
+
+        var exception = Record.Exception(() => sut.UpdateQuota("does-not-exist", StorageQuotaFactory.Create(100L, 50L)));
+
+        exception.ShouldBeNull();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
@@ -133,6 +133,33 @@ public sealed class GivenAnAccountRepository : IDisposable
     }
 
     [Fact]
+    public async Task when_updating_quota_for_existing_account_then_quota_is_persisted()
+    {
+        var repository = new AccountRepository(_factory);
+        var account = new AccountEntity { Id = new AccountId("user-1"), Profile = AccountProfileFactory.Create("User", "user@outlook.com"), Quota = StorageQuotaFactory.Unknown };
+        _ = _seedingContext.Accounts.Add(account);
+        _ = await _seedingContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await repository.UpdateQuotaAsync(new AccountId("user-1"), StorageQuotaFactory.Create(1_073_741_824L, 536_870_912L), TestContext.Current.CancellationToken);
+
+        _seedingContext.ChangeTracker.Clear();
+        var retrieved = await _seedingContext.Accounts.FindAsync([new AccountId("user-1")], cancellationToken: TestContext.Current.CancellationToken);
+        _ = retrieved.ShouldNotBeNull();
+        retrieved.Quota.TotalBytes.ShouldBe(1_073_741_824L);
+        retrieved.Quota.UsedBytes.ShouldBe(536_870_912L);
+    }
+
+    [Fact]
+    public async Task when_updating_quota_for_non_existing_account_then_no_exception_is_thrown()
+    {
+        var repository = new AccountRepository(_factory);
+
+        var exception = await Record.ExceptionAsync(() => repository.UpdateQuotaAsync(new AccountId("does-not-exist"), StorageQuotaFactory.Create(100L, 50L), TestContext.Current.CancellationToken));
+
+        exception.ShouldBeNull();
+    }
+
+    [Fact]
     public async Task when_deleting_account_then_account_is_removed()
     {
         var repository = new AccountRepository(_factory);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -42,7 +42,7 @@ public sealed class GivenAMainWindowViewModel
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -20,7 +20,7 @@ public sealed class GivenAStatusBarViewModel
     private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
 
     private AccountCardViewModel CreateCard(string email = "test@example.com", string displayName = "Test User") => new(new OneDriveAccount { Profile = AccountProfileFactory.Create(displayName, email) }, _localizationService);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAQuotaRefreshService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAQuotaRefreshService.cs
@@ -1,0 +1,98 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using Microsoft.Extensions.Logging;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Graph;
+
+public sealed class GivenAQuotaRefreshService
+{
+    private readonly IGraphService _graphService = Substitute.For<IGraphService>();
+    private readonly IAuthService _authService = Substitute.For<IAuthService>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ILogger<QuotaRefreshService> _logger = Substitute.For<ILogger<QuotaRefreshService>>();
+
+    private QuotaRefreshService CreateSut() => new(_graphService, _authService, _accountRepository, _logger);
+
+    private static OneDriveAccount BuildAccount(string id = "acc-1") => new() { Id = new AccountId(id) };
+
+    private static Result<AuthResult, AuthError> BuildSuccessAuthResult(string token = "access-token")
+        => AuthResultFactory.Success(token, "acc-1", AccountProfileFactory.Create("Test", "test@test.com"));
+
+    [Fact]
+    public async Task when_auth_succeeds_and_quota_fetched_then_account_quota_is_updated()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(BuildSuccessAuthResult());
+        _graphService.GetQuotaAsync("acc-1", Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<(long Total, long Used), string>.Ok((1_073_741_824L, 536_870_912L)));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        account.Quota.TotalBytes.ShouldBe(1_073_741_824L);
+        account.Quota.UsedBytes.ShouldBe(536_870_912L);
+    }
+
+    [Fact]
+    public async Task when_auth_succeeds_and_quota_fetched_then_quota_is_persisted_to_repository()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(BuildSuccessAuthResult());
+        _graphService.GetQuotaAsync("acc-1", Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<(long Total, long Used), string>.Ok((1_073_741_824L, 536_870_912L)));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        await _accountRepository.Received(1).UpdateQuotaAsync(new AccountId("acc-1"), StorageQuotaFactory.Create(1_073_741_824L, 536_870_912L), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_auth_fails_then_account_quota_remains_unknown()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(new Result<AuthResult, AuthError>.Error(new AuthFailedError("silent auth failed")));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        account.Quota.TotalBytes.ShouldBe(0L);
+        account.Quota.UsedBytes.ShouldBe(0L);
+    }
+
+    [Fact]
+    public async Task when_auth_fails_then_graph_service_is_not_called()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(new Result<AuthResult, AuthError>.Error(new AuthFailedError("silent auth failed")));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        await _graphService.DidNotReceive().GetQuotaAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_quota_fetch_fails_then_account_quota_remains_unknown()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(BuildSuccessAuthResult());
+        _graphService.GetQuotaAsync("acc-1", Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<(long Total, long Used), string>.Error("Graph API error"));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        account.Quota.TotalBytes.ShouldBe(0L);
+        account.Quota.UsedBytes.ShouldBe(0L);
+    }
+
+    [Fact]
+    public async Task when_quota_fetch_fails_then_repository_is_not_called()
+    {
+        var account = BuildAccount();
+        _authService.AcquireTokenSilentAsync("acc-1", Arg.Any<CancellationToken>()).Returns(BuildSuccessAuthResult());
+        _graphService.GetQuotaAsync("acc-1", Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>()).Returns(new Result<(long Total, long Used), string>.Error("Graph API error"));
+
+        await CreateSut().TryRefreshAsync(account, TestContext.Current.CancellationToken);
+
+        await _accountRepository.DidNotReceive().UpdateQuotaAsync(Arg.Any<AccountId>(), Arg.Any<StorageQuota>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -67,7 +67,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
 
     private MainWindowViewModel CreateMainWindowViewModel()
     {
-        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), syncEventAggregator, localizationService, Substitute.For<ILogger<AccountsViewModel>>());
+        var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), syncEventAggregator, localizationService, Substitute.For<ILogger<AccountsViewModel>>());
         var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), localizationService);
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
         var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator, localizationService);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -26,6 +26,7 @@ public sealed class GivenAnApplicationInitializer
     private readonly IStartupService _startupService = Substitute.For<IStartupService>();
     private readonly IAuthService _authService = Substitute.For<IAuthService>();
     private readonly IGraphService _graphService = Substitute.For<IGraphService>();
+    private readonly IQuotaRefreshService _quotaRefreshService = Substitute.For<IQuotaRefreshService>();
     private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
     private readonly ISyncService _syncService = Substitute.For<ISyncService>();
     private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
@@ -42,7 +43,7 @@ public sealed class GivenAnApplicationInitializer
         _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
     }
 
-    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
+    private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _quotaRefreshService, _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService);
@@ -58,7 +59,7 @@ public sealed class GivenAnApplicationInitializer
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService);
 
     private ApplicationInitializer CreateSut(AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, FileClassificationRulesViewModel classificationRules)
-        => new(_startupService, accounts, files, dashboard, activity, settings, classificationRules, Substitute.For<ILogger<ApplicationInitializer>>());
+        => new(_startupService, _quotaRefreshService, accounts, files, dashboard, activity, settings, classificationRules, Substitute.For<ILogger<ApplicationInitializer>>());
 
     private static OneDriveAccount BuildAccount(string id = "acc-1", string email = "user@test.com", bool isActive = false)
         => new() { Id = new AccountId(id), Profile = AccountProfileFactory.Create("Test User", email), IsActive = isActive, SelectedFolderIds = [] };
@@ -117,6 +118,22 @@ public sealed class GivenAnApplicationInitializer
         await sut.InitializeAsync(TestContext.Current.CancellationToken);
 
         settings.AccountSettings.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task when_initialized_then_quota_refresh_is_called_for_each_restored_account()
+    {
+        var acc1 = BuildAccount("acc-1");
+        var acc2 = BuildAccount("acc-2");
+        _startupService.RestoreAccountsAsync().Returns([acc1, acc2]);
+
+        var classificationRules = CreateClassificationRulesViewModel();
+        var sut = CreateSut(CreateAccountsViewModel(), CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), classificationRules);
+
+        await sut.InitializeAsync(TestContext.Current.CancellationToken);
+
+        await _quotaRefreshService.Received(1).TryRefreshAsync(acc1, Arg.Any<CancellationToken>());
+        await _quotaRefreshService.Received(1).TryRefreshAsync(acc2, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -19,7 +19,7 @@ using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, ISyncEventAggregator syncEventAggregator, ILocalizationService localizationService, ILogger<AccountsViewModel> logger) : ObservableObject
+public sealed partial class AccountsViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, IAccountOnboardingService accountOnboardingService, IQuotaRefreshService quotaRefreshService, ISyncEventAggregator syncEventAggregator, ILocalizationService localizationService, ILogger<AccountsViewModel> logger) : ObservableObject
 {
     private readonly ILogger<AccountsViewModel> _logger = logger;
     private readonly ILocalizationService _localizationService = localizationService;
@@ -107,6 +107,8 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
                     account.IsActive = Accounts.Count == 0;
 
                     var finalisedAccount = await accountOnboardingService.CompleteOnboardingAsync(account, CancellationToken.None);
+
+                    await quotaRefreshService.TryRefreshAsync(finalisedAccount, CancellationToken.None).ConfigureAwait(false);
 
                     var card = BuildCard(finalisedAccount);
                     Accounts.Add(card);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -108,7 +108,7 @@ public sealed partial class AccountsViewModel(IAuthService authService, IGraphSe
 
                     var finalisedAccount = await accountOnboardingService.CompleteOnboardingAsync(account, CancellationToken.None);
 
-                    await quotaRefreshService.TryRefreshAsync(finalisedAccount, CancellationToken.None).ConfigureAwait(false);
+                    await quotaRefreshService.TryRefreshAsync(finalisedAccount, CancellationToken.None);
 
                     var card = BuildCard(finalisedAccount);
                     Accounts.Add(card);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardAccountViewModel.cs
@@ -123,6 +123,16 @@ public sealed partial class DashboardAccountViewModel : ObservableObject
         UpdateLastSyncText(state);
     }
 
+    /// <summary>Updates the displayed storage quota. Call after a successful quota refresh from the Graph API.</summary>
+    public void UpdateQuota(StorageQuota quota)
+    {
+        _account.Quota = quota;
+        OnPropertyChanged(nameof(QuotaTotal));
+        OnPropertyChanged(nameof(QuotaUsed));
+        OnPropertyChanged(nameof(StorageFraction));
+        OnPropertyChanged(nameof(StorageText));
+    }
+
     public void AddRecentActivity(ActivityItemViewModel item)
     {
         RecentActivity.Insert(0, item);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Dashboard/DashboardViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
@@ -98,6 +99,13 @@ public sealed partial class DashboardViewModel(ISyncScheduler scheduler, ILocali
         section.FolderCount = folderCount;
 
         RecalculateGlobals();
+    }
+
+    /// <summary>Updates the storage quota for the named account section. No-op if the account is not present.</summary>
+    public void UpdateQuota(string accountId, StorageQuota quota)
+    {
+        var section = AccountSections.FirstOrDefault(s => s.AccountId == accountId);
+        section?.UpdateQuota(quota);
     }
 
     public void MarkSyncCompleted(string accountId)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
@@ -52,6 +52,19 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
     }
 
     /// <inheritdoc/>
+    public async Task UpdateQuotaAsync(AccountId id, StorageQuota quota, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await db.Accounts.FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
+        if(entity is null)
+            return;
+
+        entity.Quota = quota;
+        _ = await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task DeleteAsync(AccountId id, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IAccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IAccountRepository.cs
@@ -29,6 +29,14 @@ public interface IAccountRepository
     Task UpsertAsync(AccountEntity account, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Updates the storage quota for the account with the specified ID.
+    /// </summary>
+    /// <param name="id">The account ID.</param>
+    /// <param name="quota">The new storage quota values.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task UpdateQuotaAsync(AccountId id, StorageQuota quota, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Deletes the account with the specified ID. If no such account exists, does nothing.
     /// </summary>
     /// <param name="id">The ID of the account to delete.</param>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IQuotaRefreshService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IQuotaRefreshService.cs
@@ -1,0 +1,14 @@
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+/// <summary>
+/// Fetches the current OneDrive storage quota for an account from the Graph API,
+/// updates the in-memory account object, and persists the result to the database.
+/// All failures are swallowed — callers must not depend on success.
+/// </summary>
+public interface IQuotaRefreshService
+{
+    /// <summary>Refreshes the quota for <paramref name="account"/>. Updates <see cref="OneDriveAccount.Quota"/> and persists on success. No-op on failure.</summary>
+    Task TryRefreshAsync(OneDriveAccount account, CancellationToken ct = default);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/QuotaRefreshService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/QuotaRefreshService.cs
@@ -1,0 +1,38 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+/// <inheritdoc />
+public sealed class QuotaRefreshService(IGraphService graphService, IAuthService authService, IAccountRepository accountRepository, ILogger<QuotaRefreshService> logger) : IQuotaRefreshService
+{
+    /// <inheritdoc />
+    public async Task TryRefreshAsync(OneDriveAccount account, CancellationToken ct = default)
+    {
+        var tokenResult = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
+
+        await tokenResult
+            .TapError(_ => OneDriveSyncClientMessages.QuotaRefreshTokenFailed(logger, account.Id.Id))
+            .TapAsync(auth => ApplyQuotaAsync(account, auth, ct))
+            .ConfigureAwait(false);
+    }
+
+    private async Task ApplyQuotaAsync(OneDriveAccount account, AuthResult auth, CancellationToken ct)
+    {
+        var quotaResult = await graphService.GetQuotaAsync(account.Id.Id, _ => Task.FromResult(auth.AccessToken), ct).ConfigureAwait(false);
+
+        await quotaResult
+            .TapError(error => OneDriveSyncClientMessages.QuotaRefreshFetchFailed(logger, account.Id.Id, error))
+            .TapAsync(async quota =>
+            {
+                account.Quota = StorageQuotaFactory.Create(quota.Total, quota.Used);
+                await accountRepository.UpdateQuotaAsync(account.Id, account.Quota, ct).ConfigureAwait(false);
+            })
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -297,6 +297,16 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 3104, Level = LogLevel.Warning, Message = "[AuthService] Silent token requires UI interaction: ErrorCode={ErrorCode} Classification={Classification}")]
     public static partial void AuthSilentTokenUiRequired(ILogger logger, string errorCode, string classification);
 
+    // Quota Refresh (3200-3299)
+
+    /// <summary>Logs failure to acquire a silent token during quota refresh.</summary>
+    [LoggerMessage(EventId = 3200, Level = LogLevel.Warning, Message = "[QuotaRefreshService] Silent token failed for account {AccountId} — quota not refreshed")]
+    public static partial void QuotaRefreshTokenFailed(ILogger logger, string accountId);
+
+    /// <summary>Logs failure to fetch quota from the Graph API.</summary>
+    [LoggerMessage(EventId = 3201, Level = LogLevel.Warning, Message = "[QuotaRefreshService] Graph quota fetch failed for account {AccountId}: {Error}")]
+    public static partial void QuotaRefreshFetchFailed(ILogger logger, string accountId, string error);
+
     // Application Lifecycle (use ApplicationMessages for these)
     // - Starting/Stopping handled by ApplicationMessages.Starting/Stopping
     // - Unhandled exception handled by MainWindowInitializeFatal, BootstrapFatal, etc.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -307,6 +307,10 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 3201, Level = LogLevel.Warning, Message = "[QuotaRefreshService] Graph quota fetch failed for account {AccountId}: {Error}")]
     public static partial void QuotaRefreshFetchFailed(ILogger logger, string accountId, string error);
 
+    /// <summary>Logs unexpected exception during the startup quota refresh pass — startup continues normally.</summary>
+    [LoggerMessage(EventId = 3202, Level = LogLevel.Warning, Message = "[ApplicationInitializer] Startup quota refresh failed: {Error}")]
+    public static partial void QuotaRefreshStartupFailed(ILogger logger, string error, Exception ex);
+
     // Application Lifecycle (use ApplicationMessages for these)
     // - Starting/Stopping handled by ApplicationMessages.Starting/Stopping
     // - Unhandled exception handled by MainWindowInitializeFatal, BootstrapFatal, etc.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
@@ -43,7 +43,14 @@ public sealed class ApplicationInitializer(IStartupService startupService, IQuot
                 await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Profile.Email).ConfigureAwait(false);
             }
 
-            await RefreshQuotasAsync(restored, ct).ConfigureAwait(false);
+            try
+            {
+                await RefreshQuotasAsync(restored, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                OneDriveSyncClientMessages.QuotaRefreshStartupFailed(logger, ex.Message, ex);
+            }
         }
         catch (Exception ex)
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 /// <inheritdoc />
-public sealed class ApplicationInitializer(IStartupService startupService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, FileClassificationRulesViewModel classificationRules, ILogger<ApplicationInitializer> logger) : IApplicationInitializer
+public sealed class ApplicationInitializer(IStartupService startupService, IQuotaRefreshService quotaRefreshService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, FileClassificationRulesViewModel classificationRules, ILogger<ApplicationInitializer> logger) : IApplicationInitializer
 {
     /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken ct = default)
@@ -41,11 +42,22 @@ public sealed class ApplicationInitializer(IStartupService startupService, Accou
                 await files.ActivateAccountAsync(activeAccount.Id.Id).ConfigureAwait(false);
                 await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Profile.Email).ConfigureAwait(false);
             }
+
+            await RefreshQuotasAsync(restored, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             OneDriveSyncClientMessages.ApplicationInitializeFatal(logger, ex.Message, ex);
             throw;
+        }
+    }
+
+    private async Task RefreshQuotasAsync(IReadOnlyList<OneDriveAccount> restored, CancellationToken ct)
+    {
+        foreach (var account in restored)
+        {
+            await quotaRefreshService.TryRefreshAsync(account, ct).ConfigureAwait(false);
+            dashboard.UpdateQuota(account.Id.Id, account.Quota);
         }
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -34,6 +34,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IAuthService, AuthService>();
         _ = services.AddSingleton<IGraphClientFactory, GraphClientFactory>();
         _ = services.AddSingleton<IGraphService, GraphService>();
+        _ = services.AddSingleton<IQuotaRefreshService, QuotaRefreshService>();
         _ = services.AddSingleton<IStartupService, StartupService>();
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();
         _ = services.AddSingleton<IUploadService, UploadService>();


### PR DESCRIPTION
## Summary

- Closes #381
- `GetQuotaAsync` existed but was never called — `StorageQuota` stayed at `Unknown` (0, 0) forever, so the account tile always showed "Unknown" under Storage
- Introduces `IQuotaRefreshService` / `QuotaRefreshService` — acquires a silent token, calls `GraphService.GetQuotaAsync`, updates the in-memory `OneDriveAccount.Quota`, and persists via a new `IAccountRepository.UpdateQuotaAsync`
- `ApplicationInitializer` refreshes quotas for all restored accounts at startup (after the UI is set up)
- `AccountsViewModel` refreshes quota immediately after the add-account wizard completes (so the dashboard shows real data from first view)
- `DashboardAccountViewModel.UpdateQuota(StorageQuota)` + `DashboardViewModel.UpdateQuota(string, StorageQuota)` propagate the fetched values and raise `PropertyChanged` for `QuotaTotal`, `QuotaUsed`, `StorageFraction`, `StorageText`

## Test plan

- [x] `GivenAQuotaRefreshService` — 6 tests covering success path (quota updated + persisted), auth failure (no-op), Graph API failure (no-op)
- [x] `GivenADashboardViewModelWithQuotaUpdate` — 4 tests: total/used/fraction updated, unknown account is no-op
- [x] `GivenAnApplicationInitializer` — new test: `when_initialized_then_quota_refresh_is_called_for_each_restored_account`
- [x] `GivenAnAccountsViewModelWithACompletingWizard` — new tests: quota refresh called on wizard complete, not called on cancel
- [x] All 1148 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)