### PR TITLE
fix(apps/desktop): wire SyncProgressChanged to activity view (#369)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityViewModel.cs
@@ -1,0 +1,87 @@
+using AStar.Dev.OneDrive.Sync.Client.Activity;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Activity;
+
+public sealed class GivenAnActivityViewModel
+{
+    private const string AccountId = "acc-1";
+    private const string CurrentFile = "Documents/report.pdf";
+
+    private readonly ISyncService _syncService = Substitute.For<ISyncService>();
+    private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
+    private readonly ISyncEventAggregator _syncEventAggregator = Substitute.For<ISyncEventAggregator>();
+    private readonly ILocalizationService _loc = Substitute.For<ILocalizationService>();
+    private readonly IUiDispatcher _dispatcher = new InlineUiDispatcher();
+
+    public GivenAnActivityViewModel() =>
+        _syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
+
+    private ActivityViewModel CreateSut() => new(_syncService, _syncRepository, _syncEventAggregator, _loc, _dispatcher);
+
+    [Fact]
+    public void when_sync_progress_fires_with_total_zero_and_current_file_then_info_item_added_to_log()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        var args = new SyncProgressEventArgs(AccountId, "folder-1", 0, 0, CurrentFile, SyncState.Syncing);
+
+        _syncEventAggregator.SyncProgressChanged += Raise.EventWith(args);
+
+        sut.LogItems.ShouldHaveSingleItem();
+        sut.LogItems[0].Type.ShouldBe(ActivityItemType.Info);
+    }
+
+    [Fact]
+    public void when_sync_progress_fires_with_total_zero_and_current_file_then_item_account_id_matches_event()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        var args = new SyncProgressEventArgs(AccountId, "folder-1", 0, 0, CurrentFile, SyncState.Syncing);
+
+        _syncEventAggregator.SyncProgressChanged += Raise.EventWith(args);
+
+        sut.LogItems[0].AccountId.ShouldBe(AccountId);
+    }
+
+    [Fact]
+    public void when_sync_progress_fires_with_total_zero_and_current_file_then_item_file_name_matches_current_file()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        var args = new SyncProgressEventArgs(AccountId, "folder-1", 0, 0, CurrentFile, SyncState.Syncing);
+
+        _syncEventAggregator.SyncProgressChanged += Raise.EventWith(args);
+
+        sut.LogItems[0].FileName.ShouldBe(CurrentFile);
+    }
+
+    [Fact]
+    public void when_sync_progress_fires_with_total_greater_than_zero_then_no_item_added()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        var args = new SyncProgressEventArgs(AccountId, "folder-1", 1, 10, CurrentFile, SyncState.Syncing);
+
+        _syncEventAggregator.SyncProgressChanged += Raise.EventWith(args);
+
+        sut.LogItems.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void when_sync_progress_fires_with_empty_current_file_then_no_item_added()
+    {
+        var sut = CreateSut();
+        sut.SubscribeToSyncEvents();
+        var args = new SyncProgressEventArgs(AccountId, "folder-1", 0, 0, string.Empty, SyncState.Syncing);
+
+        _syncEventAggregator.SyncProgressChanged += Raise.EventWith(args);
+
+        sut.LogItems.ShouldBeEmpty();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -16,6 +16,7 @@ using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
@@ -45,7 +46,7 @@ public sealed class GivenAMainWindowViewModel
     private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
-    private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService);
+    private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService, new InlineUiDispatcher());
     private static FileClassificationRulesViewModel CreateClassificationRulesViewModel()
     {
         var repo = Substitute.For<IFileClassificationRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -16,6 +16,7 @@ using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -70,7 +71,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
         var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), syncEventAggregator, localizationService, Substitute.For<ILogger<AccountsViewModel>>());
         var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), localizationService);
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
-        var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator, localizationService);
+        var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator, localizationService, new InlineUiDispatcher());
         var classificationRulesRepo = Substitute.For<IFileClassificationRuleRepository>();
         classificationRulesRepo.GetAllWithIdsAsync(Arg.Any<CancellationToken>())
                                .Returns(Task.FromResult<IReadOnlyList<FileClassificationRuleEntry>>([]));

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -16,6 +16,7 @@ using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
@@ -46,7 +47,7 @@ public sealed class GivenAnApplicationInitializer
     private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _quotaRefreshService, _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
     private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
-    private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService);
+    private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService, new InlineUiDispatcher());
     private static FileClassificationRulesViewModel CreateClassificationRulesViewModel()
     {
         var repo = Substitute.For<IFileClassificationRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
@@ -9,14 +9,13 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Activity;
 
-public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRepository syncRepository, ISyncEventAggregator syncEventAggregator, ILocalizationService loc) : ObservableObject
+public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRepository syncRepository, ISyncEventAggregator syncEventAggregator, ILocalizationService loc, IUiDispatcher dispatcher) : ObservableObject
 {
     private const int MaxLogSize = 10_000;
     private string? _activeAccountId;
@@ -56,6 +55,7 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
 
     public void SubscribeToSyncEvents()
     {
+        syncEventAggregator.SyncProgressChanged += OnSyncProgressChanged;
         syncEventAggregator.JobCompleted += OnJobCompleted;
         syncEventAggregator.ConflictDetected += OnConflictDetected;
     }
@@ -100,7 +100,7 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
         };
 
     /// <summary>Called when a sync job completes.</summary>
-    public void AddActivityItem(ActivityItemViewModel item) => Dispatcher.UIThread.Post(() =>
+    public void AddActivityItem(ActivityItemViewModel item) => dispatcher.Post(() =>
                                                                     {
                                                                         LogItems.Insert(0, item);
 
@@ -112,7 +112,7 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
                                                                     });
 
     /// <summary>Called when a new conflict is detected.</summary>
-    public void AddConflictItem(SyncConflict conflict) => Dispatcher.UIThread.Post(() =>
+    public void AddConflictItem(SyncConflict conflict) => dispatcher.Post(() =>
                                                                {
                                                                    if(Conflicts.Any(c => c.Id == conflict.Id))
                                                                        return;
@@ -135,6 +135,15 @@ public sealed partial class ActivityViewModel(ISyncService syncService, ISyncRep
         LogItems.Clear();
         FilteredLog.Clear();
         LogItemCount = 0;
+    }
+
+    private void OnSyncProgressChanged(object? sender, SyncProgressEventArgs args)
+    {
+        if(args.Total != 0 || string.IsNullOrEmpty(args.CurrentFile))
+            return;
+
+        var item = new ActivityItemViewModel(loc) { AccountId = args.AccountId, FileName = args.CurrentFile, Type = ActivityItemType.Info };
+        AddActivityItem(item);
     }
 
     private void OnJobCompleted(object? sender, JobCompletedEventArgs args)


### PR DESCRIPTION
## Summary

- `ActivityViewModel.SubscribeToSyncEvents()` only subscribed to `JobCompleted` + `ConflictDetected`, missing `SyncProgressChanged` — the event that produces enumerating/progress info items shown on the dashboard but absent from the activity view
- Added `SyncProgressChanged` subscription with the same guard logic as `DashboardViewModel` (`Total == 0` and `CurrentFile` non-empty → create `Info` item)
- Replaced `Dispatcher.UIThread.Post` with injected `IUiDispatcher`, consistent with the `SyncEventAggregator` pattern and required to make the new behaviour unit-testable

Closes #369

## Test plan

- [x] New `GivenAnActivityViewModel` tests cover: info item added when `Total=0` + `CurrentFile` set; no item when `Total > 0`; no item when `CurrentFile` empty
- [x] All 1155 existing tests still pass
- [x] `dotnet build` — zero errors, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)