### PR TITLE
Allow configuration of concurrent download/upload worker count

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountCardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountCardViewModel.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Avalonia.Media;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelFolderCountChanged.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelFolderCountChanged.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -3,7 +3,6 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
@@ -1,9 +1,7 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountSyncSettingsViewModel.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Localization;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountsViewModelWithACompletingWizard.cs
@@ -1,12 +1,10 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Microsoft.Extensions.Logging;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccount.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnOneDriveAccountFactory.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Activity/GivenAnActivityViewModel.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Activity;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Localization;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictPolicyOptionFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictPolicyOptionFactory.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Conflicts;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictResolver.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Conflicts;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardAccountViewModel.cs
@@ -1,6 +1,4 @@
-using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelTrackingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelTrackingConflicts.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelUpdatingFolderCount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelUpdatingFolderCount.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelWithQuotaUpdate.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenADashboardViewModelWithQuotaUpdate.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAStorageQuota.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAStorageQuota.cs
@@ -1,5 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
 
 public sealed class GivenAStorageQuota

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAnAccountProfile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAnAccountProfile.cs
@@ -1,5 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
 
 public sealed class GivenAnAccountProfile

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAnAccountSyncConfig.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAnAccountSyncConfig.cs
@@ -1,4 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAFileClassificationRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAFileClassificationRuleRepository.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.Data.Sqlite;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.EntityFrameworkCore;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRuleRepository.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Data;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenAnAccountRepository.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenADeltaItem.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncConflict.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncConflict.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJob.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJob.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobExtensions.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobStatus.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenASyncJobStatus.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATypedSyncJob.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATypedSyncJob.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -2,7 +2,6 @@ using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAStatusBarViewModel.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenACachedTokenFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenACachedTokenFactory.cs
@@ -1,5 +1,3 @@
-using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenATokenCacheService.cs
@@ -1,8 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
-using NSubstitute;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenAnAuthResultFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Authentication/GivenAnAuthResultFactory.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAQuotaRefreshService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAQuotaRefreshService.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Onboarding/GivenAnAccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Onboarding/GivenAnAccountOnboardingService.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsService.cs
@@ -1,7 +1,6 @@
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceLoadAsync.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Settings/GivenASettingsServiceWithDefaults.cs
@@ -1,8 +1,6 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Settings;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -3,7 +3,6 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Activity;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalChangeDetector.cs
@@ -1,8 +1,6 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Detection;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
@@ -1,10 +1,8 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteDeletionDetector.cs
@@ -1,8 +1,6 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncRuleEvaluator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncRuleEvaluator.cs
@@ -1,4 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
@@ -1,7 +1,6 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -1,6 +1,4 @@
-using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAConflictApplier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAConflictApplier.cs
@@ -1,7 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Conflicts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADeleteJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADeleteJobHandler.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobBuilder.cs
@@ -1,11 +1,9 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobHandler.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadJobHandler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadJobHandler.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadService.cs
@@ -12,7 +12,6 @@ using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.Functional.Extensions;
 using Microsoft.Extensions.Logging;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Jobs;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
@@ -1,5 +1,4 @@
 using System.Threading.Channels;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
@@ -8,7 +7,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
-using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
@@ -18,6 +19,7 @@ public sealed class GivenASyncJobExecutor
     private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
     private readonly ISyncPipeline _pipeline = Substitute.For<ISyncPipeline>();
     private readonly IFileClassificationRuleRepository _classificationRuleRepository = Substitute.For<IFileClassificationRuleRepository>();
+    private readonly ISettingsService _settingsService = Substitute.For<ISettingsService>();
 
     private readonly OneDriveAccount _account = new()
     {
@@ -29,9 +31,10 @@ public sealed class GivenASyncJobExecutor
     {
         _classificationRuleRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<FileClassificationRule>>([]));
         _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(1));
+        _settingsService.Current.Returns(new AppSettings());
     }
 
-    private SyncJobExecutor CreateSut(MockFileSystem mockFileSystem) => new(_syncRepository, _syncedItemRepository, _pipeline, _classificationRuleRepository, mockFileSystem);
+    private SyncJobExecutor CreateSut(MockFileSystem mockFileSystem) => new(_syncRepository, _syncedItemRepository, _pipeline, _classificationRuleRepository, mockFileSystem, _settingsService);
 
     private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncProgressTracker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncProgressTracker.cs
@@ -1,4 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
@@ -1,6 +1,5 @@
 using System.Threading.Channels;
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Localization/GivenTheEnGbJsonFile.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Localization/GivenTheEnGbJsonFile.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenAnAddAccountWizardViewModel.cs
@@ -3,7 +3,6 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
@@ -94,6 +94,15 @@ public sealed class GivenASettingsViewModel
     }
 
     [Fact]
+    public void when_constructed_then_concurrent_worker_count_is_read_from_settings_service_current()
+    {
+        var settings = new AppSettings { ConcurrentWorkerCount = 8 };
+        var sut = BuildSut(settingsService: BuildSettingsService(settings));
+
+        sut.ConcurrentWorkerCount.ShouldBe(8);
+    }
+
+    [Fact]
     public void when_constructed_then_theme_options_contains_exactly_four_entries()
     {
         var sut = BuildSut();
@@ -462,6 +471,29 @@ public sealed class GivenASettingsViewModel
         var sut = BuildSut(settingsService: settingsService);
 
         sut.SyncIntervalMinutes = NewSyncIntervalMinutes;
+
+        settingsService.Received().SaveAsync();
+    }
+
+    [Fact]
+    public void when_concurrent_worker_count_is_set_then_settings_service_current_concurrent_worker_count_is_updated()
+    {
+        var settings = new AppSettings { ConcurrentWorkerCount = 4 };
+        var settingsService = BuildSettingsService(settings);
+        var sut = BuildSut(settingsService: settingsService);
+
+        sut.ConcurrentWorkerCount = 6;
+
+        settingsService.Current.ConcurrentWorkerCount.ShouldBe(6);
+    }
+
+    [Fact]
+    public void when_concurrent_worker_count_is_set_then_settings_service_save_async_is_called()
+    {
+        var settingsService = BuildSettingsService();
+        var sut = BuildSut(settingsService: settingsService);
+
+        sut.ConcurrentWorkerCount = 6;
 
         settingsService.Received().SaveAsync();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/GivenASettingsViewModel.cs
@@ -1,8 +1,6 @@
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Startup/GivenAStartupService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Startup/GivenAStartupService.cs
@@ -1,8 +1,6 @@
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Startup;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
@@ -168,7 +166,7 @@ public sealed class GivenAStartupService
         accountRepository.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromException<List<AccountEntity>>(new InvalidOperationException("DB unavailable")));
 
-        
+
         var errorMessage = (await CreateSut().RestoreAccountsAsync()).Match(_ => string.Empty, error => error);
 
         errorMessage.ShouldBe("DB unavailable");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountsViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive;
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
@@ -9,7 +8,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -1,12 +1,10 @@
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Home;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure;
 using AStar.Dev.OneDrive.Sync.Client.Splash;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using AStar.Dev.OneDrive.Sync.Client.LogViewer;
 using AStar.Dev.OneDrive.Sync.Client.Startup;
-using AStar.Dev.Utilities;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
@@ -16,7 +14,6 @@ using Serilog;
 using Serilog.Events;
 using Testably.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Startup;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260520175855_InitialCreate.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260520175855_InitialCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
@@ -4,7 +4,6 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.Utilities;
-using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/OneDrive/OneDriveClientServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/OneDrive/OneDriveClientServiceExtensions.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppSettings.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppSettings.cs
@@ -13,4 +13,5 @@ public sealed class AppSettings
     public string Locale { get; set; } = "en-GB";
     public ConflictPolicy DefaultConflictPolicy { get; set; } = ConflictPolicy.Ignore;
     public int SyncIntervalMinutes { get; set; } = 60;
+    public int ConcurrentWorkerCount { get; set; } = 4;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalChangeDetector.cs
@@ -3,7 +3,6 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.Utilities;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
@@ -1,6 +1,5 @@
 using System.IO.Abstractions;
 using System.Reactive;
-using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteDeletionDetector.cs
@@ -2,7 +2,6 @@ using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobBuilder.cs
@@ -6,7 +6,6 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.Utilities;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncEventAggregator.cs
@@ -1,6 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -3,7 +3,6 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncEventAggregator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncEventAggregator.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Domain;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -5,12 +5,13 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 /// <inheritdoc />
-public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem) : ISyncJobExecutor
+public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem, ISettingsService settingsService) : ISyncJobExecutor
 {
     /// <inheritdoc />
     public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
@@ -35,7 +36,8 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             },
             account.Id.Id,
             string.Empty,
-            ct: ct).ConfigureAwait(false);
+            settingsService.Current.ConcurrentWorkerCount,
+            ct).ConfigureAwait(false);
 
         if(successfulJobs.IsEmpty)
             return;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -4,7 +4,6 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using Microsoft.Extensions.Options;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressEventArgs.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressEventArgs.cs
@@ -1,5 +1,3 @@
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
-
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 public sealed class SyncProgressEventArgs(string accountId, string folderId, int completed, int total, string currentFile, SyncState syncState) : EventArgs

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressTracker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressTracker.cs
@@ -1,5 +1,4 @@
 using AStar.Dev.OneDrive.Sync.Client.Domain;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml
@@ -195,6 +195,46 @@
                         </ItemsControl>
                     </Grid>
                 </Border>
+
+                <!-- Concurrent worker count -->
+                <Border Background="{DynamicResource BackgroundSecondaryBrush}"
+                        BorderBrush="{DynamicResource BorderSubtleBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource RadiusLg}"
+                        Padding="16">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
+                            <TextBlock Text="Concurrent downloads/uploads"
+                                       FontSize="{StaticResource FontSizeMd}"
+                                       Foreground="{DynamicResource TextPrimaryBrush}"/>
+                            <TextBlock Text="Number of files to sync simultaneously."
+                                       FontSize="{StaticResource FontSizeSm}"
+                                       Foreground="{DynamicResource TextTertiaryBrush}"/>
+                        </StackPanel>
+
+                        <ItemsControl Grid.Column="1"
+                                      ItemsSource="{Binding WorkerCountOptions}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" Spacing="6"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="settings:WorkerCountOption">
+                                    <Button Padding="10,5"
+                                            CornerRadius="{StaticResource RadiusMd}"
+                                            BorderThickness="1"
+                                            FontSize="{StaticResource FontSizeSm}"
+                                            Click="OnWorkerCountClick"
+                                            Tag="{Binding Count}">
+                                        <TextBlock Text="{Binding Label}"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}"/>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Grid>
+                </Border>
             </StackPanel>
 
             <!-- ── Per-account settings ── -->

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsView.axaml.cs
@@ -34,6 +34,12 @@ public partial class SettingsView : UserControl
             vm.SyncIntervalMinutes = minutes;
     }
 
+    private void OnWorkerCountClick(object? sender, RoutedEventArgs e)
+    {
+        if(sender is Button { Tag: int count } && DataContext is SettingsViewModel vm)
+            vm.ConcurrentWorkerCount = count;
+    }
+
     private async void OnBrowseClick(object? sender, RoutedEventArgs e)
     {
         if(sender is not Button { Tag: string accountId }) return;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
@@ -34,9 +34,11 @@ public sealed partial class SettingsViewModel : ObservableObject
         Theme = settingsService.Current.Theme;
         DefaultConflictPolicy = settingsService.Current.DefaultConflictPolicy;
         SyncIntervalMinutes = settingsService.Current.SyncIntervalMinutes;
+        ConcurrentWorkerCount = settingsService.Current.ConcurrentWorkerCount;
         ThemeOptions = ThemeOptionFactory.Create(loc);
         IntervalOptions = BuildIntervalOptions();
         PolicyOptions = ConflictPolicyOptionFactory.Create(loc);
+        WorkerCountOptions = WorkerCountOptionFactory.Create(loc);
         LanguageOptions = LanguageOptionFactory.Create(loc);
         loc.CultureChanged += OnCultureChanged;
         isLoaded = true;
@@ -83,11 +85,26 @@ public sealed partial class SettingsViewModel : ObservableObject
         _ = settingsService.SaveAsync();
     }
 
+    [ObservableProperty]
+    public partial int ConcurrentWorkerCount { get; set; }
+
+    partial void OnConcurrentWorkerCountChanged(int value)
+    {
+        if (!isLoaded)
+            return;
+
+        settingsService.Current.ConcurrentWorkerCount = value;
+        _ = settingsService.SaveAsync();
+    }
+
     /// <summary>The available sync interval options, localised for the current culture.</summary>
     public IReadOnlyList<SyncIntervalOption> IntervalOptions { get; private set; }
 
     /// <summary>The available conflict policy options, localised for the current culture.</summary>
     public IReadOnlyList<ConflictPolicyOption> PolicyOptions { get; private set; }
+
+    /// <summary>The available concurrent worker count options, localised for the current culture.</summary>
+    public IReadOnlyList<WorkerCountOption> WorkerCountOptions { get; private set; }
 
     /// <summary>The available language options derived from the embedded localisation files.</summary>
     public IReadOnlyList<LanguageOption> LanguageOptions { get; private set; }
@@ -164,6 +181,8 @@ public sealed partial class SettingsViewModel : ObservableObject
         OnPropertyChanged(nameof(IntervalOptions));
         PolicyOptions = ConflictPolicyOptionFactory.Create(loc);
         OnPropertyChanged(nameof(PolicyOptions));
+        WorkerCountOptions = WorkerCountOptionFactory.Create(loc);
+        OnPropertyChanged(nameof(WorkerCountOptions));
         LanguageOptions = LanguageOptionFactory.Create(loc);
         OnPropertyChanged(nameof(LanguageOptions));
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/WorkerCountOption.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/WorkerCountOption.cs
@@ -1,0 +1,3 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Settings;
+
+public sealed record WorkerCountOption(int Count, string Label);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/WorkerCountOptionFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/WorkerCountOptionFactory.cs
@@ -1,0 +1,15 @@
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Settings;
+
+public static class WorkerCountOptionFactory
+{
+    /// <summary>Creates the localised list of WorkerCountOption instances.</summary>
+    public static IReadOnlyList<WorkerCountOption> Create(ILocalizationService loc) =>
+    [
+        new(2, loc.GetLocal("Settings.ConcurrentWorkers.Count", 2)),
+        new(4, loc.GetLocal("Settings.ConcurrentWorkers.Count", 4)),
+        new(6, loc.GetLocal("Settings.ConcurrentWorkers.Count", 6)),
+        new(8, loc.GetLocal("Settings.ConcurrentWorkers.Count", 8)),
+    ];
+}


### PR DESCRIPTION
# Summary

Users can now configure the number of concurrent file transfers via the Settings UI. Previously hardcoded to 4 workers, users can select 2, 4, 6, or 8 based on their network and system capabilities.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #401

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

- apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings
- apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell
- apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (1202 tests passed, 0 failed)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit --no-build
```

---

## Notes for reviewers

- **AppSettings**: Added `ConcurrentWorkerCount` property with default 4
- **SettingsViewModel**: Exposed via `[ObservableProperty]`, persists on change
- **SyncJobExecutor**: Injected `ISettingsService`, passes setting to pipeline
- **UI**: Added buttons (2, 4, 6, 8) in "Sync policy" section
- **Tests**: Added 3 new test cases covering initialization, persistence, and SaveAsync invocation
- **Factories**: Created `WorkerCountOption` record and `WorkerCountOptionFactory` (pattern matches existing `SyncIntervalOption`)