### PR TITLE
doc(claude): add fix-issue guardrails from usage insights

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -3,26 +3,20 @@ name: fix-issue
 description: Fix a GitHub issue end-to-end with TDD, branch hygiene, and verified tests
 disable-model-invocation: true
 ---
-Fix GitHub issue: $ARGUMENTS.
+
+Fix GitHub issue identified by the numeric issue ID passed as $ARGUMENTS (for example, 123). If the input is a URL, first extract the issue number before running any commands.
 
 **BEFORE ANY CODE:**
-1. Run `git branch` — confirm NOT on `main`. Create branch: `git checkout -b fix/<issue-number>-short-description`
-2. Call Serena `initial_instructions` before exploring the codebase
-3. Use `gh issue view $ARGUMENTS` to get issue details
 
-**IMPLEMENT (strict TDD):**
-4. Write a failing RED test first — commit it before writing production code
-5. Use `mcp__serena__find_symbol` / `mcp__serena__find_referencing_symbols` for symbol lookups — do NOT read whole files for exploration
-6. Find ALL call sites and test files before touching production code
-7. Implement minimal production code to make the RED test pass
-8. Use idiomatic `Match`/`MatchAsync` — never tuple-intermediate patterns
-9. Use primary constructors where applicable per style guide
+1. Run `gh repo view --json nameWithOwner -q '.nameWithOwner'` — confirm the repository is correct. Confirm that the issue affects exactly one top-level project under `src/<project-name>/` and list the affected path(s).
+    - If the repo is incorrect, the issue scope does not match any `src/` folder, or the branch cannot be created, stop immediately and report the failure before making changes.
+    - If `gh repo view`, `gh issue view`, `git branch`, `git checkout -b`, or Serena initialization fails, stop, paste the command output, and ask for guidance before continuing.
+2. Run `git branch` — confirm NOT on `main`. Create the branch as `git checkout -b fix/<issue-number>-<lowercase-kebab-case-summary>` using the numeric issue ID from $ARGUMENTS and a summary of 2-4 words with no spaces.
+3. Call Serena `initial_instructions` before exploring the codebase.
+4. Use `gh issue view $ARGUMENTS` to get issue details.
 
-**VERIFY (mandatory — no exceptions):**
-10. Run `dotnet build` — must be zero errors, zero warnings. Paste exact output.
-11. Run `dotnet test` — paste the EXACT pass/fail count from raw terminal output. Do NOT summarise or self-report. Do NOT claim passing without showing the output.
-12. Confirm new failures = 0 (pre-existing failures are acceptable but must be identified)
+**IMPLEMENT (strict TDD):** 5. Write a failing RED test first — commit it before writing production code. If you cannot create a failing test that reproduces the issue, stop and ask for clarification instead of inventing a test or changing production code. 6. Use `mcp__serena__find_symbol` / `mcp__serena__find_referencing_symbols` for symbol lookups — do NOT read whole files for exploration. Search first; if you cannot identify all call sites within 5 file reads, stop and report the remaining unknowns instead of guessing. 7. Find all call sites and test files before touching production code. Do not claim to have found all call sites unless the search results prove it. 10. Implement minimal production code to make the RED test pass. 11. Use idiomatic `Match`/`MatchAsync` — never tuple-intermediate patterns. 12. Use primary constructors where applicable per style guide. 13. Reuse existing `LogMessage` templates — do NOT create new ones unless no suitable template exists.
 
-**COMPLETE:**
-13. Stop and request human review before committing
-14. After approval: commit to the feature branch, then `gh pr create`
+**VERIFY (mandatory — no exceptions):** 14. Run `dotnet build` — must be zero errors, zero warnings. Paste exact output. 15. Run `dotnet test` — paste the EXACT pass/fail count from raw terminal output. Do NOT summarise or self-report. Do NOT claim passing without showing the output. 16. If new failures appear, diagnose and fix them. NEVER dismiss failures as pre-existing — if this change broke them, own it and fix it.
+
+**COMPLETE:** 17. Stop and request human review before committing. 18. After approval: commit to the feature branch, then `gh pr create`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ For sync/download bugs: confirm full flow (Graph API → persistence → sync lo
 ## GitHub
 
 Always use `gh` CLI for all GitHub operations. Never use MCP GitHub - not configured.
+When raising a PR, use `.github/PULL_REQUEST_TEMPLATE.md` as the body structure — fill in each section; do not omit or rewrite the template.
 
 ## Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ New reusable code → add to relevant package + raise GitHub issue.
 ## Logging
 
 ALL logging → Azure Application Insights. No suitable `LogMessage` template? ADD IT.
+Reuse existing `LogMessage` templates — do NOT create new ones unless no suitable template exists.
 
 ## DI
 
@@ -51,21 +52,23 @@ Patterns: see @.claude/rules/c-sharp-code-style.md and @.claude/rules/avalonia-u
 
 ## Before Starting ANY Task (mandatory, no exceptions)
 
-1. **Branch** — confirm not on `main`. Create branch first.
-2. **TDD** — commit failing test BEFORE writing production code.
-3. **Scope** — implement only what was asked. Stop for review before touching other areas.
+1. **Repo + folder** — run `gh repo view --json nameWithOwner -q '.nameWithOwner'` and confirm the correct `src/` folder for the issue scope.
+2. **Branch** — confirm not on `main`. Create branch first.
+3. **TDD** — commit failing test BEFORE writing production code.
+4. **Scope** — implement only what was asked. Stop for review before touching other areas.
 
 ## Code Exploration
 
 - Call Serena `initial_instructions` BEFORE exploring — no exceptions.
 - Use `mcp__serena__find_symbol` / `mcp__serena__find_referencing_symbols` — do NOT read whole files.
+- Cap at 5 file reads before stating a plan. Do not keep reading without producing a fix.
 - Find ALL call sites and test files before touching production code.
 - Read a file before editing it. Grep all callers before modifying a function.
 
 ## Definition of Done
 
 1. `dotnet build` — zero errors, zero warnings. Paste exact output.
-2. `dotnet test` — paste EXACT pass/fail count. New failures = zero.
+2. `dotnet test` — paste EXACT pass/fail count. New failures = zero. If this change broke tests, diagnose and fix them — never dismiss as pre-existing.
 3. Confirm all call sites and test files found and updated.
 4. Human review BEFORE committing.
 5. Approved → commit to branch, raise GitHub PR.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
@@ -15,5 +15,5 @@ public interface ISyncPipeline
     /// <param name="folderId">The folder identifier used in progress events.</param>
     /// <param name="workerCount">Maximum number of concurrent workers. Defaults to 8.</param>
     /// <param name="ct">Token used to cancel the pipeline.</param>
-    Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default);
+    Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -26,7 +26,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISyncRepository syncRepository, ILogger<ParallelSyncPipeline> logger, IOptions<SyncSettings> syncSettings) : ISyncPipeline
 {
     /// <inheritdoc />
-    public async Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 8, CancellationToken ct = default)
+    public async Task RunAsync(IEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default)
     {
         var jobList = jobs.ToList();
         if (jobList.Count == 0)


### PR DESCRIPTION
Add guardrails to `CLAUDE.md` and `.claude/skills/fix-issue/SKILL.md` based on recurring friction patterns identified in the June 2026 usage insights report.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [x] Documentation
- [ ] Maintenance

## Related issues / links

N/A — driven by usage insights report (2026-06-03).

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Manual validation
- [x] Not applicable — doc/config changes only

## Impacted areas

`.claude/skills/fix-issue/SKILL.md`, `CLAUDE.md`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

Doc-only change. Four guardrails added:
- Repo + `src/` folder confirmed before branching
- Exploration capped at 5 file reads before stating a plan
- `LogMessage` template reuse required
- New test failures must be fixed — never dismissed as pre-existing
- PRs must use `.github/PULL_REQUEST_TEMPLATE.md`