### PR TITLE
feat(file-auto-categorisation): Phase 3 — Level1Deriver (#409)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenALevel1Deriver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenALevel1Deriver.cs
@@ -1,0 +1,182 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenALevel1Deriver
+{
+    [Fact]
+    public void when_folder_type_map_accessed_then_people_maps_to_person() =>
+        Level1Deriver.FolderTypeMap["people"].ShouldBe("Person");
+
+    [Fact]
+    public void when_folder_type_map_accessed_then_places_maps_to_place() =>
+        Level1Deriver.FolderTypeMap["places"].ShouldBe("Place");
+
+    [Fact]
+    public void when_folder_type_map_accessed_then_events_maps_to_event() =>
+        Level1Deriver.FolderTypeMap["events"].ShouldBe("Event");
+
+    [Fact]
+    public void when_folder_type_map_accessed_then_photos_maps_to_object() =>
+        Level1Deriver.FolderTypeMap["photos"].ShouldBe("Object");
+
+    [Fact]
+    public void when_folder_type_map_accessed_then_portraits_maps_to_person() =>
+        Level1Deriver.FolderTypeMap["portraits"].ShouldBe("Person");
+
+    [Fact]
+    public void when_folder_type_map_accessed_then_landscapes_maps_to_place() =>
+        Level1Deriver.FolderTypeMap["landscapes"].ShouldBe("Place");
+
+    [Fact]
+    public void when_derive_called_with_people_folder_segment_then_person_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["People"];
+        IReadOnlyList<string> filenameTokens = ["birthday", "party"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_derive_called_with_places_folder_segment_then_place_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Places"];
+        IReadOnlyList<string> filenameTokens = ["mountain", "view"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Place");
+    }
+
+    [Fact]
+    public void when_derive_called_with_events_folder_segment_then_event_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Events"];
+        IReadOnlyList<string> filenameTokens = ["summer", "concert"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Event");
+    }
+
+    [Fact]
+    public void when_derive_called_with_photos_folder_segment_then_object_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Photos"];
+        IReadOnlyList<string> filenameTokens = ["misc", "shot"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Object");
+    }
+
+    [Fact]
+    public void when_derive_called_with_folder_match_and_person_name_tokens_then_folder_wins()
+    {
+        IReadOnlyList<string> folderSegments = ["Events"];
+        IReadOnlyList<string> filenameTokens = ["john", "smith"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Event");
+    }
+
+    [Fact]
+    public void when_derive_called_with_no_folder_match_and_person_name_in_tokens_then_person_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Archive"];
+        IReadOnlyList<string> filenameTokens = ["john", "smith"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_derive_called_with_no_folder_match_and_colour_in_tokens_then_color_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Archive"];
+        IReadOnlyList<string> filenameTokens = ["red", "car", "road"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Color");
+    }
+
+    [Fact]
+    public void when_derive_called_with_no_folder_match_and_no_person_and_no_colour_then_object_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["Archive"];
+        IReadOnlyList<string> filenameTokens = ["misc", "shot", "img"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Object");
+    }
+
+    [Fact]
+    public void when_derive_called_with_empty_folder_segments_and_no_person_and_no_colour_then_object_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = [];
+        IReadOnlyList<string> filenameTokens = ["misc", "img"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Object");
+    }
+
+    [Fact]
+    public void when_derive_called_with_people_folder_and_colour_filename_then_folder_wins_over_colour()
+    {
+        IReadOnlyList<string> folderSegments = ["People"];
+        IReadOnlyList<string> filenameTokens = ["red", "car"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_derive_called_with_folder_segment_in_mixed_case_then_match_is_case_insensitive()
+    {
+        IReadOnlyList<string> folderSegments = ["PLACES"];
+        IReadOnlyList<string> filenameTokens = ["some", "image"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Place");
+    }
+
+    [Fact]
+    public void when_derive_called_with_nested_folder_segments_and_recognised_segment_then_mapped_value_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = ["2024", "Events", "Summer"];
+        IReadOnlyList<string> filenameTokens = ["concert", "night"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Event");
+    }
+
+    [Fact]
+    public void when_derive_called_with_empty_folder_segments_and_person_name_tokens_then_person_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = [];
+        IReadOnlyList<string> filenameTokens = ["jane", "doe"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_folder_type_map_return_type_is_readonly_dictionary()
+    {
+        var map = Level1Deriver.FolderTypeMap;
+
+        _ = map.ShouldBeAssignableTo<IReadOnlyDictionary<string, string>>();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenALevel1Deriver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenALevel1Deriver.cs
@@ -179,4 +179,26 @@ public sealed class GivenALevel1Deriver
 
         _ = map.ShouldBeAssignableTo<IReadOnlyDictionary<string, string>>();
     }
+
+    [Fact]
+    public void when_derive_called_with_both_collections_empty_then_object_is_returned()
+    {
+        IReadOnlyList<string> folderSegments = [];
+        IReadOnlyList<string> filenameTokens = [];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Object");
+    }
+
+    [Fact]
+    public void when_derive_called_with_no_folder_match_and_person_name_and_colour_in_tokens_then_person_takes_priority()
+    {
+        IReadOnlyList<string> folderSegments = ["Archive"];
+        IReadOnlyList<string> filenameTokens = ["john", "smith", "red"];
+
+        string result = Level1Deriver.Derive(folderSegments, filenameTokens);
+
+        result.ShouldBe("Person");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/Level1Deriver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/Level1Deriver.cs
@@ -1,0 +1,51 @@
+using System.Collections.Frozen;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Derives the Level1 classification value from folder segments and filename tokens.</summary>
+public static class Level1Deriver
+{
+    /// <summary>Maps lowercase folder names to their Level1 classification value.</summary>
+    public static readonly IReadOnlyDictionary<string, string> FolderTypeMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["people"]     = "Person",
+        ["portraits"]  = "Person",
+        ["places"]     = "Place",
+        ["landscapes"] = "Place",
+        ["events"]     = "Event",
+        ["photos"]     = "Object"
+    }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///     Derives the Level1 value by checking folder segments against <see cref="FolderTypeMap"/> first,
+    ///     then falling back to person-name detection, colour detection, and finally returning "Object".
+    /// </summary>
+    /// <param name="folderSegments">The folder path segments, in order from root to leaf.</param>
+    /// <param name="filenameTokens">The tokenised filename stem words.</param>
+    public static string Derive(IReadOnlyList<string> folderSegments, IReadOnlyList<string> filenameTokens)
+    {
+        foreach(string segment in folderSegments)
+        {
+            if(FolderTypeMap.TryGetValue(segment, out string? mapped))
+                return mapped;
+        }
+
+        string joinedTokens = string.Join(" ", filenameTokens);
+
+        return TokenAnalyser.ExtractPersonName(joinedTokens)
+            .Match<string>(
+                _ => "Person",
+                () => HasColourToken(filenameTokens) ? "Color" : "Object");
+    }
+
+    private static bool HasColourToken(IReadOnlyList<string> filenameTokens)
+    {
+        foreach(string token in filenameTokens)
+        {
+            if(TokenAnalyser.ColourWords.Contains(token))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/TokenAnalyser.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/TokenAnalyser.cs
@@ -50,7 +50,8 @@ public static partial class TokenAnalyser
     {
         "file", "name", "persons", "person", "photo", "picture", "image", "thing",
         "part", "view", "day", "time", "way", "year", "place", "world", "life",
-        "hand", "room", "birthday", "party", "wedding", "event", "album"
+        "hand", "room", "birthday", "party", "wedding", "event", "album",
+        "misc", "shot", "img", "archive", "scan", "copy", "temp", "draft"
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     [GeneratedRegex(@"[^a-zA-Z]+")]
@@ -64,12 +65,12 @@ public static partial class TokenAnalyser
     /// <param name="text">The raw file name (may include extension and path separators).</param>
     public static Option<string> ExtractPersonName(string text)
     {
-        if(string.IsNullOrEmpty(text))
+        if (string.IsNullOrEmpty(text))
             return Option.None<string>();
 
         string stem = Path.GetFileNameWithoutExtension(text);
 
-        if(stem.Contains(':'))
+        if (stem.Contains(':'))
         {
             string afterColon = stem[(stem.IndexOf(':') + 1)..];
 
@@ -88,26 +89,26 @@ public static partial class TokenAnalyser
     /// <param name="tokens">Lower-case, stop-word-filtered tokens derived from a file-name stem.</param>
     public static Option<string> ExtractColourPhrase(IReadOnlyList<string> tokens)
     {
-        if(tokens.Count == 0)
+        if (tokens.Count == 0)
             return Option.None<string>();
 
         var colourIndex = -1;
-        for(var index = 0; index < tokens.Count; index++)
+        for (var index = 0; index < tokens.Count; index++)
         {
-            if(!ColourWords.Contains(tokens[index]))
+            if (!ColourWords.Contains(tokens[index]))
                 continue;
 
             colourIndex = index;
             break;
         }
 
-        if(colourIndex < 0)
+        if (colourIndex < 0)
             return Option.None<string>();
 
         string colourToken = tokens[colourIndex];
         var nextIndex = colourIndex + 1;
 
-        if(nextIndex < tokens.Count && ConcretePairableNouns.Contains(tokens[nextIndex]))
+        if (nextIndex < tokens.Count && ConcretePairableNouns.Contains(tokens[nextIndex]))
             return Option.Some(colourToken + " " + tokens[nextIndex]);
 
         return Option.Some(colourToken);
@@ -124,7 +125,7 @@ public static partial class TokenAnalyser
                            && !AbstractNouns.Contains(word))
             .ToList();
 
-        if(words.Count < 2)
+        if (words.Count < 2)
             return Option.None<string>();
 
         return Option.Some(Capitalise(words[0]) + " " + Capitalise(words[1]));


### PR DESCRIPTION
## Summary

- Add `Level1Deriver` static class with `FolderTypeMap` dictionary (6 entries: people/portraits → Person, places/landscapes → Place, events → Event, photos → Object)
- `Derive(folderSegments, filenameTokens)` applies priority chain: folder-segment match → person-name fallback → colour-token fallback → "Object"
- Extend `TokenAnalyser.AbstractNouns` with photography abbreviations (misc, shot, img, archive, scan, copy, temp, draft) to prevent false person-name matches
- 22 unit tests covering all ACs including the folder-wins-over-colour conflict rule

Closes #409

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1259 passed, 0 failed
- [x] All 6 FolderTypeMap entries verified
- [x] Folder match wins over person name and colour (AC2a)
- [x] Person name fallback (AC2b)
- [x] Colour fallback (AC2c)
- [x] Object final fallback (AC2d)
- [x] Conflict rule: `People/a red car.jpg` → `"Person"` (AC3)
- [x] Case-insensitive folder matching
- [x] Nested folder segments
- [x] Empty inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)