### PR TITLE
test(onedrive-sync-client): Phase 2a — IntegrationTestApp headless Avalonia bootstrap (#418)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="Avalonia.Headless.XUnit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="WireMock.Net" />
     <PackageReference Include="NSubstitute" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestApp.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestApp.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Markup.Xaml;
+
+[assembly: AvaloniaTestApplication(typeof(AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure.IntegrationTestApp))]
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+
+public sealed class IntegrationTestApp : Application
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<IntegrationTestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+}


### PR DESCRIPTION
# Summary

Adds `Infrastructure/IntegrationTestApp.cs` — the assembly-level headless Avalonia bootstrap required by all integration tests in the project. Also adds the missing `Avalonia.Headless.XUnit` `PackageReference` (version was already pinned in `Directory.Packages.props` from Phase 1 but the `<PackageReference>` entry was omitted from the `.csproj`; it is required for the `[AvaloniaTestApplication]` attribute to resolve).

## Type of change

- [x] Maintenance

## Related issues / links

Closes #418

## How was this tested?

- [x] Not applicable (bootstrap infrastructure — no runnable tests until Phase 2b fixture is in place)

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration`

---

## TDD Checklist (required)

- [x] Builds locally (`Build succeeded. 0 Warning(s) 0 Error(s)`)
- [x] No new analyzer warnings
- [x] Not applicable (Phase 2a is infrastructure only; tests exercising it come in Phase 2b+)

---

## How to run tests locally

```bash
dotnet build apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
```

---

## Notes for reviewers

- `IntegrationTestApp` is intentionally bare — no DI wiring. DI lives in `IntegrationTestFixture` (Phase 2b).
- The `[assembly: AvaloniaTestApplication(...)]` attribute must be in exactly one file per test assembly; this is that file.