### PR TITLE
docs(claude): compress CLAUDE.md and rule files to under 200 lines

### DIFF
--- a/.claude/rules/avalonia-ui.md
+++ b/.claude/rules/avalonia-ui.md
@@ -1,59 +1,28 @@
-UI layout and interaction patterns for Avalonia AXAML in this repository.
+## ScrollViewer — Bounded Viewport Rule
 
-## Scrollable Views — Bounded Viewport Rule
-
-**Root cause of clipping/no-scroll bugs**: A `ScrollViewer` only scrolls when its measured height is bounded. Any parent that sizes itself to content (`StackPanel`, `Auto` Grid row, unsized `ContentControl`) gives the `ScrollViewer` unlimited height — it expands to fit and never scrolls. Content at the bottom is clipped instead of reachable.
-
-### Anti-pattern
+`ScrollViewer` only scrolls when its measured height is bounded. `StackPanel`, `Auto` rows, and unsized `ContentControl` give unlimited height — content clips instead of scrolling.
 
 ```xml
-<!-- ❌ StackPanel gives unlimited height → ScrollViewer never scrolls -->
-<StackPanel>
-    <ScrollViewer>
-        ...growing content...
-    </ScrollViewer>
-</StackPanel>
+<!-- ❌ never scrolls -->
+<StackPanel><ScrollViewer>...</ScrollViewer></StackPanel>
 
-<!-- ❌ ContentControl with Auto sizing → same problem one level up -->
-<ContentControl Content="{Binding CurrentView}"/>
-```
-
-### Correct pattern
-
-```xml
-<!-- ✅ Grid star row bounds the ScrollViewer → scrolls correctly -->
+<!-- ✅ correct -->
 <Grid RowDefinitions="Auto,*">
-    <StackPanel Grid.Row="0" ...>
-        <!-- fixed header / toolbar -->
-    </StackPanel>
-
+    <StackPanel Grid.Row="0"/>
     <ScrollViewer Grid.Row="1"
                   VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   MinHeight="0">
-        <StackPanel ...>
-            <!-- growing content -->
-        </StackPanel>
+        <StackPanel/>
     </ScrollViewer>
 </Grid>
 ```
 
-### Rules
-
-- **Always** put a `ScrollViewer` in a `*`-sized `Grid` row, never in an `Auto` row or directly inside a `StackPanel`.
-- **Always** set `MinHeight="0"` on the `ScrollViewer` — Avalonia's default minimum can prevent the star row from collapsing it correctly.
-- **Shell / nav hosts**: any `ContentControl` that hosts routed views MUST set `HorizontalContentAlignment="Stretch"` and `VerticalContentAlignment="Stretch"`, and live in a `*` row itself — otherwise the viewport bound is lost one level up and the inner `ScrollViewer` still never scrolls.
-- When a view grows beyond a fixed area (lists, form rows, classification rules, accounts), **always** use this `Grid RowDefinitions="Auto,*"` + `ScrollViewer` structure from the start.
-- Prefer a dedicated view (`UserControl`) for content that can grow unboundedly (e.g. classification rules, account lists) rather than embedding it in a parent settings page — this keeps the viewport ownership unambiguous.
+Rules:
+- `ScrollViewer` MUST be in a `*` Grid row — never `Auto` or inside `StackPanel`.
+- `MinHeight="0"` REQUIRED — Avalonia's default minimum breaks star-row collapse.
+- Nav-host `ContentControl` MUST set `HorizontalContentAlignment="Stretch"` `VerticalContentAlignment="Stretch"` and live in a `*` row.
 
 ## UserControl Root
 
-Every `UserControl` that is navigation-target must declare:
-
-```xml
-<UserControl ...
-             VerticalContentAlignment="Stretch"
-             HorizontalContentAlignment="Stretch">
-```
-
-This ensures the shell's `ContentControl` can stretch it to fill the available area.
+Every navigation-target `UserControl` must declare `VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch"`.

--- a/.claude/rules/c-sharp-code-style.md
+++ b/.claude/rules/c-sharp-code-style.md
@@ -3,128 +3,61 @@ paths:
     - "**/*.cs"
 ---
 
-Coding standards and style guidelines / preferences for C# files in this repository that AI must follow.
+## Naming
 
-## Naming Conventions
+- Private fields: camelCase, no underscore prefix (`fieldName` not `_fieldName`)
+- `nameof()` for parameter names in exceptions and logging
+- No single-letter variables except loop indices. Name for meaning: `customerId` not `id`.
 
-- **Public members**: PascalCase (e.g., `MyClass`, `MyMethod`, `MyProperty`)
-- **Private members**: camelCase (e.g., `myVariable`, `myMethod`)
-- **Private fields**: camelCase without underscore prefix (e.g., `fieldName`)
-- **Constants**: PascalCase
-- Use meaningful names that clearly convey purpose; avoid abbreviations unless widely understood
-- Use `nameof()` for parameter names in exceptions and logging
-- NEVER use single-letter variable names except for loop indices (e.g., `i`, `j`, `k`).
+## Structure
 
-## Namespaces
-
-- Use file-scoped namespaces.
-- Namespace names should follow the pattern: Company.Project.Module (e.g., Contoso.Sales.Reporting).
-
-## Classes and Methods
-
-- Define one class, recored, interface etc. per file, and name the file after the class.
-- Follow SOLID principles for class and method design.
-- Keep classes / methods focused on a SINGLE responsibility.
-- Ensure good cohesion within classes and methods (related functionality grouped together).
-- Ensure low coupling between classes and methods.
-- Ensure methods do one thing and do it well.
-- Keep methods short; ideally under 20 lines.
-- Keep classes short; ideally under 300 lines.
-- Use meaningful names for classes and methods that clearly convey their purpose.
-- Put all method / constructor overloads together in the same order as their parameters.
-- Single-line method / constructor signatures where possible. Split parameters across lines ONLY if line-length > 200 characters and spilt as close to 200 characters as possible. Use as few lines as possible when splitting parameters across lines.
-- Use expression-bodied members for simple methods and properties.
-- Keep method and constructor parameters to a minimum (ideally <5 parameters); prefer using parameter objects when multiple parameters are needed.
-- Avoid long parameter lists; consider using the Builder pattern for complex object construction.
-- Use dependency injection for managing dependencies (no newing up services inside classes).
-- Prefer composition over inheritance.
-- Avoid deep nesting; use early returns and guard clauses.
-- Do not use regions or #pragma to hide code; refactor instead.
-- Never comment within methods or private members; if a comment is needed, it likely indicates the method is doing too much and should be refactored into smaller, more focused methods. Instead of comments, strive for self-explanatory code through clear naming and small method sizes.
-- Every `return` statement after a code block must be preceded by a blank line. `return` after an `if` must NOT be followed by a blank line or `{ return; }`.
-- Name for **meaning**: `customerId` not `id`, `isExpired` not `flag`.
-- Use builders for test setup / test data creation.
+- File-scoped namespaces. One type per file.
+- Single-line method/constructor signatures. Split ONLY at >200 chars.
+- Blank line before `return` after a code block. NOT after `if`/`else`.
+- Expression-bodied members for simple methods/properties.
+- No regions, no `#pragma` to hide code.
+- Early returns / guard clauses over deep nesting.
+- No newing up services; use DI.
 
 ## Primitive Obsession
 
-- Don't use string / GUID etc for domain concepts - create a specific type:
-    - Id should be strongly-typed - use AStar.Dev.Source.Generators / AStar.Dev.Source.Generators.Attributes to standardise the generation. The Id value CAN be a string / GUID but the property MUST be strongly typed.
-    - File info / Directory info should NOT be represented as a string. Either use the Testably abstraction or create a specific type (i.e. when only 3-5 properties are required)
+- IDs must be strongly-typed — use `AStar.Dev.Source.Generators.Attributes`.
+- File/directory info must NOT be a string — use Testably abstraction or dedicated type.
 
-## Immutability
+## Records
 
-- Prefer immutable data structures and objects where possible.
-- Prefer `record` types for immutable data models and DTOs.
-- Use `class` for entities with behavior or mutable state.
-- Use `init` properties when immutability is desired.
-- Use immutable collections: `IReadOnlyList<T>`, `IReadOnlyCollection<T>`, `IReadOnlyDictionary<TKey, TValue>`.
-- Use `with` expressions to create modified copies of immutable objects.
-
-## Record Design
-
-- Define record properties on the same line with the record declaration when possible.
-- Accompany each record `<name>` with a corresponding `<name>Factory` static factory class.
-- Expose static `Create` methods on the factory class for constructing instances of the record.
-- Place argument validation logic within the factory methods.
-- Never use the public constructor of a record directly; always use the factory methods.
-- Use immutable collections (e.g., `IReadOnlyList<T>`, `IReadOnlyDictionary<TKey, TValue>`) for record properties that hold multiple values.
-- Avoid methods on records; use extension methods instead for any behavior related to the record.
+- Accompany every `record Foo` with `FooFactory` static class exposing `Create` methods.
+- Validation in factory, never in constructor. Never use the public constructor directly.
+- No methods on records — use extension methods.
+- Immutable collection properties: `IReadOnlyList<T>`, `IReadOnlyDictionary<K,V>`.
 
 ## Discriminated Unions
 
-- Use records with inheritance to model discriminated unions.
-- Define an abstract base record for the union type and derive specific case records from it.
-- Place all case records in the same file as the base record.
-- Define one static factory class per discriminated union type.
-- Expose static `Create` methods on the factory class for constructing instances of each case record.
+- Abstract base record + derived case records, all in one file.
+- One `<Name>Factory` class per union, `Create` methods per case.
 
-## Variables and Constants
+## Immutability
 
-- Use `var` when the type is obvious from the right-hand side; otherwise use explicit types for clarity.
-- Use `const` for compile-time constants.
-- Use `static readonly` for runtime constants.
-- NO magic strings / numbers etc; use constants or enums instead.
+- `record` for immutable models/DTOs; `class` for entities with mutable state.
+- Immutable collections for all multi-value properties and return types.
 
-## Collections and Data Structures
+## Tests
 
-- Use `IEnumerable<T>` for collections that do not require indexing.
-- Use `IReadOnlyList<T>` or `IReadOnlyCollection<T>` when immutability is desired.
-- Use `StringBuilder` for concatenating multiple strings in loops or when performance is critical; otherwise use string interpolation for readability.
-- Use Collection Initializers and Object Initializers for cleaner code when creating collections and objects.
+- Class naming: `Given<Context>` — e.g. `GivenAnAccount`, `GivenADatabaseReadyForSync`
+- Method naming: `when_[action]_then_[outcome]` snake_case
+- AAA pattern, blank lines between sections, no section comments.
+- Shouldly assertions. NSubstitute mocks (prefer real instances).
+- No XML docs or comments on test classes/methods.
 
-## Control Flow and Logic
+## Functional Extensions
 
-- Use pattern matching and switch expressions for clearer and more concise code when dealing with multiple conditions.
-- Null checking with null-coalescing operators (`??`, `??=`, `?.`).
-- Use `ArgumentNullException` (or `ArgumentNullException.ThrowIfNull`) in public constructors and methods.
-
-## Test Classes
-
-- Name test classes with the `Given` prefix to describe the context under test (e.g., `GivenAnAccount`, `GivenANullString`, `GivenADatabaseReadyForSync`). This matches the `c-sharp-senior-qa-specialist` convention.
-- Name test methods using the `when_[action]_then_[outcome]` snake_case convention (e.g., `when_deleted_then_all_linked_rows_are_removed`). This matches the `c-sharp-senior-qa-specialist` convention.
-- Use the Arrange-Act-Assert (AAA) pattern within test methods to structure the code clearly. Divide the method into three distinct sections: setup (Arrange), execution (Act), and verification (Assert). Do not comment these sections; the structure should be clear from the code itself. Separate these sections with a single blank line for readability.
-- Use test data builders to create complex test objects, enhancing readability and maintainability of tests.
-- Avoid logic in test methods; keep tests simple and focused on behavior verification.
-- Use Shouldly for more readable and expressive assertions in tests.
-- Use NSubstitute for mocking dependencies in tests. Avoid mocking when possible; prefer using real instances or test doubles.
-- Never add XML documentation or comments to test classes or test methods.
-
-## Functional Extensions (AStar.Dev.Functional.Extensions)
-
-- **Never** await a `Task<Result<T,E>>` into an intermediate variable just to call `.Match()` on the next line. Always chain `.MatchAsync()` directly on the task:
-  ```csharp
-  // ❌ wrong
-  var result = await service.GetAsync(ct);
-  var value = result.Match<string?>(ok => ok.Value, _ => null);
-
-  // ✅ correct
-  var value = await service.GetAsync(ct)
-      .MatchAsync<TSuccess, TError, string?>(ok => ok.Value, _ => null);
-  ```
-- Error-branch code (logging, setting properties, returning sentinel values) belongs **inside** the error lambda of `Match`/`MatchAsync`, not in a separate `if` block after the call.
-- Never use `is Result<T,E>.Ok` / `is not Result<T,E>.Ok` pattern matching in production code — use `Match` or `MatchAsync`.
+Never await `Task<Result<T,E>>` into a variable then call `.Match()` — chain `.MatchAsync()` directly:
+```csharp
+// ❌ var result = await service.GetAsync(ct); result.Match(...)
+// ✅ await service.GetAsync(ct).MatchAsync(ok => ..., err => ...)
+```
+Error-branch logic belongs INSIDE the error lambda. Never use `is Result<T,E>.Ok` pattern matching.
 
 ## Utilities
 
-- The AStar.Dev.Utilities project has a plethora of helpers. Use them when suitable.
-    - e.g.: rather than `Path.Combine("Directory1", "Directory2", "Directory3")` use: `"Directory1".CombinePaths("Directory2", "Directory3")` - it will not silently drop parameters, unlike Path.Combine.
+Use `AStar.Dev.Utilities` helpers. e.g. `"dir1".CombinePaths("dir2")` not `Path.Combine(...)` — `Path.Combine` silently drops parameters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,203 +1,84 @@
 # CLAUDE.md
 
-Guidance to Claude Code (claude.ai/code) for this repo.
+## Repo
 
-## Repository Overview
+Mono-repo: Blazor web, Avalonia desktop, ~25 NuGet packages. Solution: `AStar.Dev.slnx`.
 
-Mono-repo, all AStar Development products: **Blazor** web apps, **astro** web apps, **Avalonia** desktop apps, ~25 published **NuGet packages**. Solution: `AStar.Dev.slnx`.
-
-## Build Commands
+## Build Gotcha
 
 ```bash
-dotnet restore
-dotnet build
-dotnet build packages/core/[PackageName]
-dotnet build apps/web/[AppName].Blazor
-
-# If Directory.Build.props changes aren't taking effect
-dotnet clean && dotnet build
-
-# If build fails mysteriously after a refactor (stale generated files, changed base props)
+# Stale generated files / changed base props
 dotnet clean && rm -rf artifacts/ && dotnet build
 ```
 
-## Test Commands
+## Mandatory NuGet Packages
 
-```bash
-dotnet test
+Check before writing new code — use when practicable:
+- `AStar.Dev.Functional.Extensions` — `Result<T>`, `Option<T>`, `Map`/`Bind`/`MatchAsync`
+- `AStar.Dev.Logging.Extensions` — compile-time `LogMessage` templates; avoid `logger.Log...`
+- `AStar.Dev.Utilities` — string extensions, nullability, `CombinePaths` etc.
 
-dotnet test tests/[ProjectName].Tests
-```
-
-Coverage → `TestResults/`.
-
-## Running Applications
-
-```bash
-dotnet run --project apps/web/[AppName].Blazor
-
-dotnet run --project apps/desktop/[AppName].Desktop
-
-cd apps/web/[appname] && npm run dev
-```
+New reusable code → add to relevant package + raise GitHub issue.
 
 ## Logging
 
-Logging NEVER afterthought. ALL logging MUST go to Azure Application Insights unless instructed otherwise. For C#, use `AStar.Dev.Logging.Extensions` (`LogMessage` class) for compile-time templates. No suitable template? ADD IT. Avoid `logger.Log...`. No JS equivalent exists; log anyway.
+ALL logging → Azure Application Insights. No suitable `LogMessage` template? ADD IT.
 
-## Dependency Injection
+## DI
 
-DI NEVER afterthought. Language supports it? MUST implement from start.
-
-## NuGet projects
-
-Mono-repo has many C# NuGet projects deployed to GitHub and NuGet.org. Top 3 that MUST be used:
-
-- AStar.Dev.Functional.Extensions: Result<T>, Option<T>, Map<Async>, Bind<Async> etc. ALWAYS use when practicable.
-- AStar.Dev.Logging.Extensions: Compile-time `LogMessage` format + logging extensions. ALWAYS use when practicable.
-- AStar.Dev.Utilities: string extensions, nullability checks, utility methods. ALWAYS use when practicable.
-
-Suitable method exists in above? USE IT. New reusable code? ADD IT to relevant project + raise GitHub issue documenting why, where, how to deploy.
+DI from the start. Never `new` a service inside a class.
 
 ## Architecture
 
-### Directory Layout
+- `Directory.Build.props/targets` and `Directory.Packages.props` centralized — never duplicate in `.csproj`.
+- Child `Directory.Build.props` MUST import parent via `$([MSBuild]::GetPathOfFileAbove(...))`.
+- All `bin/` and `obj/` redirect to `artifacts/`.
+- Local dev: `<ProjectReference>` not `<PackageReference>` (avoids publish cycles).
+- CI version: `-p:Version=$(GitTag)`; local fallback `0.1.0`. Tag format: `v1.2.3`.
 
-```
-apps/
-  web/        # Blazor (C#) WebAssembly/Server and astro apps
-  desktop/    # Avalonia (C#) cross-platform desktop apps
-packages/
-  core/       # Domain models, business logic
-  infra/      # Data access, auth, logging, HTTP clients
-  ui/         # Shared UI components
-infra/terraform/
-  staging/    # Auto-applies on merge to main
-  prod/       # Requires GitHub Environments approval gate
-tests/        # Repo-wide integration/E2E tests
-```
+## Conventions
 
-### C# Centralized Build Configuration
+- **Commits**: Conventional Commits — `feat(scope): ...`, `fix(scope): ...`
+- **Branches**: `feature/...`, `bug/...`, `fix/...`, `doc/...`; `main` always deployable
+- **Method signatures**: single-line regardless of param count. Split ONLY at >200 chars.
+- **Comments**: only when _reason_ isn't derivable from code. Never restate what code does.
+- **XML comments**: all public members. Implementing interface → `<inheritdoc />` only.
+- **Test projects**: `*.Tests.Unit` / `*.Tests.Integration`
+- **Blank line before `return`** after a code block. NOT after `if`/`else`.
 
-All `.csproj` inherit from three root files — never duplicate settings already defined there:
+Patterns: see @.claude/rules/c-sharp-code-style.md and @.claude/rules/avalonia-ui.md.
 
-- **`Directory.Build.props`**
-- **`Directory.Build.targets`**
-- **`Directory.Packages.props`**
+## Before Starting ANY Task (mandatory, no exceptions)
 
-### Build Output
-
-ALL `bin/` and `obj/` redirect to `artifacts/` at repo root.
-
-### Versioning
-
-- CI injects version at publish via `-p:Version=$(GitTag)`; local builds fallback to `0.1.0`
-- Tag format: `v1.2.3` (triggers `nuget-publish.yml`)
-- Pre-release: `v2.0.0-beta.1`
-
-### NuGet Packages
-
-- Naming: `AStar.Dev.[Area].[Name]`
-- Published to GitHub Packages and NuGet.org via CI
-- Symbol packages (`.snupkg`) published alongside `.nupkg`
-- **No manual release** — use tag workflow
-- Local dev: use `<ProjectReference>` not `<PackageReference>` to avoid publish cycles
-
-### Avalonia / Blazor / C# / .NET Patterns
-
-C#-specific patterns (DI, EF Core, Mediator/MediatR, Avalonia, Refit/Polly, Serilog, FluentValidation, functional extensions): see @.claude/rules/c-sharp-code-style.md.
-Avalonia AXAML layout patterns (scrollable viewports, bounded containers, UserControl roots): see @.claude/rules/avalonia-ui.md.
-
-### C#/.NET Conventions
-
-- Eliminate "what" comments by extracting well-named methods — NOT by moving them into XML docs.
-- Blank line before every `return` (except `return` directly after `if`/`else`).
-
-### Conventions
-
-- **Commit messages**: Conventional Commits — `feat(packages/core): ...`, `fix(apps/web/Portal.Blazor): ...`
-- **Branch names**: `feature/...`, `bug/...`, `doc/...`; `main` ALWAYS deployable
-- **Test projects**: Named `*.Tests.Unit` or `*.Tests.Integration` — auto-set `IsPackable=false`
-- **Method signatures**: Always single-line regardless of param count — `public void Foo(string a, int b, CancellationToken ct = default)`. Never split params across lines. Every file type.
-- **Comments**: Never restate what code says — any file type (`.cs`, `.csproj`, `.axaml`, config, etc.). Refactor to extract when needed. Only comment when _reason_ behind decision isn't derivable from code.
-- **Child `Directory.Build.props`**: Sub-folder overrides must import parent via `$([MSBuild]::GetPathOfFileAbove(...))`
-- **Naming**: follow @.claude/rules/c-sharp-code-style.md (.Net) or @.claude/rules/javascript-code-style.md (JS). Fallback to official language naming when no local spec exists.
-- **XML Comments**: all public methods/properties
-    - Classes implementing interface: use `<inheritdoc />`, not class-level docs.
-
-## Before Starting ANY Task
-
-Three steps **MANDATORY** before single line of code. No exceptions, including spikes.
-
-1. **Branch first** — run `git branch`, confirm not on `main`. If on main, create branch:
-
-    ```bash
-    git checkout -b feature/short-description<-issue-number>
-    ```
-
-    Naming: `feature/...`, `bug/...`, `doc/...`. NEVER commit to `main`. See @docs/git-instructions.md.
-
-2. **Tests MANDATORY** — EVERY coding task MUST follow TDD. COMMIT FAILING TEST BEFORE writing production code.
-
-3. **Scope** — implement ONLY what was asked. Stop and wait for review before touching any other phase or area. Honor all explicit style requirements (primary constructors, idiomatic `Match`/`MatchAsync`, no tuple-intermediate patterns).
-
-## Branching & Commits
-
-ALL development work MUST follow the GIT rules in: @docs/git-instructions.md
+1. **Branch** — confirm not on `main`. Create branch first.
+2. **TDD** — commit failing test BEFORE writing production code.
+3. **Scope** — implement only what was asked. Stop for review before touching other areas.
 
 ## Code Exploration
 
-- Call Serena `initial_instructions` BEFORE exploring the codebase — no exceptions.
-- Use `mcp__serena__find_symbol` and `mcp__serena__find_referencing_symbols` for symbol lookups — do NOT read whole files for exploration.
+- Call Serena `initial_instructions` BEFORE exploring — no exceptions.
+- Use `mcp__serena__find_symbol` / `mcp__serena__find_referencing_symbols` — do NOT read whole files.
 - Find ALL call sites and test files before touching production code.
-- Before editing any file, read it first. Before modifying a function, grep for all callers. Research before you edit.
+- Read a file before editing it. Grep all callers before modifying a function.
 
 ## Definition of Done
 
-Before any coding task complete — commits and PRs included:
+1. `dotnet build` — zero errors, zero warnings. Paste exact output.
+2. `dotnet test` — paste EXACT pass/fail count. New failures = zero.
+3. Confirm all call sites and test files found and updated.
+4. Human review BEFORE committing.
+5. Approved → commit to branch, raise GitHub PR.
 
-1. `dotnet build` affected projects — zero errors, zero warnings
-2. `dotnet test` affected test projects — all pass except new TDD `RED` tests. COMMIT failing tests.
-3. Write MINIMAL production code to pass test(s)
-4. Request human review BEFORE committing.
-5. Human requests changes? Implement, re-request review.
-6. ONLY after human approval: commit to branch, raise GitHub PR.
+Never say "fixed"/"done" without evidence. Say "I believe this is fixed because…"
+For sync/download bugs: confirm full flow (Graph API → persistence → sync logic) first.
 
-## Verification Before Declaring Done
+## Subagents
 
-NEVER say "fixed", "done", or "complete" without explicit evidence:
-
-- Run `dotnet build` — zero errors required. Paste exact output.
-- Run `dotnet test` — paste the EXACT pass/fail count from raw terminal output. Do NOT summarise or self-report. New failures must be zero; pre-existing failures must be identified.
-- Confirm ALL call sites and test files were found and updated before reporting completion.
-- Trace the original bug/requirement through the code path and state in plain text WHY the change addresses it at the root cause.
-- For sync/download bugs specifically: confirm the full flow (Graph API → persistence → sync logic) before touching any code. Write a failing reproducing test first; declare done only when it turns green.
-
-Say "I believe this is fixed because…" — never just "fixed".
-
-## Subagent Usage
-
-- Use `c-sharp-qa` subagent for adding or expanding tests in C# files.
-- Use `c-sharp-dev` subagent for implementing C# features.
-- Use `c-sharp-reviewer` subagent for code review.
-- When a subagent drifts off task or produces wrong output, take over directly — do not re-prompt the same agent repeatedly.
-
-### Verifying Subagent Output
-
-After ANY subagent completes, verify before trusting its report:
-
-1. **Files**: `Read` every file the subagent claims to have written or modified — do NOT assume it succeeded.
-2. **Tests**: Re-run `dotnet test` yourself and paste actual output. Never accept a subagent's "all tests pass" summary as truth.
-3. **Diff**: Confirm the actual changes match what was requested.
-
-If verification fails, take over directly — do not re-prompt the same subagent.
+- `c-sharp-qa` → tests; `c-sharp-dev` → C# features; `c-sharp-reviewer` → code review.
+- After any subagent: `Read` every claimed file, re-run `dotnet test` yourself, verify diff.
+- Subagent drifts → take over directly, don't re-prompt.
 
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
-
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+Knowledge graph at `graphify-out/`. Before architecture questions, read `graphify-out/GRAPH_REPORT.md`.
+Use `graphify query/path/explain` for cross-module questions. After modifying code, run `graphify update .`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ ALL development work MUST follow the GIT rules in: @docs/git-instructions.md
 - Call Serena `initial_instructions` BEFORE exploring the codebase — no exceptions.
 - Use `mcp__serena__find_symbol` and `mcp__serena__find_referencing_symbols` for symbol lookups — do NOT read whole files for exploration.
 - Find ALL call sites and test files before touching production code.
+- Before editing any file, read it first. Before modifying a function, grep for all callers. Research before you edit.
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

- Removed all content derivable from the code itself (build commands, directory layout, standard C# conventions, SOLID principles)
- Kept only rules, gotchas, and non-obvious conventions
- Total expanded content cut from ~408 lines to 188 lines (under 200)

## Files changed

- `CLAUDE.md` — 84 lines (was 204)
- `.claude/rules/c-sharp-code-style.md` — 63 lines (was 131)
- `.claude/rules/avalonia-ui.md` — 28 lines (was 60)
- `docs/git-instructions.md` — unchanged (13 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)