### PR TITLE
test(onedrive-sync-client): Phase 5 — DI wiring smoke test (#425)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/GivenTheIntegrationTestFixture.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/GivenTheIntegrationTestFixture.cs
@@ -1,0 +1,26 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+
+public sealed class GivenTheIntegrationTestFixture(IntegrationTestFixture fixture) : IClassFixture<IntegrationTestFixture>
+{
+    [Fact]
+    public void when_resolving_services_then_sync_service_is_not_null()
+        => fixture.Services.GetRequiredService<ISyncService>().ShouldNotBeNull();
+
+    [Fact]
+    public void when_resolving_services_then_synced_item_registrar_is_not_null()
+        => fixture.Services.GetRequiredService<ISyncedItemRegistrar>().ShouldNotBeNull();
+
+    [Fact]
+    public void when_resolving_services_then_file_auto_categorisor_is_not_null()
+        => fixture.Services.GetRequiredService<IFileAutoCategorisor>().ShouldNotBeNull();
+
+    [Fact]
+    public void when_resolving_services_then_file_classification_rule_repository_is_not_null()
+        => fixture.Services.GetRequiredService<IFileClassificationRuleRepository>().ShouldNotBeNull();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
@@ -90,8 +90,10 @@ public sealed class IntegrationTestFixture : IAsyncLifetime
         {
             var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
             var authProvider = new BaseBearerTokenAuthenticationProvider(new TokenFactoryProvider(tokenFactory));
-            var adapter = new HttpClientRequestAdapter(authProvider, httpClient: httpClient);
-            adapter.BaseUrl = baseUrl;
+            var adapter = new HttpClientRequestAdapter(authProvider, httpClient: httpClient)
+            {
+                BaseUrl = baseUrl
+            };
 
             return new GraphServiceClient(adapter);
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Infrastructure/IntegrationTestFixture.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.LogViewer;
 using AStar.Dev.OneDrive.Sync.Client.Startup;
 using Microsoft.EntityFrameworkCore;
@@ -53,6 +54,7 @@ public sealed class IntegrationTestFixture : IAsyncLifetime
         ReplaceWithStub<IAuthService>(services);
         ReplaceWithStub<IFolderPickerService>(services);
         ReplaceWithStub<IFileManagerService>(services);
+        services.AddSingleton(Substitute.For<ILocalizationService>());
 
         var fileSystemDescriptor = services.Single(d => d.ServiceType == typeof(IFileSystem));
         services.Remove(fileSystemDescriptor);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Conflicts/GivenAConflictItemViewModel.cs
@@ -101,9 +101,10 @@ public sealed class GivenAConflictItemViewModel
     {
         var loc = BuildLocalizationService();
         loc.GetLocal("Conflict.Collapse").Returns("test-collapse");
-        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc);
-
-        sut.IsExpanded = true;
+        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc)
+        {
+            IsExpanded = true
+        };
 
         sut.CollapseExpandLabel.ShouldBe("test-collapse");
     }
@@ -113,9 +114,10 @@ public sealed class GivenAConflictItemViewModel
     {
         var loc = BuildLocalizationService();
         loc.GetLocal("Conflict.Resolve").Returns("test-resolve");
-        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc);
-
-        sut.IsExpanded = false;
+        var sut = new ConflictItemViewModel(BuildConflict(), Substitute.For<ISyncService>(), loc)
+        {
+            IsExpanded = false
+        };
 
         sut.CollapseExpandLabel.ShouldBe("test-resolve");
     }


### PR DESCRIPTION
# Summary

- Adds `Infrastructure/GivenTheIntegrationTestFixture.cs` — four smoke tests that verify all key services resolve from the DI container; fails fast if any registration is broken.
- Fixes `IntegrationTestFixture` to stub `ILocalizationService`, which `ISyncService` depends on but was never registered.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #425

## How was this tested?

- [x] Unit tests added/updated

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration`

---

## TDD Checklist (required)

- [x] Builds locally (`Build succeeded. 0 Warning(s) 0 Error(s)`)
- [x] Tests pass (`Failed: 0, Passed: 18, Skipped: 0, Total: 18`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test --filter "GivenTheIntegrationTestFixture"
```

---

## Notes for reviewers

- The smoke test immediately exposed a missing `ILocalizationService` registration — exactly the "fails fast" behaviour the phase was designed to provide.
- `ILocalizationService` is added via `services.AddSingleton(Substitute.For<ILocalizationService>())` directly (not via `ReplaceWithStub`) since it has no prior registration in the test container.