### PR TITLE
test(onedrive-sync-client): Phase 2b — IntegrationTestFixture and TestDbContextFactory (#419)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
@@ -1,0 +1,105 @@
+using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.LogViewer;
+using AStar.Dev.OneDrive.Sync.Client.Startup;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+using WireMock.Server;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+
+public sealed class IntegrationTestFixture : IAsyncLifetime
+{
+    public WireMockServer WireMock { get; private set; } = null!;
+    public MockFileSystem FileSystem { get; } = new();
+    public ServiceProvider Services { get; private set; } = null!;
+
+    private string tempDbPath = string.Empty;
+
+    public async ValueTask InitializeAsync()
+    {
+        WireMock = WireMockServer.Start(0);
+        tempDbPath = Path.GetTempFileName() + ".db";
+
+        var inMemoryLogSink = new InMemoryLogSink();
+        var services = new ServiceCollection();
+
+        services.AddLogging();
+        services.AddPersistence();
+
+        var dbContextDescriptor = services.Single(d => d.ServiceType == typeof(IDbContextFactory<AppDbContext>));
+        services.Remove(dbContextDescriptor);
+        services.AddSingleton<IDbContextFactory<AppDbContext>>(new TestDbContextFactory(tempDbPath));
+
+        services.AddSingleton(Options.Create(new EntraIdConfiguration
+        {
+            ClientId = "test-client-id",
+            RedirectUri = "http://localhost",
+            AuthorityForMicrosoftAccountsOnly = "https://login.microsoftonline.com/consumers",
+            Scopes = ["Files.ReadWrite", "offline_access"]
+        }));
+        services.AddSingleton(Options.Create(new SyncSettings { ProgressReportInterval = 1 }));
+
+        services.AddShell(inMemoryLogSink);
+
+        ReplaceWithStub<IAuthService>(services);
+        ReplaceWithStub<IFolderPickerService>(services);
+        ReplaceWithStub<IFileManagerService>(services);
+
+        var fileSystemDescriptor = services.Single(d => d.ServiceType == typeof(IFileSystem));
+        services.Remove(fileSystemDescriptor);
+        services.AddSingleton<IFileSystem>(FileSystem);
+
+        var graphFactoryDescriptor = services.Single(d => d.ServiceType == typeof(IGraphClientFactory));
+        services.Remove(graphFactoryDescriptor);
+        services.AddSingleton<IGraphClientFactory>(new WireMockGraphClientFactory(WireMock.Url!));
+
+        Services = services.BuildServiceProvider();
+
+        await using var context = Services.GetRequiredService<IDbContextFactory<AppDbContext>>().CreateDbContext();
+        await context.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Services.DisposeAsync();
+        WireMock.Stop();
+        try { File.Delete(tempDbPath); } catch { }
+    }
+
+    private static void ReplaceWithStub<TService>(ServiceCollection services) where TService : class
+    {
+        var descriptor = services.Single(d => d.ServiceType == typeof(TService));
+        services.Remove(descriptor);
+        services.AddSingleton(Substitute.For<TService>());
+    }
+
+    private sealed class WireMockGraphClientFactory(string baseUrl) : IGraphClientFactory
+    {
+        public GraphServiceClient CreateClient(Func<CancellationToken, Task<string>> tokenFactory)
+        {
+            var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            var authProvider = new BaseBearerTokenAuthenticationProvider(new TokenFactoryProvider(tokenFactory));
+            var adapter = new HttpClientRequestAdapter(authProvider, httpClient: httpClient);
+            adapter.BaseUrl = baseUrl;
+
+            return new GraphServiceClient(adapter);
+        }
+
+        private sealed class TokenFactoryProvider(Func<CancellationToken, Task<string>> tokenFactory) : IAccessTokenProvider
+        {
+            public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken ct = default)
+                => tokenFactory(ct);
+
+            public AllowedHostsValidator AllowedHostsValidator { get; } = new();
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/TestDbContextFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/TestDbContextFactory.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+
+public sealed class TestDbContextFactory(string dbPath) : IDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+
+        return new AppDbContext(options);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Infrastructure/TestDbContextFactory.cs` — implements `IDbContextFactory<AppDbContext>` pointing to a caller-supplied temp SQLite path; lives entirely in the test project
- Adds `Infrastructure/IntegrationTestFixture.cs` — implements `IAsyncLifetime`; owns WireMock (port 0), temp SQLite, and a `ServiceProvider` built from `AddPersistence()` + `AddShell()` with descriptor replacements for `IDbContextFactory<AppDbContext>`, `IAuthService`, `IFolderPickerService`, `IFileManagerService`, `IFileSystem`, and `IGraphClientFactory` (Kiota base URL → `WireMockServer.Url`); runs EF migrations in `InitializeAsync`; cleans up in `DisposeAsync`

## Type of change

- [x] Maintenance

## Related issues / links

Closes #419

## How was this tested?

- [x] Not applicable — this phase adds infrastructure only; behavioural tests are added in Phase 3–5

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration`

---

## TDD Checklist (required)

- [x] Builds locally — `dotnet build` zero errors, zero warnings
- [x] No new analyzer warnings
- [x] Not applicable — infrastructure only, no public API changes

---

## How to run tests locally

```bash
dotnet build apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
```

---

## Notes for reviewers

- No production code touched — `InternalsVisibleTo` grants access to `AddPersistence` / `AddShell`
- `WireMockGraphClientFactory` (private nested class) replaces `IGraphClientFactory` so Graph API calls hit WireMock rather than `graph.microsoft.com`
- `ReplaceWithStub<T>` helper removes the registered descriptor and adds an NSubstitute stub; avoids native UI calls in headless tests