### PR TITLE
fix(onedrive-sync-client): auto-categoriser not called + temp-then-move download strategy

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
@@ -1,0 +1,115 @@
+using System.IO.Abstractions;
+using System.Net;
+using System.Text;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.TestHelpers;
+using Microsoft.Extensions.Logging;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Jobs;
+
+public sealed class GivenAnHttpDownloaderTempFileHandling
+{
+    private const string DownloadUrl = "https://example.com/file.jpg";
+    private const string LocalPath = "/tmp/downloaded-file.jpg";
+    private const string TempPath = LocalPath + ".download";
+    private static readonly DateTimeOffset RemoteModified = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static IHttpClientFactory CreateOkFactory(string content = "file content")
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8)
+        };
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(new FakeHttpMessageHandler(_ => response)));
+
+        return factory;
+    }
+
+    private static IFileSystem CreateAlwaysFailMoveFileSystem()
+    {
+        var mockFs = new MockFileSystem();
+        var fakeFs = Substitute.For<IFileSystem>();
+        fakeFs.FileStream.Returns(mockFs.FileStream);
+        fakeFs.Directory.Returns(mockFs.Directory);
+        fakeFs.Path.Returns(mockFs.Path);
+        fakeFs.File.When(f => f.Move(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(_ => throw new IOException("The process cannot access the file because it is being used by another process."));
+
+        return fakeFs;
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_no_temp_file_remains()
+    {
+        var mockFileSystem = new MockFileSystem();
+        var sut = new HttpDownloader(CreateOkFactory(), mockFileSystem, Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        mockFileSystem.File.Exists(TempPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_content_is_written_to_final_path_not_temp_path()
+    {
+        const string content = "expected file content";
+        var mockFileSystem = new MockFileSystem();
+        var sut = new HttpDownloader(CreateOkFactory(content), mockFileSystem, Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        mockFileSystem.File.Exists(LocalPath).ShouldBeTrue();
+        mockFileSystem.File.ReadAllText(LocalPath).ShouldBe(content);
+    }
+
+    [Fact]
+    public async Task when_file_move_fails_all_retries_then_result_is_error()
+    {
+        var sut = new HttpDownloader(CreateOkFactory(), CreateAlwaysFailMoveFileSystem(), Substitute.For<ILogger<HttpDownloader>>());
+
+        var result = await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<System.Reactive.Unit, string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_file_move_fails_all_retries_then_temp_file_is_deleted()
+    {
+        var fakeFs = CreateAlwaysFailMoveFileSystem();
+        var sut = new HttpDownloader(CreateOkFactory(), fakeFs, Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        fakeFs.File.Received(1).Delete(TempPath);
+    }
+
+    [Fact]
+    public async Task when_file_move_fails_then_warning_is_logged_per_failed_retry_attempt()
+    {
+        var logger = new TestLogger<HttpDownloader>();
+        var sut = new HttpDownloader(CreateOkFactory(), CreateAlwaysFailMoveFileSystem(), logger);
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        logger.Entries.Count(e => e.Level == LogLevel.Warning && e.EventId.Id == 2707).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_all_move_retries_exhausted_then_error_is_logged_with_event_2708()
+    {
+        var logger = new TestLogger<HttpDownloader>();
+        var sut = new HttpDownloader(CreateOkFactory(), CreateAlwaysFailMoveFileSystem(), logger);
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        logger.Entries.ShouldContain(e => e.Level == LogLevel.Error && e.EventId.Id == 2708);
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -14,12 +14,16 @@ namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline
 public sealed class GivenASyncJobExecutor
 {
     private const string UploadFilePath = "/sync-root/Documents/file.txt";
+    private const string ColourDownloadRelativePath = "a/b/c/d/e/f/g/Photos/red-car.jpg";
+    private const string ColourUploadLocalPath = "/sync-root/a/b/c/d/e/f/g/Photos/black-dress.jpg";
+    private const string ColourUploadRelativePath = "a/b/c/d/e/f/g/Photos/black-dress.jpg";
 
     private readonly ISyncRepository _syncRepository = Substitute.For<ISyncRepository>();
     private readonly ISyncedItemRepository _syncedItemRepository = Substitute.For<ISyncedItemRepository>();
     private readonly ISyncPipeline _pipeline = Substitute.For<ISyncPipeline>();
     private readonly IFileClassificationRuleRepository _classificationRuleRepository = Substitute.For<IFileClassificationRuleRepository>();
     private readonly ISettingsService _settingsService = Substitute.For<ISettingsService>();
+    private readonly IFileAutoCategorisor _fileAutoCategorisor = new RuleBasedFileAutoCategorisor();
 
     private readonly OneDriveAccount _account = new()
     {
@@ -34,12 +38,12 @@ public sealed class GivenASyncJobExecutor
         _settingsService.Current.Returns(new AppSettings());
     }
 
-    private SyncJobExecutor CreateSut(MockFileSystem mockFileSystem) => new(_syncRepository, _syncedItemRepository, _pipeline, _classificationRuleRepository, mockFileSystem, _settingsService);
+    private SyncJobExecutor CreateSut(MockFileSystem mockFileSystem) => new(_syncRepository, _syncedItemRepository, _pipeline, _classificationRuleRepository, mockFileSystem, _settingsService, _fileAutoCategorisor);
 
-    private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt")
+    private static SyncJob MakeJob(string remoteId, SyncDirection direction, string localPath = "/tmp/file.txt", string relativePath = "Documents/file.txt")
     {
         var remote = RemoteItemRefFactory.Create(new AccountId("user-1"), new OneDriveFolderId(""), new OneDriveItemId(remoteId));
-        var target = SyncFileTargetFactory.Create(localPath, "Documents/file.txt");
+        var target = SyncFileTargetFactory.Create(localPath, relativePath);
         var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
 
         return direction switch
@@ -121,6 +125,38 @@ public sealed class GivenASyncJobExecutor
         await sut.ExecuteAsync(_account, tokenFactory, [job], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Documents")), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_pipeline_completes_download_job_with_colour_in_path_then_auto_categoriser_classification_is_persisted()
+    {
+        const int syncedItemId = 42;
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(syncedItemId));
+        var job = MakeJob("item-1", SyncDirection.Download, relativePath: ColourDownloadRelativePath);
+        SimulateJobCompleted(job.Complete());
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+        var sut = CreateSut(new MockFileSystem());
+
+        await sut.ExecuteAsync(_account, tokenFactory, [job], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Color")), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_pipeline_completes_upload_job_with_colour_in_path_then_auto_categoriser_classification_is_persisted()
+    {
+        const int syncedItemId = 43;
+        _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(syncedItemId));
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(ColourUploadLocalPath).Which(m => m.HasStringContent("data"));
+        var job = (UploadSyncJob)MakeJob("item-1", SyncDirection.Upload, localPath: ColourUploadLocalPath, relativePath: ColourUploadRelativePath);
+        SimulateJobCompleted(((UploadSyncJob)job.Complete()) with { UploadedRemoteItemId = "uploaded-remote-id" });
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+        var sut = CreateSut(mockFileSystem);
+
+        await sut.ExecuteAsync(_account, tokenFactory, [job], [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+
+        await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Color")), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -187,6 +187,14 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 2706, Level = LogLevel.Warning, Message = "[HttpDownloader] Download cancelled during 429 backoff — {Url} attempt {Attempt}/{Max}")]
     public static partial void DownloadCancelledDuringBackoff(ILogger logger, string url, int attempt, int max);
 
+    /// <summary>Logs a failed file move attempt with retry details.</summary>
+    [LoggerMessage(EventId = 2707, Level = LogLevel.Warning, Message = "[HttpDownloader] Move to '{Path}' failed — retrying (attempt {Attempt}/{Max})")]
+    public static partial void DownloadMoveRetrying(ILogger logger, string path, int attempt, int max);
+
+    /// <summary>Logs file move exhausted all retries.</summary>
+    [LoggerMessage(EventId = 2708, Level = LogLevel.Error, Message = "[HttpDownloader] Move to '{Path}' failed after {Max} attempts — {Error}")]
+    public static partial void DownloadMoveExhausted(ILogger logger, string path, int max, string error);
+
     // Upload Operations (2800-2899)
 
     /// <summary>Logs file upload completion.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -9,6 +9,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 /// <summary>
 /// Handles file downloads with automatic retry on 429 Too Many Requests.
 /// Uses exponential backoff respecting the Retry-After header when present.
+/// Downloads are written to a temporary path (<c>.download</c> suffix) and moved
+/// atomically to the final path on completion, preventing conflicts with file-system
+/// indexers or antivirus scanners that may open the destination file during a long sync.
 /// A new HttpClient is obtained from IHttpClientFactory per download call so the
 /// factory can rotate and dispose handlers freely without this class holding stale references.
 /// </summary>
@@ -16,8 +19,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 {
     private const string UserAgent = "AStar.Dev.OneDrive.Sync/1.0";
     private const int MaxRetries = 5;
+    private const int MaxMoveRetries = 3;
     private const double BaseDelaySeconds = 2.0;
     private const double MaxDelaySeconds = 120.0;
+    private static readonly TimeSpan MoveRetryDelay = TimeSpan.FromSeconds(1);
 
     /// <inheritdoc />
     public async Task<Result<Unit, string>> DownloadAsync(string url, string localPath, DateTimeOffset remoteModified, IProgress<long>? progress = null, CancellationToken ct = default)
@@ -25,6 +30,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
         using var http = httpClientFactory.CreateClient();
         http.DefaultRequestHeaders.Add("User-Agent", UserAgent);
 
+        string tempPath = localPath + ".download";
         int attempt = 0;
 
         while (true)
@@ -56,11 +62,23 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 EnsureDirectoryExists(localPath);
 
                 await using var stream = await response.Content.ReadAsStreamAsync(ct);
-                await WriteToFileAsync(stream, localPath, progress, ct);
+                await WriteToFileAsync(stream, tempPath, progress, ct);
+
+                var moveResult = await MoveWithRetryAsync(tempPath, localPath, ct);
+                if (moveResult is Result<Unit, string>.Error)
+                {
+                    TryDeleteTemp(tempPath);
+                    return moveResult;
+                }
 
                 PreserveRemoteTimestamp(localPath, remoteModified);
 
                 return new Result<Unit, string>.Ok(Unit.Default);
+            }
+            catch (IOException ex)
+            {
+                TryDeleteTemp(tempPath);
+                return new Result<Unit, string>.Error($"File write failed for '{localPath}': {ex.Message}");
             }
             catch (HttpRequestException) when (attempt <= MaxRetries)
             {
@@ -77,6 +95,47 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
             {
                 response?.Dispose();
             }
+        }
+    }
+
+    private async Task<Result<Unit, string>> MoveWithRetryAsync(string tempPath, string localPath, CancellationToken ct)
+    {
+        IOException? lastError = null;
+
+        for (int attempt = 1; attempt <= MaxMoveRetries; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                fileSystem.File.Move(tempPath, localPath, overwrite: true);
+                return new Result<Unit, string>.Ok(Unit.Default);
+            }
+            catch (IOException ex)
+            {
+                lastError = ex;
+
+                if (attempt < MaxMoveRetries)
+                {
+                    OneDriveSyncClientMessages.DownloadMoveRetrying(logger, localPath, attempt, MaxMoveRetries);
+                    await Task.Delay(MoveRetryDelay, ct);
+                }
+            }
+        }
+
+        OneDriveSyncClientMessages.DownloadMoveExhausted(logger, localPath, MaxMoveRetries, lastError?.Message ?? string.Empty);
+        return new Result<Unit, string>.Error($"Could not move downloaded file to '{localPath}' after {MaxMoveRetries} attempts: {lastError?.Message}");
+    }
+
+    private void TryDeleteTemp(string tempPath)
+    {
+        try
+        {
+            fileSystem.File.Delete(tempPath);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup — do not mask the original error.
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -11,7 +11,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 /// <inheritdoc />
-public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem, ISettingsService settingsService) : ISyncJobExecutor
+public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileClassificationRuleRepository classificationRuleRepository, IFileSystem fileSystem, ISettingsService settingsService, IFileAutoCategorisor fileAutoCategorisor) : ISyncJobExecutor
 {
     /// <inheritdoc />
     public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
@@ -67,7 +67,10 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
 
     private async Task ClassifyAsync(int syncedItemId, string remotePath, IReadOnlyList<FileClassificationRule> classificationRules, CancellationToken ct)
     {
-        var classifications = FileClassifier.Classify(remotePath, classificationRules);
+        var classifications = FileClassifier.Classify(remotePath, classificationRules)
+            .Append(fileAutoCategorisor.Categorise(remotePath))
+            .ToList()
+            .AsReadOnly();
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/clean-db.sqlite3-query
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/clean-db.sqlite3-query
@@ -3,6 +3,8 @@ DELETE FROM SyncedItems;
 
 DELETE FROM SyncedItemClassifications;
 
+DELETE FROM SyncJobs;
+
 SELECT
     *
 FROM


### PR DESCRIPTION
## Summary

Two bugs discovered during a 3000-file sync run where colour/person-name classifications (red, black, etc.) were absent and after ~12k files all downloads failed with `IOException: being used by another process`.

- **Bug 1**: `SyncJobExecutor.ClassifyAsync` never called `IFileAutoCategorisor.Categorise()`. Only user-defined keyword rules ran; auto-categoriser colour/person outputs were silently dropped for every downloaded and uploaded file. Phantom-file registration (`SyncedItemRegistrar`) was already correct — this was a gap only in the download/upload post-processing path.
- **Bug 2**: `HttpDownloader` wrote directly to the final file path with `FileShare.None`. After thousands of files, OS indexers (Baloo/Tracker) or antivirus began opening newly-created files, causing `IOException` on the next `FileStream.New(FileMode.Create)` and failing all remaining downloads. Downloads now write to `<localPath>.download` first then rename atomically to the final path.

## Type of change

- [x] Bug fix

## Related issues / links

None — discovered during runtime testing.

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation (3000-file sync run triggered both bugs)

Adds 8 new unit tests across two test classes:
- `GivenASyncJobExecutor` — 2 new: colour classification persisted for download and upload jobs
- `GivenAnHttpDownloaderTempFileHandling` — 6 new: no temp file after success, correct content at final path, `Result.Error` on move exhaustion, temp cleanup on failure, log event 2707 (Warning, per retry) and 2708 (Error, exhausted)

All 1312 unit tests pass.

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally — zero errors, zero warnings
- [x] Tests pass (`dotnet test`) — 1312 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed — `SyncJobExecutor` constructor gains `IFileAutoCategorisor` (already registered as singleton in DI; no registration change needed)
- [x] Documentation updated (if applicable) — XML doc on `HttpDownloader` updated to describe temp-write strategy

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- `SyncJobExecutor.ClassifyAsync` now mirrors `SyncedItemRegistrar.RegisterPhantomAsync` exactly: `FileClassifier.Classify(...).Append(fileAutoCategorisor.Categorise(...))`.
- `MoveWithRetryAsync` retries up to 3 times with 1 s delay. On exhaustion it returns `Result.Error` (no throw) and cleans the temp file. Log events 2707/2708 fire so App Insights captures every retry.
- `TryDeleteTemp` catches all exceptions to avoid masking the original error on cleanup failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)