### PR TITLE
test(onedrive-sync-client): Phase 4a — GivenFileClassificationRuleRepository (#423)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenFileClassificationRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenFileClassificationRuleRepository.cs
@@ -1,0 +1,64 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.FileClassification;
+
+public sealed class GivenFileClassificationRuleRepository(IntegrationTestFixture fixture) : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        var factory = fixture.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+        context.FileClassificationRules.RemoveRange(context.FileClassificationRules);
+        await context.SaveChangesAsync();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task when_adding_a_rule_then_it_can_be_retrieved()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRuleRepository>();
+
+        await repository.AddAsync(BuildRule(["invoice", "receipt"], "Finance"), ct);
+
+        var rules = await repository.GetAllAsync(ct);
+        rules.Count.ShouldBe(1);
+        rules[0].Classification.Level1.ShouldBe("Finance");
+    }
+
+    [Fact]
+    public async Task when_adding_multiple_rules_then_all_are_returned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRuleRepository>();
+
+        await repository.AddAsync(BuildRule(["invoice"], "Finance"), ct);
+        await repository.AddAsync(BuildRule(["photo", "image"], "Photos"), ct);
+        await repository.AddAsync(BuildRule(["contract", "legal"], "Documents"), ct);
+
+        var rules = await repository.GetAllAsync(ct);
+        rules.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task when_no_rules_exist_then_an_empty_collection_is_returned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRuleRepository>();
+
+        var rules = await repository.GetAllAsync(ct);
+
+        rules.ShouldBeEmpty();
+    }
+
+    private static FileClassificationRule BuildRule(IReadOnlyList<string> keywords, string level1) => FileClassificationRuleFactory.Create(
+        keywords,
+        FileClassificationFactory.Create(level1, Option.None<string>(), Option.None<string>(), isSpecial: false));
+}


### PR DESCRIPTION
# Summary

Adds `FileClassification/GivenFileClassificationRuleRepository.cs` — integration tests for `IFileClassificationRuleRepository` against a real SQLite database, covering add+retrieve, multi-add, and empty-state scenarios.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #423

## How was this tested?

- [x] Unit tests added/updated

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration`

---

## TDD Checklist (required)

- [x] Builds locally (`Build succeeded. 0 Warning(s) 0 Error(s)`)
- [x] Tests pass (`Failed: 0, Passed: 3, Skipped: 0, Total: 3`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test --filter "GivenFileClassificationRuleRepository"
```

---

## Notes for reviewers

- `IAsyncLifetime.InitializeAsync` truncates `FileClassificationRules` via `AppDbContext` before each test — all three tests are isolated despite sharing the fixture's SQLite DB.
- `TestContext.Current.CancellationToken` passed explicitly to all repository calls — xUnit1051 fires when methods with optional `CancellationToken = default` params are called without it.