### PR TITLE
feat(file-auto-categorisation): Phase 2 — TokenAnalyser (#408)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATokenAnalyser.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATokenAnalyser.cs
@@ -46,94 +46,88 @@ public sealed class GivenATokenAnalyser
     [Fact]
     public void when_extract_person_name_called_with_john_smith_text_then_name_is_returned()
     {
-        var result = TokenAnalyser.ExtractPersonName("a file with a persons name: john smith - in it.jpg");
+        Option<string> result = TokenAnalyser.ExtractPersonName("a file with a persons name: john smith - in it.jpg");
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("John Smith");
     }
 
     [Fact]
     public void when_extract_person_name_called_with_jane_doe_text_then_name_is_returned()
     {
-        var result = TokenAnalyser.ExtractPersonName("jane doe birthday party.jpg");
+        Option<string> result = TokenAnalyser.ExtractPersonName("jane doe birthday party.jpg");
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("Jane Doe");
     }
 
     [Fact]
     public void when_extract_person_name_called_with_no_person_name_then_none_is_returned()
     {
-        var result = TokenAnalyser.ExtractPersonName("a red car on the road.jpg");
+        Option<string> result = TokenAnalyser.ExtractPersonName("a red car on the road.jpg");
 
-        result.IsSome.ShouldBeFalse();
+        result.MapOrDefault(v => false, true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_extract_person_name_called_with_single_word_then_none_is_returned()
     {
-        var result = TokenAnalyser.ExtractPersonName("red.jpg");
+        Option<string> result = TokenAnalyser.ExtractPersonName("red.jpg");
 
-        result.IsSome.ShouldBeFalse();
+        result.MapOrDefault(v => false, true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_extract_person_name_called_with_empty_string_then_none_is_returned()
     {
-        var result = TokenAnalyser.ExtractPersonName(string.Empty);
+        Option<string> result = TokenAnalyser.ExtractPersonName(string.Empty);
 
-        result.IsSome.ShouldBeFalse();
+        result.MapOrDefault(v => false, true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_red_car_tokens_then_compound_phrase_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase(["red", "car", "road"]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase(["red", "car", "road"]);
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("red car");
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_red_dress_tokens_then_compound_phrase_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase(["red", "dress", "floor"]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase(["red", "dress", "floor"]);
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("red dress");
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_colour_followed_by_non_noun_then_colour_only_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase(["file", "red", "name"]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase(["file", "red", "name"]);
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("red");
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_no_colour_tokens_then_none_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase(["file", "something", "else"]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase(["file", "something", "else"]);
 
-        result.IsSome.ShouldBeFalse();
+        result.MapOrDefault(v => false, true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_empty_list_then_none_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase([]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase([]);
 
-        result.IsSome.ShouldBeFalse();
+        result.MapOrDefault(v => false, true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_extract_colour_phrase_called_with_colour_only_token_then_colour_is_returned()
     {
-        var result = TokenAnalyser.ExtractColourPhrase(["red"]);
+        Option<string> result = TokenAnalyser.ExtractColourPhrase(["red"]);
 
-        result.IsSome.ShouldBeTrue();
         result.MapOrDefault(v => v, string.Empty).ShouldBe("red");
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATokenAnalyser.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATokenAnalyser.cs
@@ -1,0 +1,171 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenATokenAnalyser
+{
+    [Fact]
+    public void when_stop_words_accessed_then_common_articles_are_present()
+    {
+        TokenAnalyser.StopWords.ShouldContain("a");
+        TokenAnalyser.StopWords.ShouldContain("an");
+        TokenAnalyser.StopWords.ShouldContain("the");
+        TokenAnalyser.StopWords.ShouldContain("on");
+        TokenAnalyser.StopWords.ShouldContain("in");
+        TokenAnalyser.StopWords.ShouldContain("of");
+        TokenAnalyser.StopWords.ShouldContain("with");
+    }
+
+    [Fact]
+    public void when_stop_words_accessed_then_filler_words_are_present()
+    {
+        TokenAnalyser.StopWords.ShouldContain("it");
+        TokenAnalyser.StopWords.ShouldContain("its");
+        TokenAnalyser.StopWords.ShouldContain("and");
+        TokenAnalyser.StopWords.ShouldContain("at");
+    }
+
+    [Fact]
+    public void when_colour_words_accessed_then_common_colours_are_present()
+    {
+        TokenAnalyser.ColourWords.ShouldContain("red");
+        TokenAnalyser.ColourWords.ShouldContain("blue");
+        TokenAnalyser.ColourWords.ShouldContain("green");
+        TokenAnalyser.ColourWords.ShouldContain("black");
+        TokenAnalyser.ColourWords.ShouldContain("white");
+        TokenAnalyser.ColourWords.ShouldContain("yellow");
+        TokenAnalyser.ColourWords.ShouldContain("pink");
+        TokenAnalyser.ColourWords.ShouldContain("purple");
+        TokenAnalyser.ColourWords.ShouldContain("orange");
+        TokenAnalyser.ColourWords.ShouldContain("brown");
+        TokenAnalyser.ColourWords.ShouldContain("grey");
+        TokenAnalyser.ColourWords.ShouldContain("gray");
+    }
+
+    [Fact]
+    public void when_extract_person_name_called_with_john_smith_text_then_name_is_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName("a file with a persons name: john smith - in it.jpg");
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("John Smith");
+    }
+
+    [Fact]
+    public void when_extract_person_name_called_with_jane_doe_text_then_name_is_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName("jane doe birthday party.jpg");
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("Jane Doe");
+    }
+
+    [Fact]
+    public void when_extract_person_name_called_with_no_person_name_then_none_is_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName("a red car on the road.jpg");
+
+        result.IsSome.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_extract_person_name_called_with_single_word_then_none_is_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName("red.jpg");
+
+        result.IsSome.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_extract_person_name_called_with_empty_string_then_none_is_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName(string.Empty);
+
+        result.IsSome.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_red_car_tokens_then_compound_phrase_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["red", "car", "road"]);
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red car");
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_red_dress_tokens_then_compound_phrase_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["red", "dress", "floor"]);
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red dress");
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_colour_followed_by_non_noun_then_colour_only_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["file", "red", "name"]);
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red");
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_no_colour_tokens_then_none_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["file", "something", "else"]);
+
+        result.IsSome.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_empty_list_then_none_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase([]);
+
+        result.IsSome.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_extract_colour_phrase_called_with_colour_only_token_then_colour_is_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["red"]);
+
+        result.IsSome.ShouldBeTrue();
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red");
+    }
+
+    [Fact]
+    public void when_plan_example_red_car_tokens_processed_then_correct_phrase_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["red", "car", "road"]);
+
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red car");
+    }
+
+    [Fact]
+    public void when_plan_example_red_dress_tokens_processed_then_correct_phrase_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["red", "dress", "floor"]);
+
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red dress");
+    }
+
+    [Fact]
+    public void when_plan_example_file_with_red_tokens_processed_then_colour_only_returned()
+    {
+        var result = TokenAnalyser.ExtractColourPhrase(["file", "red", "name"]);
+
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("red");
+    }
+
+    [Fact]
+    public void when_plan_example_john_smith_text_processed_then_person_name_returned()
+    {
+        var result = TokenAnalyser.ExtractPersonName("a file with a persons name: john smith - in it.jpg");
+
+        result.MapOrDefault(v => v, string.Empty).ShouldBe("John Smith");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -62,7 +62,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         var classification = FileClassificationFactory.Create(NewLevel1.Trim(), level2, level3, NewIsSpecial);
         var rule = FileClassificationRuleFactory.Create(keywords, classification);
 
-        var id = await repository.AddAsync(rule);
+        int id = await repository.AddAsync(rule);
         Rules.Add(new FileClassificationRuleRowViewModel(id, rule, DeleteRuleAsync, UpdateRuleAsync));
 
         NewKeywords = string.Empty;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationFactory.cs
@@ -8,7 +8,7 @@ public static class FileClassificationFactory
     /// <summary>Creates a <see cref="FileClassification"/> with the specified levels. If level1 is null or empty/whitespace, defaults to "Unclassified".</summary>
     public static FileClassification Create(string level1, Option<string> level2, Option<string> level3, bool isSpecial)
     {
-        var normalizedLevel1 = string.IsNullOrWhiteSpace(level1) ? "Unclassified" : level1;
+        string normalizedLevel1 = string.IsNullOrWhiteSpace(level1) ? "Unclassified" : level1;
 
         return new(normalizedLevel1, level2, level3, isSpecial);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/TokenAnalyser.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/TokenAnalyser.cs
@@ -1,0 +1,134 @@
+using System.Collections.Frozen;
+using System.Text.RegularExpressions;
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>
+///     Provides static utilities for extracting semantic information — person names and colour phrases —
+///     from tokenised file-name stems.
+/// </summary>
+public static partial class TokenAnalyser
+{
+    /// <summary>
+    ///     Common articles, prepositions, and filler words that carry no semantic meaning in a file name.
+    /// </summary>
+    public static readonly IReadOnlySet<string> StopWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "a", "an", "the", "on", "in", "of", "with", "at", "and", "it", "its",
+        "is", "to", "for", "by", "as", "be", "or", "not", "from", "that", "this",
+        "but", "are", "was", "were", "do", "does", "did", "s", "t"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Colour words used both to identify colour phrases and to exclude colour tokens from person-name detection.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ColourWords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "red", "blue", "green", "black", "white", "yellow", "pink", "purple",
+        "orange", "brown", "grey", "gray", "gold", "silver", "teal", "navy",
+        "maroon", "beige", "coral", "cyan", "magenta"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Physical, concrete nouns that may follow a colour to form a compound phrase (e.g. "red car").
+    ///     Also excluded from person-name detection.
+    /// </summary>
+    private static readonly FrozenSet<string> ConcretePairableNouns = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "car", "dress", "road", "floor", "door", "tree", "house", "cat", "dog", "bird",
+        "table", "chair", "shirt", "bag", "hat", "coat", "cup", "box", "boat", "bus",
+        "van", "bike", "phone", "book", "bed", "wall", "sky", "sea", "lake", "park",
+        "shop", "ring", "shoe", "truck", "plane", "train", "horse", "fish", "rose",
+        "ball", "lamp", "sofa", "desk", "clock", "flag", "map", "key", "pen", "coin"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Abstract or generic nouns excluded from person-name detection but not eligible to pair with a colour.
+    /// </summary>
+    private static readonly FrozenSet<string> AbstractNouns = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "file", "name", "persons", "person", "photo", "picture", "image", "thing",
+        "part", "view", "day", "time", "way", "year", "place", "world", "life",
+        "hand", "room", "birthday", "party", "wedding", "event", "album"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    [GeneratedRegex(@"[^a-zA-Z]+")]
+    private static partial Regex NonAlphaPattern();
+
+    /// <summary>
+    ///     Attempts to extract a two-word person name from a file-name string.
+    ///     Returns <see cref="Option{T}.Some" /> with the title-cased name when found,
+    ///     or <see cref="Option{T}.None" /> when no candidate pair is detected.
+    /// </summary>
+    /// <param name="text">The raw file name (may include extension and path separators).</param>
+    public static Option<string> ExtractPersonName(string text)
+    {
+        if(string.IsNullOrEmpty(text))
+            return Option.None<string>();
+
+        string stem = Path.GetFileNameWithoutExtension(text);
+
+        if(stem.Contains(':'))
+        {
+            string afterColon = stem[(stem.IndexOf(':') + 1)..];
+
+            return ExtractNamePairFromText(afterColon)
+                .Match<Option<string>>(Option.Some, () => ExtractNamePairFromText(stem));
+        }
+
+        return ExtractNamePairFromText(stem);
+    }
+
+    /// <summary>
+    ///     Attempts to identify a colour phrase from an already-tokenised, stop-word-filtered token list.
+    ///     Returns <see cref="Option{T}.Some" /> containing either a bare colour or a colour-noun compound,
+    ///     or <see cref="Option{T}.None" /> when no colour token is present.
+    /// </summary>
+    /// <param name="tokens">Lower-case, stop-word-filtered tokens derived from a file-name stem.</param>
+    public static Option<string> ExtractColourPhrase(IReadOnlyList<string> tokens)
+    {
+        if(tokens.Count == 0)
+            return Option.None<string>();
+
+        var colourIndex = -1;
+        for(var index = 0; index < tokens.Count; index++)
+        {
+            if(!ColourWords.Contains(tokens[index]))
+                continue;
+
+            colourIndex = index;
+            break;
+        }
+
+        if(colourIndex < 0)
+            return Option.None<string>();
+
+        string colourToken = tokens[colourIndex];
+        var nextIndex = colourIndex + 1;
+
+        if(nextIndex < tokens.Count && ConcretePairableNouns.Contains(tokens[nextIndex]))
+            return Option.Some(colourToken + " " + tokens[nextIndex]);
+
+        return Option.Some(colourToken);
+    }
+
+    private static Option<string> ExtractNamePairFromText(string text)
+    {
+        List<string> words = NonAlphaPattern()
+            .Split(text)
+            .Where(word => word.Length >= 2
+                           && !StopWords.Contains(word)
+                           && !ColourWords.Contains(word)
+                           && !ConcretePairableNouns.Contains(word)
+                           && !AbstractNouns.Contains(word))
+            .ToList();
+
+        if(words.Count < 2)
+            return Option.None<string>();
+
+        return Option.Some(Capitalise(words[0]) + " " + Capitalise(words[1]));
+    }
+
+    private static string Capitalise(string word) => char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
@@ -130,8 +130,8 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
 
     private static Result<AuthResult, AuthError> BuildSuccess(AuthenticationResult result)
     {
-        var displayName = ClaimsProfileResolver.ResolveDisplayName(result.ClaimsPrincipal, result.Account.Username);
-        var email = ClaimsProfileResolver.ResolveEmail(result.ClaimsPrincipal, result.Account.Username);
+        string displayName = ClaimsProfileResolver.ResolveDisplayName(result.ClaimsPrincipal, result.Account.Username);
+        string email = ClaimsProfileResolver.ResolveEmail(result.ClaimsPrincipal, result.Account.Username);
 
         return AuthResultFactory.Success(result.AccessToken, result.Account.HomeAccountId.Identifier, AccountProfileFactory.Create(displayName, email), result.ExpiresOn);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/ClaimsProfileResolver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/ClaimsProfileResolver.cs
@@ -12,7 +12,7 @@ internal static class ClaimsProfileResolver
     /// <summary>Returns <c>preferred_username</c> if present and non-empty, then <c>email</c> if present and non-empty, otherwise <paramref name="fallback"/>.</summary>
     internal static string ResolveEmail(ClaimsPrincipal? claims, string fallback)
     {
-        var candidate = claims?.FindFirst("preferred_username")?.Value
+        string? candidate = claims?.FindFirst("preferred_username")?.Value
                         ?? claims?.FindFirst("email")?.Value;
 
         return string.IsNullOrEmpty(candidate) ? fallback : candidate;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Settings/SettingsViewModel.cs
@@ -147,7 +147,7 @@ public sealed partial class SettingsViewModel : ObservableObject
         if (account is null)
             return;
 
-        var path = await folderPickerService.PickFolderAsync(storageProvider, "Choose local sync folder", ct).ConfigureAwait(false);
+        string? path = await folderPickerService.PickFolderAsync(storageProvider, "Choose local sync folder", ct).ConfigureAwait(false);
         if (path is not null)
             account.LocalSyncPath = path;
     }


### PR DESCRIPTION
# Summary

Adds `TokenAnalyser` static class to the `Domain` layer (Phase 2 of 5). Provides stop-word removal, colour-phrase extraction, and person-name extraction — the token analysis foundation for auto-categorisation.

## Type of change

- [x] Feature

## Related issues / links

Closes #408
Depends on #407
Part of auto-categorisation feature: #407 #408 #409 #410 #411

## How was this tested?

- [x] Unit tests added/updated

18 new tests in `GivenATokenAnalyser` covering all acceptance criteria:
- `StopWords` / `ColourWords` membership
- `ExtractPersonName` — colon strategy, free-form fallback, empty/single-word guard
- `ExtractColourPhrase` — compound phrase, colour-only, None for missing colour
- All four plan examples end-to-end

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/TokenAnalyser.cs` (new)
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenATokenAnalyser.cs` (new)

---

## TDD Checklist (required)

- [x] Builds locally — 0 errors, 0 warnings
- [x] Tests pass (`dotnet test`) — 1223 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed — `Option<T>` untouched; functional discipline maintained throughout (`Match<TResult>` used for branching, `MapOrDefault` in assertions)

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

`TokenAnalyser` is not wired to any caller — app remains fully operational.

`ExtractPersonName` uses a two-strategy approach: colon-delimited text first (handles `"name: john smith"`), free-form scan as fallback. Both strategies filter stop words, colour words, concrete nouns, and abstract nouns before pairing the first two candidate words.

`ExtractColourPhrase` compounds colour + next token only when the next token is in `ConcretePairableNouns` — prevents `"red name"` from the third plan example producing a false compound.

No procedural `IsSome`/`IsNone` properties were added to `Option<T>` — all branching uses `Match<TResult>` and all test assertions use `MapOrDefault`.