### PR TITLE
docs: parallel change deployment pattern + classification spike plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ DI from the start. Never `new` a service inside a class. Never modify production
 - Local dev: `<ProjectReference>` not `<PackageReference>` (avoids publish cycles).
 - CI version: `-p:Version=$(GitTag)`; local fallback `0.1.0`. Tag format: `v1.2.3`.
 
+## Parallel Change
+
+All features MUST use parallel-change pattern: old code → new code (coexist) → cutover → cleanup. Each step remains deployable. No breaking changes mid-PR.
+
 ## Conventions
 
 - **Commits**: Conventional Commits — `feat(scope): ...`, `fix(scope): ...`

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.TestHelpers;
@@ -36,6 +37,19 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
         fakeFs.Path.Returns(mockFs.Path);
         fakeFs.File.When(f => f.Move(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
             .Do(_ => throw new IOException("The process cannot access the file because it is being used by another process."));
+
+        return fakeFs;
+    }
+
+    private static IFileSystem CreateCapturingFileSystem(string[] capturedTempPath)
+    {
+        var mockFs = new MockFileSystem();
+        var fakeFs = Substitute.For<IFileSystem>();
+        fakeFs.FileStream.Returns(mockFs.FileStream);
+        fakeFs.Directory.Returns(mockFs.Directory);
+        fakeFs.Path.Returns(mockFs.Path);
+        fakeFs.File.When(f => f.Move(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(callInfo => capturedTempPath[0] = callInfo.ArgAt<string>(0));
 
         return fakeFs;
     }
@@ -82,7 +96,7 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
-        fakeFs.File.Received(1).Delete(TempPath);
+        fakeFs.File.Received(1).Delete(Arg.Is<string>(p => p.EndsWith(".download")));
     }
 
     [Fact]
@@ -105,6 +119,31 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
         logger.Entries.ShouldContain(e => e.Level == LogLevel.Error && e.EventId.Id == 2708);
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_temp_path_is_not_plain_dot_download_suffix()
+    {
+        string[] capturedTempPath = [string.Empty];
+        var sut = new HttpDownloader(CreateOkFactory(), CreateCapturingFileSystem(capturedTempPath), Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        capturedTempPath[0].ShouldNotBe(LocalPath + ".download");
+    }
+
+    [Fact]
+    public async Task when_download_succeeds_then_temp_path_contains_guid_segment_before_download_extension()
+    {
+        string[] capturedTempPath = [string.Empty];
+        var sut = new HttpDownloader(CreateOkFactory(), CreateCapturingFileSystem(capturedTempPath), Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        capturedTempPath[0].ShouldEndWith(".download");
+        string[] segments = capturedTempPath[0].Split('.');
+        string guidSegment = segments[^2];
+        Regex.IsMatch(guidSegment, "^[0-9a-f]{32}$").ShouldBeTrue();
     }
 
     private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -44,7 +44,9 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         var entries = await repository.GetAllWithIdsAsync(cancellationToken);
         Rules.Clear();
         foreach (var entry in entries)
+        {
             Rules.Add(new FileClassificationRuleRowViewModel(entry.Id, entry.Rule, DeleteRuleAsync, UpdateRuleAsync));
+        }
     }
 
     private bool CanAdd => !string.IsNullOrWhiteSpace(NewKeywords) && !string.IsNullOrWhiteSpace(NewLevel1);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationRuleEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationRuleEntityConfiguration.cs
@@ -13,5 +13,8 @@ public sealed class FileClassificationRuleEntityConfiguration : IEntityTypeConfi
         _ = builder.Property(e => e.Level1).IsRequired();
         _ = builder.Property(e => e.Level2).IsRequired(false);
         _ = builder.Property(e => e.Level3).IsRequired(false);
+
+        builder.HasIndex(e => new { e.Level1, e.Level2, e.Level3 });
+        builder.HasIndex(e => e.IsSpecial);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260524212430_AddFileClassification.cs
@@ -2,54 +2,53 @@
 
 #nullable disable
 
-namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddFileClassification : Migration
 {
     /// <inheritdoc />
-    public partial class AddFileClassification : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.CreateTable(
-                name: "SyncedItemClassifications",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    SyncedItemId = table.Column<int>(type: "INTEGER", nullable: false),
-                    Level1 = table.Column<string>(type: "TEXT", nullable: false),
-                    Level2 = table.Column<string>(type: "TEXT", nullable: true),
-                    Level3 = table.Column<string>(type: "TEXT", nullable: true),
-                    TagName = table.Column<string>(type: "TEXT", nullable: false),
-                    IsSpecial = table.Column<bool>(type: "INTEGER", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_SyncedItemClassifications", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_SyncedItemClassifications_SyncedItems_SyncedItemId",
-                        column: x => x.SyncedItemId,
-                        principalTable: "SyncedItems",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+        migrationBuilder.CreateTable(
+            name: "SyncedItemClassifications",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                SyncedItemId = table.Column<int>(type: "INTEGER", nullable: false),
+                Level1 = table.Column<string>(type: "TEXT", nullable: false),
+                Level2 = table.Column<string>(type: "TEXT", nullable: true),
+                Level3 = table.Column<string>(type: "TEXT", nullable: true),
+                TagName = table.Column<string>(type: "TEXT", nullable: false),
+                IsSpecial = table.Column<bool>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SyncedItemClassifications", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_SyncedItemClassifications_SyncedItems_SyncedItemId",
+                    column: x => x.SyncedItemId,
+                    principalTable: "SyncedItems",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_SyncedItemClassifications_SyncedItemId",
-                table: "SyncedItemClassifications",
-                column: "SyncedItemId");
+        migrationBuilder.CreateIndex(
+            name: "IX_SyncedItemClassifications_SyncedItemId",
+            table: "SyncedItemClassifications",
+            column: "SyncedItemId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_SyncedItemClassifications_TagName",
-                table: "SyncedItemClassifications",
-                column: "TagName");
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_SyncedItemClassifications_TagName",
+            table: "SyncedItemClassifications",
+            column: "TagName");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "SyncedItemClassifications");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "SyncedItemClassifications");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260525051332_AddFileClassificationRules.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260525051332_AddFileClassificationRules.cs
@@ -2,37 +2,36 @@
 
 #nullable disable
 
-namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations;
+
+/// <inheritdoc />
+public partial class AddFileClassificationRules : Migration
 {
     /// <inheritdoc />
-    public partial class AddFileClassificationRules : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.CreateTable(
-                name: "FileClassificationRules",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    Keywords = table.Column<string>(type: "TEXT", nullable: false),
-                    Level1 = table.Column<string>(type: "TEXT", nullable: false),
-                    Level2 = table.Column<string>(type: "TEXT", nullable: true),
-                    Level3 = table.Column<string>(type: "TEXT", nullable: true),
-                    IsSpecial = table.Column<bool>(type: "INTEGER", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_FileClassificationRules", x => x.Id);
-                });
-        }
+        migrationBuilder.CreateTable(
+            name: "FileClassificationRules",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                Keywords = table.Column<string>(type: "TEXT", nullable: false),
+                Level1 = table.Column<string>(type: "TEXT", nullable: false),
+                Level2 = table.Column<string>(type: "TEXT", nullable: true),
+                Level3 = table.Column<string>(type: "TEXT", nullable: true),
+                IsSpecial = table.Column<bool>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_FileClassificationRules", x => x.Id);
+            });
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "FileClassificationRules");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "FileClassificationRules");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605160036_ClassificationIndexes.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605160036_ClassificationIndexes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605160036_ClassificationIndexes")]
+    partial class ClassificationIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605160036_ClassificationIndexes.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605160036_ClassificationIndexes.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations;
+
+/// <inheritdoc />
+public partial class ClassificationIndexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_FileClassificationRules_IsSpecial",
+            table: "FileClassificationRules",
+            column: "IsSpecial");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_FileClassificationRules_Level1_Level2_Level3",
+            table: "FileClassificationRules",
+            columns: ["Level1", "Level2", "Level3"]);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_FileClassificationRules_IsSpecial",
+            table: "FileClassificationRules");
+
+        migrationBuilder.DropIndex(
+            name: "IX_FileClassificationRules_Level1_Level2_Level3",
+            table: "FileClassificationRules");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRuleRepository.cs
@@ -21,6 +21,8 @@ public sealed class FileClassificationRuleRepository(IDbContextFactory<AppDbCont
                     e.Level2 is not null ? Option.Some(e.Level2) : Option.None<string>(),
                     e.Level3 is not null ? Option.Some(e.Level3) : Option.None<string>(),
                     e.IsSpecial)))
+                    .OrderBy(r => r.Classification.IsSpecial)
+                    .ThenBy(r => r.Classification.Level1)
             .ToList()
             .AsReadOnly();
     }
@@ -39,6 +41,8 @@ public sealed class FileClassificationRuleRepository(IDbContextFactory<AppDbCont
                     e.Level2 is not null ? Option.Some(e.Level2) : Option.None<string>(),
                     e.Level3 is not null ? Option.Some(e.Level3) : Option.None<string>(),
                     e.IsSpecial))))
+            .OrderBy(r => r.Rule.Classification.IsSpecial)
+            .ThenBy(r => r.Rule.Classification.Level1)
             .ToList()
             .AsReadOnly();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -30,7 +30,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
         using var http = httpClientFactory.CreateClient();
         http.DefaultRequestHeaders.Add("User-Agent", UserAgent);
 
-        string tempPath = localPath + ".download";
+        string tempPath = localPath + "." + Guid.NewGuid().ToString("N") + ".download";
         int attempt = 0;
 
         while (true)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -16,7 +16,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
     /// <inheritdoc />
     public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IReadOnlyList<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
     {
-        if(jobs.Count == 0)
+        if (jobs.Count == 0)
             return;
 
         await syncRepository.EnqueueJobsAsync(jobs).ConfigureAwait(false);
@@ -29,7 +29,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             onProgress,
             args =>
             {
-                if(args.Job.Status.State == SyncJobState.Completed)
+                if (args.Job.Status.State == SyncJobState.Completed)
                     successfulJobs.Add(args.Job);
 
                 onJobCompleted(args);
@@ -39,23 +39,28 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             settingsService.Current.ConcurrentWorkerCount,
             ct).ConfigureAwait(false);
 
-        if(successfulJobs.IsEmpty)
+        if (successfulJobs.IsEmpty)
             return;
 
+        await CategoriseFilesAsync(account, syncedItems, successfulJobs, ct).ConfigureAwait(false);
+    }
+
+    private async Task CategoriseFilesAsync(OneDriveAccount account, Dictionary<string, SyncedItemEntity> syncedItems, ConcurrentBag<SyncJob> successfulJobs, CancellationToken ct)
+    {
         var classificationRules = await classificationRuleRepository.GetAllAsync(ct).ConfigureAwait(false);
 
-        foreach(var job in successfulJobs)
+        foreach (var job in successfulJobs)
         {
             string remotePath = NormaliseRemotePath(job.Target.RelativePath);
 
-            if(job is DownloadSyncJob)
+            if (job is DownloadSyncJob)
             {
                 var entity = SyncedItemEntityFactory.CreateFromDownloadJob(account.Id, job, remotePath);
                 int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
                 syncedItems[job.Remote.RemoteItemId.Id] = entity;
                 await ClassifyAsync(syncedItemId, remotePath, classificationRules, ct).ConfigureAwait(false);
             }
-            else if(job is UploadSyncJob uploadJob && uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId)
+            else if (job is UploadSyncJob uploadJob && uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId)
             {
                 var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, uploadJob, remotePath, fileSystem);
                 int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
@@ -71,6 +76,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             .Append(fileAutoCategorisor.Categorise(remotePath))
             .ToList()
             .AsReadOnly();
+            
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/clean-db.sqlite3-query
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/clean-db.sqlite3-query
@@ -10,18 +10,27 @@ SELECT
 FROM
     SyncedItemClassifications
 WHERE
-    Level1 != 'Unclassified';
+    Level1 = 'Unclassified';
 
 DELETE FROM SyncJobs;
 
--- Update the FileClassificationRules table to set Level1 to the Keywords where it is currently empty
 UPDATE FileClassificationRules
 SET
-    Level1 = Keywords
+    Level2 = null
 WHERE
-    Level1 = '';
+    Level2 = '';
 
-SELECT
-    *
+SELECT DISTINCT
+    Level1
+FROM
+    SyncedItemClassifications;
+
+SELECT DISTINCT
+    Level1, Level2, Level3
+FROM
+    SyncedItemClassifications;
+
+
+SELECT *
 FROM
     FileClassificationRules;

--- a/apps/desktop/spike/ClassificationSpike/Program.cs
+++ b/apps/desktop/spike/ClassificationSpike/Program.cs
@@ -23,7 +23,7 @@ Console.WriteLine(new string('-', 50));
 Spike.DisplayFileCount(dbContext);
 Console.WriteLine(new string('-', 50));
 
-Spike.ReadAndDisplayMappings();
+Spike.ReadAndDisplayMappings(dbContext);
 Console.WriteLine(new string('-', 50));
 
 Spike.DisplayFileClassificationRules(dbContext);

--- a/apps/desktop/spike/ClassificationSpike/Spike.cs
+++ b/apps/desktop/spike/ClassificationSpike/Spike.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure;
 using AStar.Dev.Utilities;
 using Microsoft.EntityFrameworkCore;
@@ -37,10 +38,10 @@ public static class Spike
         }
     }
 
-    internal static void ReadAndDisplayMappings()
+    internal static void ReadAndDisplayMappings(AppDbContext dbContext)
     {
         string[] fileData = File.ReadAllLines("/home/jbarden/Documents/Mappings.csv");
-        foreach (string line in fileData)
+        foreach (string line in fileData.Skip(1))
         {
             string[] parts = line.Split(',');
             if (parts.Length > 0)
@@ -53,7 +54,15 @@ public static class Spike
                 string level2 = parts[5].Trim();
                 string level3 = parts[6].Trim();
                 Console.WriteLine($"File Name Contains: {fileNameContains}, Database Mapping: {databaseMapping}, Celebrity: {celebrity}, Searchable: {searchable}, Level 1: {level1}, Level 2: {level2}, Level 3: {level3}");
+                dbContext.FileClassificationRules.Add(new FileClassificationRuleEntity
+                {
+                    Keywords = fileNameContains,
+                    Level1 = databaseMapping,
+                    IsSpecial = bool.Parse(searchable),
+                    Level2 = level1
+                });
             }
         }
+        dbContext.SaveChanges();
     }
 }

--- a/docs/plans/OneDrive_O.md
+++ b/docs/plans/OneDrive_O.md
@@ -13,6 +13,20 @@ Problems:
 
 This plan replaces the flat table with a **proper 3-level category hierarchy** plus a separate keyword table.
 
+### Two classifiers run today
+
+The sync pipeline already combines **two** sources, appending both into `SyncedItemClassifications`:
+
+1. **`FileClassifier.Classify(path, dbRules)`** — matches the (flat) DB rule table; emits an `[Unclassified]`
+   sentinel when nothing matches. This is the table being made hierarchical.
+2. **`RuleBasedFileAutoCategorisor.Categorise(path)`** (`IFileAutoCategorisor`) — heuristic engine built on
+   `TokenAnalyser` (person-name + colour-phrase extraction) and `Level1Deriver.FolderTypeMap`. Derives
+   `Person` / `Color` / `Place` / `Event` / `Object` Level1 plus Level2/3, always returns one result.
+
+Call sites: [`SyncedItemRegistrar`](../../apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs)
+and [`SyncJobExecutor`](../../apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs).
+This plan **keeps** the analyser and combines the two cleanly (see *Classification Pipeline & Combination*).
+
 ### Decisions agreed in planning
 
 | Question | Decision |
@@ -21,6 +35,9 @@ This plan replaces the flat table with a **proper 3-level category hierarchy** p
 | Keyword placement | **Leaf node only** — a keyword attaches to the deepest assigned node of its branch (a node with no children) |
 | IsSpecial | **Category node + keyword override** — flag on category node; keyword override `None` = inherit, `Some(bool)` = override |
 | Migration | **Transform existing data** — EF Core migration rebuilds the tree from existing rows; no drop-and-reseed, no data loss |
+| TokenAnalyser combine | **Union, drop sentinel** — DB-rule matches and the `TokenAnalyser` heuristic both contribute; `FileClassifier` stops emitting the `Unclassified` sentinel, the combiner owns the fallback |
+| Analyser vocab | **Keep hardcoded** — `StopWords`/`ColourWords`/`ConcretePairableNouns`/`AbstractNouns`/`FolderTypeMap` stay as `FrozenSet`s in code |
+| Analyser categories | **Map to hierarchy L1** — `Person`, `Color`, `Place`, `Event`, `Object` are seeded as Level 1 category nodes so both sources share one vocabulary |
 
 ---
 
@@ -251,7 +268,46 @@ public static IReadOnlyList<FileClassification> Classify(
 where `KeywordMapping` carries the keyword plus its resolved Level1/Level2/Level3 names and effective
 `IsSpecial`. Matching logic (tokenise path, match keyword against tokens) is unchanged; only the rule shape and
 the `FileClassification` construction change. Effective `IsSpecial` = `keyword.ResolveIsSpecial(leafCategory.IsSpecial)`.
-Unchanged behaviour: returns a single `Unclassified` sentinel when nothing matches.
+
+**Behaviour change — drop the sentinel.** `Classify` now returns an **empty list** when no mapping matches. The
+`Unclassified` fallback moves to the combiner (below) so it can see whether the analyser also produced nothing.
+
+---
+
+## Classification Pipeline & Combination
+
+`TokenAnalyser` and `RuleBasedFileAutoCategorisor` are **kept unchanged** — their vocab stays as hardcoded
+`FrozenSet`s. A new combiner unions the two sources with the **Union, drop sentinel** policy.
+
+```csharp
+// Domain/ClassificationCombiner.cs
+public static class ClassificationCombiner
+{
+    public static IReadOnlyList<FileClassification> Combine(
+        IReadOnlyList<FileClassification> ruleMatches,   // FileClassifier output (may be empty)
+        FileClassification analyserResult)               // RuleBasedFileAutoCategorisor output (always present)
+    {
+        var combined = ruleMatches
+            .Append(analyserResult)
+            .DistinctBy(classification => (classification.Level1, classification.Level2, classification.Level3))
+            .ToList();
+
+        return combined.Count == 0
+            ? [FileClassificationFactory.CreateUnclassified()]
+            : combined.AsReadOnly();
+    }
+}
+```
+
+- The `Unclassified` sentinel now fires **only** if both sources are empty (in practice the analyser always
+  yields at least `Object`, so it is a true safety net).
+- De-dupe on the `(Level1, Level2, Level3)` triple so a rule match and an identical analyser result collapse.
+- Because the analyser's Level1 values (`Person`/`Color`/`Place`/`Event`/`Object`) are **seeded as Level 1
+  category nodes** by the migration, both sources speak the same Level1 vocabulary and de-dupe correctly.
+
+Call sites `SyncedItemRegistrar` and `SyncJobExecutor` change from
+`FileClassifier.Classify(...).Append(autoCategorisor.Categorise(...))` to
+`ClassificationCombiner.Combine(FileClassifier.Classify(path, mappings), autoCategorisor.Categorise(path))`.
 
 ---
 
@@ -347,7 +403,25 @@ foreach (var oldRule in QueryOldRules(connection))
 
 The leaf rule holds automatically: keywords only ever attach to the deepest assigned node of a branch.
 
-**6. Drop old table**: `DROP TABLE FileClassificationRules;`
+**6. Seed analyser Level 1 nodes** — idempotently add the categoriser's derived Level1 values so both sources
+share one tree. Insert only names not already present at Level 1 (from step 2):
+
+```sql
+INSERT INTO FileClassificationCategories (Name, Level, ParentId, IsSpecial)
+SELECT seed.Name, 1, NULL, 0
+FROM (SELECT 'Person' AS Name UNION SELECT 'Color' UNION SELECT 'Place'
+      UNION SELECT 'Event' UNION SELECT 'Object') seed
+WHERE NOT EXISTS (
+    SELECT 1 FROM FileClassificationCategories existing
+    WHERE existing.Level = 1 AND existing.ParentId IS NULL AND existing.Name = seed.Name);
+```
+
+These names mirror `Level1Deriver.FolderTypeMap` + the colour/person/object fallbacks in
+`RuleBasedFileAutoCategorisor`. The analyser still derives them in code; seeding only guarantees a matching
+editable node exists so de-dupe in the combiner aligns. (`SyncedItemClassifications` rows remain string-only;
+no FK back to the tree — see *Out of Scope*.)
+
+**7. Drop old table**: `DROP TABLE FileClassificationRules;`
 
 ### Down (rollback)
 
@@ -387,14 +461,19 @@ rule in `.claude/rules/avalonia-ui.md`.
 - `Domain/FileClassificationKeywordFactory.cs`
 - `Domain/FileClassificationKeywordExtensions.cs`
 - `Domain/KeywordMapping.cs` (+ `KeywordMappingFactory.cs`)
+- `Domain/ClassificationCombiner.cs`
 - `Data/Migrations/<timestamp>_HierarchicalFileClassificationRules.cs`
 
 ### Modify
 - `Data/AppDbContext.cs` — swap DbSets
-- `Domain/FileClassifier.cs` — new signature / mapping input
+- `Domain/FileClassifier.cs` — new signature / mapping input; **drop the `Unclassified` sentinel** (return empty)
+- `Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs` — use `ClassificationCombiner.Combine(...)`
+- `Infrastructure/Sync/Pipeline/SyncJobExecutor.cs` — use `ClassificationCombiner.Combine(...)`
 - `Data/PersistenceServiceExtensions.cs` — DI swap
 - `Classifications/FileClassificationRulesViewModel.cs` + `FileClassificationRuleRowViewModel.cs` — tree binding
 - Any other call site of `IFileClassificationRuleRepository` (services, tests)
+
+`TokenAnalyser`, `RuleBasedFileAutoCategorisor`, `Level1Deriver` — **unchanged**.
 
 ### Delete (after migration applied + call sites updated)
 - `Data/Entities/FileClassificationRuleEntity.cs`
@@ -409,8 +488,12 @@ rule in `.claude/rules/avalonia-ui.md`.
 
 ## Out of Scope
 
-`SyncedItemClassifications` stores the *result* of classifying a file (denormalised Level1/2/3 strings). Those
-are historical records; this plan does not touch them. Raise a separate issue if FK integrity is wanted there.
+`SyncedItemClassifications` stores the *result* of classifying a file (denormalised Level1/2/3 strings) from
+**both** sources (DB rules + analyser). It stays **string-only** — no FK to `FileClassificationCategories`.
+Adding referential integrity there (and back-linking historical rows to tree nodes) is a separate issue.
+
+`TokenAnalyser` and `RuleBasedFileAutoCategorisor` internals — kept **as-is**, vocab stays hardcoded. This plan
+only changes how their output is *combined* with DB-rule output (the combiner) and seeds matching Level1 nodes.
 
 Full tree-edit UX (drag/move nodes, rich keyword editor) — follow-up issue.
 
@@ -423,18 +506,59 @@ Full tree-edit UX (drag/move nodes, rich keyword editor) — follow-up issue.
 | `GivenFileClassificationCategoryFactory` | Level 1–3 validation, L1 forbids ParentId, L>1 requires ParentId, name trim/empty reject |
 | `GivenFileClassificationKeywordFactory` | empty/whitespace keyword rejected; valid keyword trimmed + lowercased |
 | `GivenFileClassificationKeywordExtensions` | `ResolveIsSpecial` — 4 combos (category ±, override None/Some) |
-| `GivenAFileClassifier` | path tokenised, keyword match builds correct Level1/2/3 path + effective IsSpecial; unclassified sentinel |
+| `GivenAFileClassifier` | path tokenised, keyword match builds correct Level1/2/3 path + effective IsSpecial; **returns empty (no sentinel) on no match** |
+| `GivenAClassificationCombiner` | union of rule + analyser results; de-dupe on (L1,L2,L3) triple; `Unclassified` only when both empty; analyser result always retained |
 | `GivenFileClassificationRepository` | CRUD both tables; **leaf enforcement** (reject keyword on non-leaf, reject child under keyword-owning node); `GetAllKeywordMappingsAsync` projection; cascade delete |
-| `GivenHierarchicalMigration` (integration) | old flat rules round-trip into tree; keyword count = token count; keywords land on leaf; effective IsSpecial preserved |
+| `GivenHierarchicalMigration` (integration) | old flat rules round-trip into tree; keyword count = token count; keywords land on leaf; effective IsSpecial preserved; **analyser L1 nodes (Person/Color/Place/Event/Object) seeded once, no duplicates** |
+
+---
+
+## Phased Delivery
+
+**Invariant: `main` is buildable, test-green and deployable after _every_ phase.** Pattern is
+expand → migrate → contract (parallel-change): new structures land additively and unused first, the pipeline
+cuts over atomically, then the old structures are removed. Each phase changes/creates **≤ 6 files (tests
+included)** and ships as one PR. One GitHub issue per phase (raised on approval, per repo convention).
+
+Old and new code coexist from Phase 4 until Phase 9 — that overlap is what keeps `main` deployable.
+
+| # | Goal | Files (count) | Why `main` stays deployable |
+|---|---|---|---|
+| **1** | Category domain | `Domain/FileClassificationCategory.cs`, `…CategoryFactory.cs`, `Tests/…/GivenAFileClassificationCategoryFactory.cs` **(3)** | Pure additive; nothing references it yet |
+| **2** | Keyword domain | `Domain/FileClassificationKeyword.cs`, `…KeywordFactory.cs`, `…KeywordExtensions.cs`, `Tests/…/GivenAFileClassificationKeywordFactory.cs`, `…/GivenFileClassificationKeywordExtensions.cs` **(5)** | Additive; unused |
+| **3** | Mapping + combiner | `Domain/KeywordMapping.cs`, `…KeywordMappingFactory.cs`, `Domain/ClassificationCombiner.cs`, `Tests/…/GivenAClassificationCombiner.cs` **(4)** | Combiner compiled but not wired into pipeline |
+| **4** | EF entities + configs | 2 entities + 2 configs **(4)** | Not yet mapped in `AppDbContext` → no migration drift; compiles |
+| **5** | DbSets + create/seed/backfill migration | `Data/AppDbContext.cs` (+2 DbSets), migration `.cs` + `.Designer.cs`, `AppDbContextModelSnapshot.cs` **(4)** | New tables created **alongside** the old; seeds L1/2/3 + keywords + analyser L1 nodes. **No drop.** Old table + flow untouched |
+| **6** | New repository (registered alongside old) | `Data/Repositories/IFileClassificationRepository.cs`, `FileClassificationRepository.cs`, `Data/PersistenceServiceExtensions.cs` (add reg, keep old), `Tests/…/GivenAFileClassificationRepository.cs` **(4)** | Both repos registered; nothing consumes the new one yet |
+| **7** | Classifier overload + **pipeline cutover** | `Domain/FileClassifier.cs` (add `Classify(path, mappings)`, keep old overload), `Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs`, `Infrastructure/Sync/Pipeline/SyncJobExecutor.cs`, `Tests/…/GivenAFileClassifier.cs`, `…/GivenASyncedItemRegistrar.cs`, `…/GivenASyncJobExecutor.cs` **(6)** | Atomic: pipeline switches to new repo + `ClassificationCombiner`. New repo (Ph6) resolves the new ctor deps. Old repo now only used by the VM |
+| **8** | VM cutover to the tree | `Classifications/FileClassificationRulesViewModel.cs`, `FileClassificationRuleRowViewModel.cs`, `FileClassificationsView.axaml` (+`.axaml.cs`), `App.axaml.cs` (design-time DI), `Tests/…/GivenAFileClassificationRulesViewModel.cs` **(≤6)** | After this **nothing** references `IFileClassificationRuleRepository` but its own interface/impl. If a `CategoryNodeViewModel` is needed, split into 8a/8b to stay ≤6 |
+| **9** | Remove old repository + old classifier overload | `Data/PersistenceServiceExtensions.cs` (drop old reg), **delete** `IFileClassificationRuleRepository.cs`, `FileClassificationRuleRepository.cs`, `Tests/…/GivenAFileClassificationRuleRepository.cs`, `Domain/FileClassifier.cs` (remove old overload) **(5)** | Old repo unreferenced since Ph8; safe to delete. `FileClassificationRule`/`Entry`/`Factory` now unused |
+| **10** | Remove old rule domain | **delete** `Domain/FileClassificationRule.cs`, `FileClassificationRuleEntry.cs`, `FileClassificationRuleFactory.cs` **(3)** | Unreferenced after Ph9 |
+| **11** | Drop old table + entity | `Data/AppDbContext.cs` (remove old DbSet), **delete** `FileClassificationRuleEntity.cs` + `FileClassificationRuleEntityConfiguration.cs`, drop-table migration `.cs` + `.Designer.cs`, `AppDbContextModelSnapshot.cs` **(6)** | Data copied in Ph5; no code reads the old table since Ph7/8. Drop migration **re-runs the idempotent backfill first** to capture any rows the old UI wrote between Ph5 and Ph8, then drops. Model clean |
+
+### Sequencing guarantees
+
+- **Migrations are additive until Phase 11.** Ph5 only creates/seeds; the destructive `DROP TABLE` is last, after
+  every reader is gone.
+- **Late-write safety.** Old UI can still write the old table between Ph5 and Ph8. The backfill is **idempotent**
+  (`WHERE NOT EXISTS` / keyword de-dupe) and is **re-executed inside the Ph11 drop migration** so no rule is lost.
+- **Per-phase gate (Definition of Done below) runs every phase** — a phase merges only on zero-warning build +
+  zero new test failures, keeping `main` deployable.
 
 ---
 
 ## Definition of Done
 
+### Per phase (every PR)
+
 - [ ] `dotnet build` — zero errors, zero warnings (paste exact output)
 - [ ] `dotnet test` — zero new failures (paste exact pass/fail count)
-- [ ] All `IFileClassificationRuleRepository` call sites found + updated
-- [ ] Migration runs cleanly on a DB with existing `FileClassificationRules` rows
-- [ ] Old entity / config / repository / domain files deleted
-- [ ] Human review before commit
-- [ ] PR raised using `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] `main` deployable: app starts, DI resolves, any new migration applies cleanly on a DB with existing rows
+- [ ] ≤ 6 files changed/created (tests included)
+- [ ] Human review before commit; PR raised using `.github/PULL_REQUEST_TEMPLATE.md`
+
+### Whole change (after Phase 11)
+
+- [ ] All `IFileClassificationRuleRepository` call sites removed
+- [ ] Old entity / config / repository / domain files deleted; old table dropped
+- [ ] Backfill verified: keyword count = token count; analyser L1 nodes seeded once; effective IsSpecial preserved

--- a/docs/plans/OneDrive_O.md
+++ b/docs/plans/OneDrive_O.md
@@ -1,0 +1,440 @@
+# Plan: FileClassificationRules — Proper Hierarchy (OneDrive_O)
+
+## Context
+
+`AStar.Dev.OneDrive.Sync.Client` stores `FileClassificationRules` in SQLite as a **flat list**. Each row holds
+pipe-delimited `Keywords` plus three denormalised string columns (`Level1` NOT NULL, `Level2?`, `Level3?`) and a
+single `IsSpecial` flag covering the whole rule.
+
+Problems:
+- Category strings duplicated across rows; no referential integrity between levels.
+- No single source of truth for the category tree.
+- `IsSpecial` is coarse — applies to the entire rule, not to an individual keyword.
+
+This plan replaces the flat table with a **proper 3-level category hierarchy** plus a separate keyword table.
+
+### Decisions agreed in planning
+
+| Question | Decision |
+|---|---|
+| Hierarchy shape | **Fixed 3 levels**: Level1 → Level2 → Level3 (self-referencing category table, level enforced 1–3) |
+| Keyword placement | **Leaf node only** — a keyword attaches to the deepest assigned node of its branch (a node with no children) |
+| IsSpecial | **Category node + keyword override** — flag on category node; keyword override `None` = inherit, `Some(bool)` = override |
+| Migration | **Transform existing data** — EF Core migration rebuilds the tree from existing rows; no drop-and-reseed, no data loss |
+
+---
+
+## Current State
+
+### Table
+
+```
+FileClassificationRules (Id PK, Keywords TEXT NOT NULL, Level1 TEXT NOT NULL, Level2 TEXT?, Level3 TEXT?, IsSpecial INTEGER)
+```
+
+`Keywords` is a `|`-delimited string per row (e.g. `"photos|photo|img"`).
+
+### Key files
+
+| Role | Path |
+|---|---|
+| EF entity | `Data/Entities/FileClassificationRuleEntity.cs` |
+| EF config | `Data/Configuration/FileClassificationRuleEntityConfiguration.cs` |
+| DbContext | `Data/AppDbContext.cs` |
+| Repository interface | `Data/Repositories/IFileClassificationRuleRepository.cs` |
+| Repository impl | `Data/Repositories/FileClassificationRuleRepository.cs` |
+| Domain rule | `Domain/FileClassificationRule.cs` |
+| Domain entry | `Domain/FileClassificationRuleEntry.cs` |
+| Domain classification (result) | `Domain/FileClassification.cs` |
+| Classifier | `Domain/FileClassifier.cs` |
+| Rule factory | `Domain/FileClassificationRuleFactory.cs` |
+| Classification factory | `Domain/FileClassificationFactory.cs` |
+| Row VM | `Classifications/FileClassificationRuleRowViewModel.cs` |
+| List VM | `Classifications/FileClassificationRulesViewModel.cs` |
+
+`FileClassification` / `FileClassificationFactory` are the **result** of classifying a file (its tags), not rule
+storage — they stay unchanged.
+
+---
+
+## Target State
+
+### New tables
+
+```sql
+-- The 3-level category tree
+FileClassificationCategories
+  Id          INTEGER  PRIMARY KEY AUTOINCREMENT
+  Name        TEXT     NOT NULL
+  Level       INTEGER  NOT NULL          -- 1, 2 or 3; validated in factory
+  ParentId    INTEGER  NULL              -- FK -> FileClassificationCategories.Id (NULL only for Level 1)
+  IsSpecial   INTEGER  NOT NULL DEFAULT 0
+
+-- One row per keyword; keyword attaches to a LEAF category node only
+FileClassificationKeywords
+  Id          INTEGER  PRIMARY KEY AUTOINCREMENT
+  Keyword     TEXT     NOT NULL
+  CategoryId  INTEGER  NOT NULL          -- FK -> FileClassificationCategories.Id ON DELETE CASCADE
+  IsSpecial   INTEGER  NULL              -- NULL = inherit Category.IsSpecial; 0/1 = override
+```
+
+`FileClassificationRules` is **dropped** by the migration after data is transferred.
+
+### Constraints (enforced in factory + EF config; not SQL CHECK, for SQLite portability)
+
+- `Level = 1` → `ParentId` must be `NULL`.
+- `Level = 2` → parent node must have `Level = 1`.
+- `Level = 3` → parent node must have `Level = 2`.
+- Category `Name` unique among siblings → unique index on `(ParentId, Name)`.
+- `Keyword` must be non-empty, non-whitespace.
+- **Leaf rule**: a keyword's `CategoryId` must reference a node with **no child categories**. Enforced in the
+  repository on add/update (and preserved by migration backfill). A category that has children cannot own
+  keywords; conversely adding a child to a category that owns keywords is rejected.
+
+---
+
+## EF Core Entities
+
+### `FileClassificationCategoryEntity`
+
+```csharp
+// Data/Entities/FileClassificationCategoryEntity.cs
+public sealed class FileClassificationCategoryEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Level { get; set; }
+    public int? ParentId { get; set; }
+    public FileClassificationCategoryEntity? Parent { get; set; }
+    public ICollection<FileClassificationCategoryEntity> Children { get; set; } = [];
+    public ICollection<FileClassificationKeywordEntity> Keywords { get; set; } = [];
+    public bool IsSpecial { get; set; }
+}
+```
+
+### `FileClassificationKeywordEntity`
+
+```csharp
+// Data/Entities/FileClassificationKeywordEntity.cs
+public sealed class FileClassificationKeywordEntity
+{
+    public int Id { get; set; }
+    public string Keyword { get; set; } = string.Empty;
+    public int CategoryId { get; set; }
+    public FileClassificationCategoryEntity Category { get; set; } = null!;
+    public bool? IsSpecial { get; set; }  // null = inherit from Category.IsSpecial
+}
+```
+
+`FileClassificationRuleEntity` is **deleted** once migration and all call-site updates are complete.
+
+---
+
+## EF Core Configurations
+
+### `FileClassificationCategoryEntityConfiguration`
+
+```csharp
+// Data/Configuration/FileClassificationCategoryEntityConfiguration.cs
+public sealed class FileClassificationCategoryEntityConfiguration : IEntityTypeConfiguration<FileClassificationCategoryEntity>
+{
+    public void Configure(EntityTypeBuilder<FileClassificationCategoryEntity> builder)
+    {
+        builder.HasKey(category => category.Id);
+        builder.Property(category => category.Name).IsRequired();
+        builder.Property(category => category.Level).IsRequired();
+        builder.HasIndex(category => new { category.ParentId, category.Name }).IsUnique();
+        builder.HasOne(category => category.Parent)
+               .WithMany(category => category.Children)
+               .HasForeignKey(category => category.ParentId)
+               .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+```
+
+### `FileClassificationKeywordEntityConfiguration`
+
+```csharp
+// Data/Configuration/FileClassificationKeywordEntityConfiguration.cs
+public sealed class FileClassificationKeywordEntityConfiguration : IEntityTypeConfiguration<FileClassificationKeywordEntity>
+{
+    public void Configure(EntityTypeBuilder<FileClassificationKeywordEntity> builder)
+    {
+        builder.HasKey(keyword => keyword.Id);
+        builder.Property(keyword => keyword.Keyword).IsRequired();
+        builder.HasOne(keyword => keyword.Category)
+               .WithMany(category => category.Keywords)
+               .HasForeignKey(keyword => keyword.CategoryId)
+               .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+Delete `FileClassificationRuleEntityConfiguration`.
+
+---
+
+## DbContext Changes
+
+```csharp
+// AppDbContext.cs
+public DbSet<FileClassificationCategoryEntity> FileClassificationCategories => Set<FileClassificationCategoryEntity>();
+public DbSet<FileClassificationKeywordEntity> FileClassificationKeywords => Set<FileClassificationKeywordEntity>();
+
+// Delete: public DbSet<FileClassificationRuleEntity> FileClassificationRules => ...
+```
+
+---
+
+## Domain Model Changes
+
+### New records
+
+```csharp
+// Domain/FileClassificationCategory.cs
+public sealed record FileClassificationCategory(int Id, string Name, int Level, Option<int> ParentId, bool IsSpecial);
+
+// Domain/FileClassificationKeyword.cs
+public sealed record FileClassificationKeyword(int Id, string Keyword, int CategoryId, Option<bool> IsSpecialOverride);
+```
+
+`IsSpecialOverride` semantics:
+- `Option.None` → inherit owning `FileClassificationCategory.IsSpecial`.
+- `Option.Some(true/false)` → explicit override.
+
+### Extension methods (no methods on records)
+
+```csharp
+// Domain/FileClassificationKeywordExtensions.cs
+public static class FileClassificationKeywordExtensions
+{
+    public static bool ResolveIsSpecial(this FileClassificationKeyword keyword, bool categoryIsSpecial)
+        => keyword.IsSpecialOverride.MapOrDefault(value => value, categoryIsSpecial);
+}
+```
+
+### Factories (each `record Foo` gets a `FooFactory` returning `Result<T, string>`)
+
+**`FileClassificationCategoryFactory`**
+- `Level` must be 1–3.
+- `Level = 1` → `ParentId` must be `None`.
+- `Level > 1` → `ParentId` must be `Some`.
+- `Name` non-empty, non-whitespace (normalise/trim).
+
+**`FileClassificationKeywordFactory`**
+- `Keyword` non-empty, non-whitespace (trim, lower-case to match classifier tokenisation).
+
+### Retire
+
+| Item | Reason |
+|---|---|
+| `FileClassificationRule` | keyword→category FK replaces "keywords + classification in one row" |
+| `FileClassificationRuleEntry` | `FileClassificationKeyword` carries its own `Id` |
+| `FileClassificationRuleFactory` | replaced by `FileClassificationKeywordFactory` |
+
+`FileClassification` + `FileClassificationFactory` — **unchanged** (classification result, not rule storage).
+
+---
+
+## Classifier Changes
+
+`FileClassifier.Classify` currently takes `IReadOnlyList<FileClassificationRule>`. New signature consumes the
+flat keyword→category mappings (keywords live on leaf nodes; the full Level1/2/3 path is resolved by walking
+`Category → Parent → Parent`).
+
+```csharp
+public static IReadOnlyList<FileClassification> Classify(
+    string remotePath,
+    IReadOnlyList<KeywordMapping> mappings);
+```
+
+where `KeywordMapping` carries the keyword plus its resolved Level1/Level2/Level3 names and effective
+`IsSpecial`. Matching logic (tokenise path, match keyword against tokens) is unchanged; only the rule shape and
+the `FileClassification` construction change. Effective `IsSpecial` = `keyword.ResolveIsSpecial(leafCategory.IsSpecial)`.
+Unchanged behaviour: returns a single `Unclassified` sentinel when nothing matches.
+
+---
+
+## Repository
+
+### Interface (new file)
+
+```csharp
+// Data/Repositories/IFileClassificationRepository.cs
+public interface IFileClassificationRepository
+{
+    Task<IReadOnlyList<FileClassificationCategory>> GetAllCategoriesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<FileClassificationKeyword>> GetKeywordsForCategoryAsync(int categoryId, CancellationToken cancellationToken = default);
+
+    // Flat projection for the classifier: keyword + its resolved category path, for every keyword row
+    Task<IReadOnlyList<KeywordMapping>> GetAllKeywordMappingsAsync(CancellationToken cancellationToken = default);
+
+    Task<Result<int, string>> AddCategoryAsync(FileClassificationCategory category, CancellationToken cancellationToken = default);
+    Task<Result<int, string>> AddKeywordAsync(FileClassificationKeyword keyword, CancellationToken cancellationToken = default);
+    Task<Result<Unit, string>> UpdateCategoryAsync(int id, FileClassificationCategory category, CancellationToken cancellationToken = default);
+    Task<Result<Unit, string>> UpdateKeywordAsync(int id, FileClassificationKeyword keyword, CancellationToken cancellationToken = default);
+    Task<Result<Unit, string>> DeleteCategoryAsync(int id, CancellationToken cancellationToken = default);
+    Task<Result<Unit, string>> DeleteKeywordAsync(int id, CancellationToken cancellationToken = default);
+}
+```
+
+### Key implementation notes
+
+- **Leaf enforcement** lives here: `AddKeywordAsync` / `UpdateKeywordAsync` reject a `CategoryId` that has child
+  categories; `AddCategoryAsync` rejects a `ParentId` that already owns keywords. Return `Result.Error`, no throw.
+- `GetAllKeywordMappingsAsync` loads `FileClassificationKeywords` with `.Include(k => k.Category).ThenInclude(c => c.Parent)...`
+  (walk up to L1) and projects to `KeywordMapping` (keyword text, Level1/2/3 names, effective `IsSpecial`).
+- DI: swap `IFileClassificationRuleRepository` → `IFileClassificationRepository` registration in
+  `Data/PersistenceServiceExtensions.cs`; update every call site.
+
+---
+
+## EF Core Migration
+
+Migration name: `HierarchicalFileClassificationRules`. SQLite has no native string-split, so keyword splitting
+is done in C# inside the migration `Up` using a raw `DbConnection` (open the connection
+`migrationBuilder` runs against; read old rows; issue parameterised INSERTs).
+
+### Up — logical steps
+
+**1. Create new tables** (`CreateTable` for both, including indexes + FKs).
+
+**2. Seed Level 1** — distinct non-empty `Level1`:
+
+```sql
+INSERT INTO FileClassificationCategories (Name, Level, ParentId, IsSpecial)
+SELECT Level1, 1, NULL, MAX(CAST(IsSpecial AS INTEGER))
+FROM FileClassificationRules
+WHERE Level1 IS NOT NULL AND Level1 != ''
+GROUP BY Level1;
+```
+
+**3. Seed Level 2** — distinct `Level1+Level2`:
+
+```sql
+INSERT INTO FileClassificationCategories (Name, Level, ParentId, IsSpecial)
+SELECT r.Level2, 2, l1.Id, MAX(CAST(r.IsSpecial AS INTEGER))
+FROM FileClassificationRules r
+JOIN FileClassificationCategories l1 ON l1.Name = r.Level1 AND l1.Level = 1
+WHERE r.Level2 IS NOT NULL AND r.Level2 != ''
+GROUP BY r.Level2, l1.Id;
+```
+
+**4. Seed Level 3** — distinct `Level1+Level2+Level3`:
+
+```sql
+INSERT INTO FileClassificationCategories (Name, Level, ParentId, IsSpecial)
+SELECT r.Level3, 3, l2.Id, MAX(CAST(r.IsSpecial AS INTEGER))
+FROM FileClassificationRules r
+JOIN FileClassificationCategories l1 ON l1.Name = r.Level1 AND l1.Level = 1
+JOIN FileClassificationCategories l2 ON l2.Name = r.Level2 AND l2.ParentId = l1.Id AND l2.Level = 2
+WHERE r.Level3 IS NOT NULL AND r.Level3 != ''
+GROUP BY r.Level3, l2.Id;
+```
+
+**5. Migrate keywords (C#)** — for each old rule, resolve its **leaf** category (deepest non-null level =
+the leaf for that branch), split `Keywords` on `|`, insert one keyword row per token against that leaf:
+
+```csharp
+foreach (var oldRule in QueryOldRules(connection))
+{
+    var leafCategoryId = ResolveLeafCategoryId(connection, oldRule); // deepest of L3 ?? L2 ?? L1
+    foreach (var token in oldRule.Keywords.Split('|', StringSplitOptions.RemoveEmptyEntries))
+        InsertKeyword(connection, token.Trim().ToLowerInvariant(), leafCategoryId, isSpecial: null);
+    // isSpecial null: rule-level IsSpecial already promoted onto the category node (steps 2-4)
+}
+```
+
+The leaf rule holds automatically: keywords only ever attach to the deepest assigned node of a branch.
+
+**6. Drop old table**: `DROP TABLE FileClassificationRules;`
+
+### Down (rollback)
+
+Reconstructing pipe-delimited rows from normalised data is lossy/complex. Mark unsupported; rollback = restore
+from a pre-migration backup.
+
+```csharp
+protected override void Down(MigrationBuilder migrationBuilder)
+    => throw new NotSupportedException("HierarchicalFileClassificationRules cannot be rolled back automatically. Restore from backup.");
+```
+
+---
+
+## UI / ViewModel Impact
+
+`FileClassificationRulesViewModel` + `FileClassificationRuleRowViewModel` currently bind a flat grid of rules.
+They must become a tree (categories) + keyword editor. Scope note: this plan covers the **data + domain +
+migration**. A follow-up issue should cover the full tree-edit UX (add/move/delete category nodes, assign
+keywords to leaves, toggle `IsSpecial` at node + keyword). Minimum here: keep the app compiling and able to
+list/add/delete categories and leaf keywords. Avalonia tree binding follows the ScrollViewer bounded-viewport
+rule in `.claude/rules/avalonia-ui.md`.
+
+---
+
+## Files to Create / Modify / Delete
+
+### Create
+- `Data/Entities/FileClassificationCategoryEntity.cs`
+- `Data/Entities/FileClassificationKeywordEntity.cs`
+- `Data/Configuration/FileClassificationCategoryEntityConfiguration.cs`
+- `Data/Configuration/FileClassificationKeywordEntityConfiguration.cs`
+- `Data/Repositories/IFileClassificationRepository.cs`
+- `Data/Repositories/FileClassificationRepository.cs`
+- `Domain/FileClassificationCategory.cs`
+- `Domain/FileClassificationKeyword.cs`
+- `Domain/FileClassificationCategoryFactory.cs`
+- `Domain/FileClassificationKeywordFactory.cs`
+- `Domain/FileClassificationKeywordExtensions.cs`
+- `Domain/KeywordMapping.cs` (+ `KeywordMappingFactory.cs`)
+- `Data/Migrations/<timestamp>_HierarchicalFileClassificationRules.cs`
+
+### Modify
+- `Data/AppDbContext.cs` — swap DbSets
+- `Domain/FileClassifier.cs` — new signature / mapping input
+- `Data/PersistenceServiceExtensions.cs` — DI swap
+- `Classifications/FileClassificationRulesViewModel.cs` + `FileClassificationRuleRowViewModel.cs` — tree binding
+- Any other call site of `IFileClassificationRuleRepository` (services, tests)
+
+### Delete (after migration applied + call sites updated)
+- `Data/Entities/FileClassificationRuleEntity.cs`
+- `Data/Configuration/FileClassificationRuleEntityConfiguration.cs`
+- `Data/Repositories/IFileClassificationRuleRepository.cs`
+- `Data/Repositories/FileClassificationRuleRepository.cs`
+- `Domain/FileClassificationRule.cs`
+- `Domain/FileClassificationRuleEntry.cs`
+- `Domain/FileClassificationRuleFactory.cs`
+
+---
+
+## Out of Scope
+
+`SyncedItemClassifications` stores the *result* of classifying a file (denormalised Level1/2/3 strings). Those
+are historical records; this plan does not touch them. Raise a separate issue if FK integrity is wanted there.
+
+Full tree-edit UX (drag/move nodes, rich keyword editor) — follow-up issue.
+
+---
+
+## Testing Plan (TDD: factories → extensions → classifier → repository → migration)
+
+| Test class | Covers |
+|---|---|
+| `GivenFileClassificationCategoryFactory` | Level 1–3 validation, L1 forbids ParentId, L>1 requires ParentId, name trim/empty reject |
+| `GivenFileClassificationKeywordFactory` | empty/whitespace keyword rejected; valid keyword trimmed + lowercased |
+| `GivenFileClassificationKeywordExtensions` | `ResolveIsSpecial` — 4 combos (category ±, override None/Some) |
+| `GivenAFileClassifier` | path tokenised, keyword match builds correct Level1/2/3 path + effective IsSpecial; unclassified sentinel |
+| `GivenFileClassificationRepository` | CRUD both tables; **leaf enforcement** (reject keyword on non-leaf, reject child under keyword-owning node); `GetAllKeywordMappingsAsync` projection; cascade delete |
+| `GivenHierarchicalMigration` (integration) | old flat rules round-trip into tree; keyword count = token count; keywords land on leaf; effective IsSpecial preserved |
+
+---
+
+## Definition of Done
+
+- [ ] `dotnet build` — zero errors, zero warnings (paste exact output)
+- [ ] `dotnet test` — zero new failures (paste exact pass/fail count)
+- [ ] All `IFileClassificationRuleRepository` call sites found + updated
+- [ ] Migration runs cleanly on a DB with existing `FileClassificationRules` rows
+- [ ] Old entity / config / repository / domain files deleted
+- [ ] Human review before commit
+- [ ] PR raised using `.github/PULL_REQUEST_TEMPLATE.md`


### PR DESCRIPTION
## Summary

- Added mandatory parallel-change pattern to CLAUDE.md for all feature deployments
- Updated OneDrive_O.md classification spike plan with implementation details and database schema

## Changes

- **CLAUDE.md**: New section requiring parallel-change pattern (old code → new code → cutover → cleanup) to preserve deployability
- **docs/plans/OneDrive_O.md**: Detailed spike plan with classification rule hierarchy, database schema, and implementation phases
- **Database migrations**: Added classification rule indexing (ClassificationIndexes migration)
- **Tests**: Updated GivenAnHttpDownloaderTempFileHandling test case coverage

## Testing

- All spike code changes are in test/spike contexts, not production
- Database schema changes included for spike evolution