### PR TITLE
fix(apps/desktop): apply N0 thousand-separator format to sync progress counts

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -25,7 +25,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         Action<int>? enumerationProgress = onProgress is null ? null : count =>
         {
             if (count % progressReportInterval == 0)
-                RaiseProgress(account.Id.Id, count, 0, $"Enumerating: {count} item(s) found", onProgress);
+                RaiseProgress(account.Id.Id, count, 0, $"Enumerating: {count:N0} item(s) found", onProgress);
         };
 
         var enumerationResult = await dependencies.RemoteFolderEnumerator.EnumerateAsync(account, tokenFactory, enumerationProgress, ct).ConfigureAwait(false);
@@ -52,7 +52,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
 
         if(allJobs.Count > 0)
         {
-            RaiseProgress(account.Id.Id, 0, allJobs.Count, $"Syncing {allJobs.Count} file(s)...", onProgress);
+            RaiseProgress(account.Id.Id, 0, allJobs.Count, $"Syncing {allJobs.Count:N0} file(s)...", onProgress);
             await dependencies.JobExecutor.ExecuteAsync(account, tokenFactory, allJobs, syncedItemsDict, onProgress ?? (_ => { }), onJobCompleted ?? (_ => { }), ct).ConfigureAwait(false);
         }
         else


### PR DESCRIPTION
## Summary

- Enumeration and sync-job progress messages displayed raw integers (`12345`); applied `N0` format specifier so they render with culture-appropriate thousand separators (`12,345` in en-US, `12.345` in de-DE, etc.)
- Both affected call sites updated: `"Enumerating: {count:N0} item(s) found"` and `"Syncing {allJobs.Count:N0} file(s)..."`
- Existing tests use `StartsWith("Enumerating:")` — no test changes required

## Test plan

- [x] `dotnet build` — zero warnings/errors
- [x] All 1,135 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)