### PR TITLE
feat(onedrive-sync-client): FileClassificationKeyword domain record, factory, and extensions (#438)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassificationKeywordFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassificationKeywordFactory.cs
@@ -70,4 +70,20 @@ public sealed class GivenAFileClassificationKeywordFactory
 
         result.Match(k => k.IsSpecialOverride, _ => Option.Some(true)).ShouldBe(Option.None<bool>());
     }
+
+    [Fact]
+    public void when_value_is_null_then_result_is_failure()
+    {
+        var result = FileClassificationKeywordFactory.Create(null!, Option.None<bool>());
+
+        _ = result.ShouldBeOfType<Result<FileClassificationKeyword, string>.Error>();
+    }
+
+    [Fact]
+    public void when_value_has_mixed_case_and_surrounding_spaces_then_value_is_trimmed_and_lowercased()
+    {
+        var result = FileClassificationKeywordFactory.Create("  CaTs  ", Option.None<bool>());
+
+        result.Match(k => k.Value, _ => string.Empty).ShouldBe(AnyValidValue);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassificationKeywordFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassificationKeywordFactory.cs
@@ -1,0 +1,73 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAFileClassificationKeywordFactory
+{
+    private const string AnyValidValue = "cats";
+
+    [Fact]
+    public void when_value_is_empty_then_result_is_failure()
+    {
+        var result = FileClassificationKeywordFactory.Create("", Option.None<bool>());
+
+        _ = result.ShouldBeOfType<Result<FileClassificationKeyword, string>.Error>();
+    }
+
+    [Fact]
+    public void when_value_is_whitespace_then_result_is_failure()
+    {
+        var result = FileClassificationKeywordFactory.Create("   ", Option.None<bool>());
+
+        _ = result.ShouldBeOfType<Result<FileClassificationKeyword, string>.Error>();
+    }
+
+    [Fact]
+    public void when_value_has_leading_and_trailing_spaces_then_value_is_trimmed()
+    {
+        var result = FileClassificationKeywordFactory.Create("  cats  ", Option.None<bool>());
+
+        result.Match(k => k.Value, _ => string.Empty).ShouldBe(AnyValidValue);
+    }
+
+    [Fact]
+    public void when_value_has_uppercase_then_value_is_lowercased()
+    {
+        var result = FileClassificationKeywordFactory.Create("CATS", Option.None<bool>());
+
+        result.Match(k => k.Value, _ => string.Empty).ShouldBe(AnyValidValue);
+    }
+
+    [Fact]
+    public void when_value_is_valid_then_result_is_success()
+    {
+        var result = FileClassificationKeywordFactory.Create(AnyValidValue, Option.None<bool>());
+
+        _ = result.ShouldBeOfType<Result<FileClassificationKeyword, string>.Ok>();
+    }
+
+    [Fact]
+    public void when_value_is_valid_with_special_override_true_then_result_is_success()
+    {
+        var result = FileClassificationKeywordFactory.Create(AnyValidValue, Option.Some(true));
+
+        result.Match(k => k.IsSpecialOverride, _ => Option.None<bool>()).ShouldBe(Option.Some(true));
+    }
+
+    [Fact]
+    public void when_value_is_valid_with_special_override_false_then_result_is_success()
+    {
+        var result = FileClassificationKeywordFactory.Create(AnyValidValue, Option.Some(false));
+
+        result.Match(k => k.IsSpecialOverride, _ => Option.None<bool>()).ShouldBe(Option.Some(false));
+    }
+
+    [Fact]
+    public void when_value_is_valid_with_no_override_then_is_special_override_is_none()
+    {
+        var result = FileClassificationKeywordFactory.Create(AnyValidValue, Option.None<bool>());
+
+        result.Match(k => k.IsSpecialOverride, _ => Option.Some(true)).ShouldBe(Option.None<bool>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenFileClassificationKeywordExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenFileClassificationKeywordExtensions.cs
@@ -1,0 +1,53 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenFileClassificationKeywordExtensions
+{
+    private const string AnyValidValue = "cats";
+
+    [Fact]
+    public void when_override_is_true_and_classification_is_not_special_then_result_is_true()
+    {
+        var keyword = new FileClassificationKeyword(AnyValidValue, Option.Some(true));
+        var classification = FileClassificationFactory.Create("Archive", Option.None<string>(), Option.None<string>(), false);
+
+        var result = keyword.ResolveIsSpecial(classification);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_override_is_false_and_classification_is_special_then_result_is_false()
+    {
+        var keyword = new FileClassificationKeyword(AnyValidValue, Option.Some(false));
+        var classification = FileClassificationFactory.Create("Archive", Option.None<string>(), Option.None<string>(), true);
+
+        var result = keyword.ResolveIsSpecial(classification);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_override_is_none_and_classification_is_special_then_result_is_true()
+    {
+        var keyword = new FileClassificationKeyword(AnyValidValue, Option.None<bool>());
+        var classification = FileClassificationFactory.Create("Archive", Option.None<string>(), Option.None<string>(), true);
+
+        var result = keyword.ResolveIsSpecial(classification);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_override_is_none_and_classification_is_not_special_then_result_is_false()
+    {
+        var keyword = new FileClassificationKeyword(AnyValidValue, Option.None<bool>());
+        var classification = FileClassificationFactory.Create("Archive", Option.None<string>(), Option.None<string>(), false);
+
+        var result = keyword.ResolveIsSpecial(classification);
+
+        result.ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeyword.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeyword.cs
@@ -1,0 +1,6 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>A keyword used to match file paths against a classification rule.</summary>
+public sealed record FileClassificationKeyword(string Value, Option<bool> IsSpecialOverride);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeywordExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeywordExtensions.cs
@@ -1,0 +1,9 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Extension methods for <see cref="FileClassificationKeyword"/>.</summary>
+public static class FileClassificationKeywordExtensions
+{
+    /// <summary>Resolves the effective IsSpecial flag, preferring the keyword's override when present.</summary>
+    public static bool ResolveIsSpecial(this FileClassificationKeyword keyword, FileClassification classification) =>
+        keyword.IsSpecialOverride.Match(overrideValue => overrideValue, () => classification.IsSpecial);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeywordFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationKeywordFactory.cs
@@ -1,0 +1,17 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="FileClassificationKeyword"/>.</summary>
+public static class FileClassificationKeywordFactory
+{
+    /// <summary>Creates a <see cref="FileClassificationKeyword"/> with validation.</summary>
+    public static Result<FileClassificationKeyword, string> Create(string value, Option<bool> isSpecialOverride)
+    {
+        string normalised = value?.Trim().ToLowerInvariant() ?? string.Empty;
+        if(string.IsNullOrEmpty(normalised))
+            return new Result<FileClassificationKeyword, string>.Error("Value must not be empty.");
+
+        return new Result<FileClassificationKeyword, string>.Ok(new(normalised, isSpecialOverride));
+    }
+}


### PR DESCRIPTION
# Summary

Adds the `FileClassificationKeyword` domain type as part of the FileClassificationRules hierarchy (Phase 2 of the OneDrive file-classification plan).

## Type of change

- [x] Feature

## Related issues / links

Closes #438

## How was this tested?

- [x] Unit tests added/updated

10 tests for `FileClassificationKeywordFactory` (null/empty/whitespace rejection, trim, lowercase, combined normalisation, `IsSpecialOverride` persistence) and 4 tests for `FileClassificationKeywordExtensions.ResolveIsSpecial` (all override × classification combos).

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — Domain only. Additive; no existing call sites modified.

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1341 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- `FileClassificationKeyword` is a sealed record — no methods on the record itself per convention; behaviour lives in `FileClassificationKeywordExtensions`.
- `FileClassificationKeywordFactory.Create` normalises input (trim + lowercase) before validation, consistent with `FileClassificationCategoryFactory` pattern.
- `ResolveIsSpecial` uses `Option<bool>.Match` — no `is Option<bool>.Some` pattern matching.
- This type is currently unwired; it will be consumed when `FileClassificationRule.Keywords` is refactored from `IReadOnlyList<string>` to `IReadOnlyList<FileClassificationKeyword>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)