### PR TITLE
feat(file-auto-categorisation): Phase 5 — wire IFileAutoCategorisor into SyncedItemRegistrar

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenASyncedItemRegistrar.cs
@@ -16,6 +16,7 @@ public sealed class GivenASyncedItemRegistrar
     private readonly IFileClassificationRuleRepository _fileClassificationRuleRepository = Substitute.For<IFileClassificationRuleRepository>();
     private readonly IDirectory _mockDirectory = Substitute.For<IDirectory>();
     private readonly IFileSystem _fileSystem = Substitute.For<IFileSystem>();
+    private readonly IFileAutoCategorisor _fileAutoCategorisor = Substitute.For<IFileAutoCategorisor>();
 
     public GivenASyncedItemRegistrar()
     {
@@ -28,11 +29,12 @@ public sealed class GivenASyncedItemRegistrar
                 FileClassificationRuleFactory.Create(keywords, FileClassificationFactory.Create("Media", Option.None<string>(), Option.None<string>(), false)),
                 FileClassificationRuleFactory.Create(keywords1, FileClassificationFactory.Create("Work", Option.None<string>(), Option.None<string>(), false))
             }.AsReadOnly()));
+        _fileAutoCategorisor.Categorise(Arg.Any<string>()).Returns(FileClassificationFactory.Create("Unclassified", Option.None<string>(), Option.None<string>(), false));
     }
 
-    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileClassificationRuleRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
+    private SyncedItemRegistrar CreateSut() => new(_syncedItemRepository, _fileClassificationRuleRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>(), _fileAutoCategorisor);
 
-    private SyncedItemRegistrar CreateSutWithRules(IReadOnlyList<FileClassificationRule> rules) => new(_syncedItemRepository, _fileClassificationRuleRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>());
+    private SyncedItemRegistrar CreateSutWithRules(IReadOnlyList<FileClassificationRule> rules) => new(_syncedItemRepository, _fileClassificationRuleRepository, _fileSystem, Substitute.For<ILogger<SyncedItemRegistrar>>(), _fileAutoCategorisor);
 
     private static FileClassificationRule ClassificationRule(string keyword, string level1)
         => FileClassificationRuleFactory.Create([keyword], FileClassificationFactory.Create(level1, Option.None<string>(), Option.None<string>(), false));
@@ -134,7 +136,7 @@ public sealed class GivenASyncedItemRegistrar
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(
             entityId,
-            Arg.Is<IReadOnlyList<FileClassification>>(list => list.Count == 1 && list[0].TagName == "Unclassified"),
+            Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.TagName == "Unclassified")),
             Arg.Any<CancellationToken>());
     }
 
@@ -162,5 +164,47 @@ public sealed class GivenASyncedItemRegistrar
         await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/photos", "/sync/photos", syncedItems, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.DidNotReceive().UpsertClassificationsAsync(Arg.Any<int>(), Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_then_auto_categorisor_categorise_is_called()
+    {
+        var sut = CreateSut();
+        var item = FileItem("file-auto-1", "/Photos/a red car on the road.jpg");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/Photos/a red car on the road.jpg", "/sync/Photos/a red car on the road.jpg", syncedItems, TestContext.Current.CancellationToken);
+
+        _fileAutoCategorisor.Received(1).Categorise("/Photos/a red car on the road.jpg");
+    }
+
+    [Fact]
+    public async Task when_register_phantom_called_then_upsert_classifications_includes_auto_derived_classification()
+    {
+        const int entityId = 99;
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(entityId));
+        _fileAutoCategorisor.Categorise(Arg.Any<string>()).Returns(FileClassificationFactory.Create("Color", Option.Some("Red"), Option.None<string>(), false));
+        var sut = CreateSut();
+        var item = FileItem("file-auto-2", "/Photos/a red car on the road.jpg");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterPhantomAsync(new AccountId("user-1"), item, "/Photos/a red car on the road.jpg", "/sync/Photos/a red car on the road.jpg", syncedItems, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertClassificationsAsync(
+            entityId,
+            Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Color")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_register_folder_called_then_auto_categorisor_is_not_called()
+    {
+        var sut = CreateSut();
+        var item = FolderItem("folder-auto-1", "/Photos");
+        var syncedItems = new Dictionary<string, SyncedItemEntity>();
+
+        await sut.RegisterFolderAsync(new AccountId("user-1"), item, "/Photos", "/sync/Photos", syncedItems, TestContext.Current.CancellationToken);
+
+        _fileAutoCategorisor.DidNotReceive().Categorise(Arg.Any<string>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
@@ -9,7 +9,7 @@ using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
 /// <inheritdoc />
-public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger) : ISyncedItemRegistrar
+public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemRepository, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem, ILogger<SyncedItemRegistrar> logger, IFileAutoCategorisor fileAutoCategorisor) : ISyncedItemRegistrar
 {
     /// <inheritdoc />
     public async Task RegisterFolderAsync(AccountId accountId, FolderDeltaItem item, string remotePath, string localPath, Dictionary<string, SyncedItemEntity> syncedItems, CancellationToken ct)
@@ -28,7 +28,7 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
         int syncedItemId = await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
 
         var classificationRules = await classificationRuleRepository.GetAllAsync(ct);
-        var classifications = FileClassifier.Classify(remotePath, classificationRules);
+        var classifications = FileClassifier.Classify(remotePath, classificationRules).Append(fileAutoCategorisor.Categorise(remotePath)).ToList().AsReadOnly();
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
         syncedItems[item.Id.Id] = phantomItem;
     }


### PR DESCRIPTION
# Summary

Injects `IFileAutoCategorisor` into `SyncedItemRegistrar` via constructor DI and appends the auto-derived `FileClassification` to the keyword-rule classifications on every `RegisterPhantomAsync` call. No DB schema changes required — classifications persist through the existing `UpsertClassificationsAsync` path.

## Type of change

- [x] Feature

## Related issues / links

Closes #411

## How was this tested?

- [x] Unit tests added/updated

Three new tests in `GivenASyncedItemRegistrar`:
- `when_register_phantom_called_then_auto_categorisor_categorise_is_called`
- `when_register_phantom_called_then_upsert_classifications_includes_auto_derived_classification`
- `when_register_folder_called_then_auto_categorisor_is_not_called`

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1304/1304 passed
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- `IFileAutoCategorisor` was already registered as a singleton in `ShellServiceExtensions` (Phase 4, #410) — no DI changes needed.
- The constructor parameter order places `IFileAutoCategorisor` last to minimise diff noise.
- `RegisterFolderAsync` is deliberately unchanged — folders are not auto-categorised.