### PR TITLE
feat(file-auto-categorisation): Phase 4 — auto-categorisor assembly (#410)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
@@ -28,7 +28,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     {
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
 
-        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     {
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
 
-        result.Level2.Match(v => v, () => null).ShouldBe("John Smith");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     {
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
 
-        result.Level3.Match(v => v, () => null).ShouldBe("Red Car");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     {
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
 
-        result.Level3.Match(v => v, () => null).ShouldBe("Red Dress");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public sealed class GivenARuleBasedFileAutoCategorisor
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
 
         result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => v, () => null).ShouldBe("Red");
-        result.Level3.Match(v => v, () => null).ShouldBe("Red Car");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
     }
 
     [Fact]
@@ -87,8 +87,8 @@ public sealed class GivenARuleBasedFileAutoCategorisor
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
 
         result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => v, () => null).ShouldBe("Red");
-        result.Level3.Match(v => v, () => null).ShouldBe("Red Dress");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
 
         result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
         result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
@@ -107,7 +107,7 @@ public sealed class GivenARuleBasedFileAutoCategorisor
         FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
 
         result.Level1.ShouldBe("Person");
-        result.Level2.Match(v => v, () => null).ShouldBe("John Smith");
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
         result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
@@ -185,5 +185,149 @@ public sealed class GivenARuleBasedFileAutoCategorisor
         FileClassification result = sut.Categorise(string.Empty);
 
         result.IsSpecial.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_places_folder_path_then_level1_is_place()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Places/a scenic lake view.jpg");
+
+        result.Level1.ShouldBe("Place");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_landscapes_folder_path_then_level1_is_place()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Landscapes/a scenic lake view.jpg");
+
+        result.Level1.ShouldBe("Place");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_events_folder_path_then_level1_is_event()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Events/birthday party.jpg");
+
+        result.Level1.ShouldBe("Event");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_portraits_folder_path_then_level1_is_person()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Portraits/a file with a persons name: jane doe.jpg");
+
+        result.Level1.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level1_is_person()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+
+        result.Level1.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level2_is_person_name_not_colour()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level3_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_unknown_folder_and_person_name_in_filename_then_level1_is_person()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Uncategorised/jane doe portrait.jpg");
+
+        result.Level1.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_blue_car_path_then_level1_is_color()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+
+        result.Level1.ShouldBe("Color");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_blue_car_path_then_level2_is_blue()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_blue_car_path_then_level3_is_blue_car()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Blue Car");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_green_hat_path_then_level2_is_green()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Green");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_green_hat_path_then_level3_is_green_hat()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Green Hat");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_colour_only_filename_then_level2_is_colour()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+
+        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_colour_only_filename_then_level3_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_tag_name_requested_and_level3_is_present_then_tag_name_is_level3()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.TagName.ShouldBe("Red Car");
+    }
+
+    [Fact]
+    public void when_tag_name_requested_and_level3_is_absent_and_level2_is_present_then_tag_name_is_level2()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+
+        result.TagName.ShouldBe("Red");
+    }
+
+    [Fact]
+    public void when_tag_name_requested_and_level2_and_level3_are_absent_then_tag_name_is_level1()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+
+        result.TagName.ShouldBe(result.Level1);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
@@ -1,0 +1,189 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenARuleBasedFileAutoCategorisor
+{
+    private readonly IFileAutoCategorisor sut = new RuleBasedFileAutoCategorisor();
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_car_path_then_level1_is_color()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.Level1.ShouldBe("Color");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_person_name_path_then_level1_is_person()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+
+        result.Level1.ShouldBe("Person");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_car_path_then_level2_is_red()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_person_name_path_then_level2_is_john_smith()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+
+        result.Level2.Match(v => v, () => null).ShouldBe("John Smith");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_car_path_then_level3_is_red_car()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.Level3.Match(v => v, () => null).ShouldBe("Red Car");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_dress_path_then_level3_is_red_dress()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+
+        result.Level3.Match(v => v, () => null).ShouldBe("Red Dress");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_misc_red_path_then_level3_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_person_name_path_then_level3_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_car_path_then_full_classification_is_correct()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.Level1.ShouldBe("Color");
+        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+        result.Level3.Match(v => v, () => null).ShouldBe("Red Car");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_dress_path_then_full_classification_is_correct()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+
+        result.Level1.ShouldBe("Color");
+        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+        result.Level3.Match(v => v, () => null).ShouldBe("Red Dress");
+    }
+
+    [Fact]
+    public void when_categorise_called_with_misc_red_path_then_full_classification_is_correct()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+
+        result.Level1.ShouldBe("Color");
+        result.Level2.Match(v => v, () => null).ShouldBe("Red");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_person_name_path_then_full_classification_is_correct()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+
+        result.Level1.ShouldBe("Person");
+        result.Level2.Match(v => v, () => null).ShouldBe("John Smith");
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_empty_path_then_does_not_throw()
+    {
+        Should.NotThrow(() => sut.Categorise(string.Empty));
+    }
+
+    [Fact]
+    public void when_categorise_called_with_empty_path_then_returns_valid_classification()
+    {
+        FileClassification result = sut.Categorise(string.Empty);
+
+        result.ShouldNotBeNull();
+        result.Level1.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_only_root_segments_then_does_not_throw()
+    {
+        Should.NotThrow(() => sut.Categorise("a/b/c/d/e/f/g"));
+    }
+
+    [Fact]
+    public void when_categorise_called_with_only_root_segments_then_returns_valid_classification()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g");
+
+        result.ShouldNotBeNull();
+        result.Level1.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_no_meaningful_tokens_then_does_not_throw()
+    {
+        Should.NotThrow(() => sut.Categorise("a/b/c/d/e/f/g/a/the.jpg"));
+    }
+
+    [Fact]
+    public void when_categorise_called_with_no_meaningful_tokens_then_level2_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+
+        result.Level2.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_no_meaningful_tokens_then_level3_is_none()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+
+        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_red_car_path_then_is_special_is_false()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+
+        result.IsSpecial.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_people_person_name_path_then_is_special_is_false()
+    {
+        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+
+        result.IsSpecial.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_empty_path_then_is_special_is_false()
+    {
+        FileClassification result = sut.Categorise(string.Empty);
+
+        result.IsSpecial.ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/IFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/IFileAutoCategorisor.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Derives a <see cref="FileClassification"/> from a full remote file path.</summary>
+public interface IFileAutoCategorisor
+{
+    /// <summary>Derives a <see cref="FileClassification"/> from a full remote file path.</summary>
+    FileClassification Categorise(string remotePath);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RuleBasedFileAutoCategorisor.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <inheritdoc />
+public sealed partial class RuleBasedFileAutoCategorisor : IFileAutoCategorisor
+{
+    [GeneratedRegex(@"[^a-zA-Z]+")]
+    private static partial Regex NonAlphaPattern();
+
+    /// <inheritdoc />
+    public FileClassification Categorise(string remotePath)
+    {
+        string strippedPath = PathNormaliser.StripRootPath(remotePath);
+        IReadOnlyList<string> folderSegments = PathNormaliser.GetFolderSegments(strippedPath);
+        string filenameStem = PathNormaliser.GetFilenameStem(strippedPath);
+        List<string> tokens = Tokenise(filenameStem);
+
+        string level1 = DeriveLevel1(folderSegments, filenameStem, tokens);
+        (Option<string> level2, Option<string> level3) = DeriveLevel2AndLevel3(filenameStem, tokens);
+
+        return FileClassificationFactory.Create(level1, level2, level3, isSpecial: false);
+    }
+
+    private static string DeriveLevel1(IReadOnlyList<string> folderSegments, string filenameStem, IReadOnlyList<string> tokens)
+    {
+        foreach (string segment in folderSegments)
+        {
+            if (Level1Deriver.FolderTypeMap.TryGetValue(segment, out string? mapped) && mapped != "Object")
+                return mapped;
+        }
+
+        return TokenAnalyser.ExtractPersonName(filenameStem)
+            .Match<string>(
+                _ => "Person",
+                () => tokens.Any(t => TokenAnalyser.ColourWords.Contains(t)) ? "Color" : "Object"
+            );
+    }
+
+    private static (Option<string> Level2, Option<string> Level3) DeriveLevel2AndLevel3(string filenameStem, IReadOnlyList<string> tokens) =>
+        TokenAnalyser.ExtractPersonName(filenameStem)
+            .Match<(Option<string>, Option<string>)>(
+                name => (Option.Some(name), Option.None<string>()),
+                () => DeriveColourLevels(tokens)
+            );
+
+    private static (Option<string> Level2, Option<string> Level3) DeriveColourLevels(IReadOnlyList<string> tokens) =>
+        TokenAnalyser.ExtractColourPhrase(tokens)
+            .Match<(Option<string>, Option<string>)>(
+                phrase => BuildColourLevels(phrase),
+                () => (Option.None<string>(), Option.None<string>())
+            );
+
+    private static (Option<string> Level2, Option<string> Level3) BuildColourLevels(string phrase)
+    {
+        int spaceIndex = phrase.IndexOf(' ');
+
+        if (spaceIndex < 0)
+            return (Option.Some(TitleCase(phrase)), Option.None<string>());
+
+        return (Option.Some(TitleCase(phrase[..spaceIndex])), Option.Some(TitleCase(phrase)));
+    }
+
+    private static List<string> Tokenise(string filenameStem) =>
+        NonAlphaPattern()
+            .Split(filenameStem.ToLowerInvariant())
+            .Where(t => t.Length > 0 && !TokenAnalyser.StopWords.Contains(t))
+            .ToList();
+
+    private static string TitleCase(string phrase) =>
+        string.Join(' ', phrase.Split(' ')
+            .Where(w => w.Length > 0)
+            .Select(w => char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.OneDrive;
@@ -61,6 +62,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ISyncWorkerFactory, SyncWorkerFactory>();
         _ = services.AddSingleton<ISyncPipeline, ParallelSyncPipeline>();
         _ = services.AddSingleton<IAppBootstrapper, AppBootstrapper>();
+        _ = services.AddSingleton<IFileAutoCategorisor, RuleBasedFileAutoCategorisor>();
         _ = services.AddOneDriveClient();
 
         return services;


### PR DESCRIPTION
# Summary

Implements Phase 4 of the file auto-categorisation feature. Defines `IFileAutoCategorisor` and `RuleBasedFileAutoCategorisor`, which assembles PathNormaliser, TokenAnalyser, and Level1Deriver (Phases 1–3) into a complete `FileClassification(Level1, Level2, Level3, isSpecial: false)`.

## Type of change

- [x] Feature

## Related issues / links

Closes #410

Depends on #409 (Phase 3 — Level1Deriver, already merged)

## How was this tested?

- [x] Unit tests added/updated

40 tests in `GivenARuleBasedFileAutoCategorisor` covering:
- All 4 plan examples end-to-end
- Level1/Level2/Level3 individually for key paths
- Folder-map priority (People/Places/Events/Portraits/Landscapes)
- Folder-wins vs filename-inference conflict
- Colour variants (red, blue, green)
- Person-name extraction with and without colon syntax
- TagName property (Level3 → Level2 → Level1 fallback)
- Edge cases: empty path, only-root-segments, no-meaningful-tokens

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — Domain + Startup only. App remains fully operational; `IFileAutoCategorisor` is registered in DI but not injected anywhere yet (Phase 5 will wire it up).

---

## TDD Checklist (required)

- [x] Builds locally — `0 Warnings, 0 Errors`
- [x] Tests pass (`dotnet test`) — `1301 passed, 0 failed`
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable) — XML docs on all public members

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

**Key design decision:** `Level1Deriver.FolderTypeMap` maps `"photos" → "Object"` (generic bucket). The implementation skips folder-map entries that resolve to `"Object"` and falls through to filename inference, so `Photos/a red car...` correctly yields `Level1=Color`. Specific mappings (`People→Person`, `Places→Place`, `Events→Event`) still override as intended by the plan.