### PR TITLE
test(onedrive-sync-client): Phase 3a — GivenSyncedItemRegistrar when registering new folders (#421)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/SyncPipeline/GivenSyncedItemRegistrar_WhenRegisteringNewFolders.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/SyncPipeline/GivenSyncedItemRegistrar_WhenRegisteringNewFolders.cs
@@ -1,0 +1,74 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.SyncPipeline;
+
+public sealed class GivenSyncedItemRegistrar_WhenRegisteringNewFolders(IntegrationTestFixture fixture) : IClassFixture<IntegrationTestFixture>
+{
+    [Fact]
+    public async Task when_registering_a_folder_then_the_folder_is_created_in_the_file_system()
+    {
+        var registrar = fixture.Services.GetRequiredService<ISyncedItemRegistrar>();
+        var accountId = new AccountId("account-fs-test");
+        const string localPath = "/local/fs-test/Documents";
+        await SeedAccountAsync(accountId);
+
+        await registrar.RegisterFolderAsync(accountId, BuildFolderItem("folder-id-fs"), "Documents", localPath, [], CancellationToken.None);
+
+        fixture.FileSystem.Directory.Exists(localPath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_registering_a_folder_then_a_synced_item_entity_is_persisted()
+    {
+        var registrar = fixture.Services.GetRequiredService<ISyncedItemRegistrar>();
+        var repository = fixture.Services.GetRequiredService<ISyncedItemRepository>();
+        var accountId = new AccountId("account-persist-test");
+        const string localPath = "/local/persist-test/Documents";
+        await SeedAccountAsync(accountId);
+
+        await registrar.RegisterFolderAsync(accountId, BuildFolderItem("folder-id-persist"), "Documents", localPath, [], CancellationToken.None);
+
+        var items = await repository.GetAllByAccountAsync(accountId, CancellationToken.None);
+        items.ShouldContainKey("folder-id-persist");
+    }
+
+    [Fact]
+    public async Task when_registering_the_same_folder_twice_then_only_one_row_exists()
+    {
+        var registrar = fixture.Services.GetRequiredService<ISyncedItemRegistrar>();
+        var repository = fixture.Services.GetRequiredService<ISyncedItemRepository>();
+        var accountId = new AccountId("account-upsert-test");
+        const string localPath = "/local/upsert-test/Documents";
+        var folderItem = BuildFolderItem("folder-id-upsert");
+        await SeedAccountAsync(accountId);
+
+        await registrar.RegisterFolderAsync(accountId, folderItem, "Documents", localPath, [], CancellationToken.None);
+        await registrar.RegisterFolderAsync(accountId, folderItem, "Documents", localPath, [], CancellationToken.None);
+
+        var items = await repository.GetAllByAccountAsync(accountId, CancellationToken.None);
+        items.Count.ShouldBe(1);
+    }
+
+    private async Task SeedAccountAsync(AccountId accountId)
+    {
+        var factory = fixture.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+        context.Set<AccountEntity>().Add(new AccountEntity { Id = accountId });
+        await context.SaveChangesAsync();
+    }
+
+    private static FolderDeltaItem BuildFolderItem(string itemId) => DeltaItemFactory.CreateFolder(
+        new OneDriveItemId(itemId),
+        new DriveId("test-drive-id"),
+        Option.None<OneDriveFolderId>(),
+        ItemPathFactory.Create("Documents"),
+        VersionInfoFactory.Create(Option.None<string>(), Option.None<string>()));
+}


### PR DESCRIPTION
# Summary

Adds `SyncPipeline/GivenSyncedItemRegistrar_WhenRegisteringNewFolders.cs` — integration tests for folder registration via `ISyncedItemRegistrar` against a real SQLite database and `MockFileSystem`.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #421

## How was this tested?

- [x] Unit tests added/updated

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration`

---

## TDD Checklist (required)

- [x] Builds locally (`Build succeeded. 0 Warning(s) 0 Error(s)`)
- [x] Tests pass (`Failed: 0, Passed: 3, Skipped: 0, Total: 3`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test --filter "GivenSyncedItemRegistrar_WhenRegisteringNewFolders"
```

---

## Notes for reviewers

- `SyncedItemEntity.AccountId` is a FK to `AccountEntity` — each test seeds its own `AccountEntity` row via `SeedAccountAsync` before calling `RegisterFolderAsync`.
- Each test uses a unique `AccountId` so they remain isolated within the shared `IntegrationTestFixture`.
- Empty `syncedItems` dictionaries passed as `[]` (collection expression) — the registrar updates them in-place but tests assert via the repository, not the dictionary.