### PR TITLE
feat(onedrive-sync-client): KeywordMapping, KeywordMappingFactory, ClassificationCombiner (#439)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
@@ -73,4 +73,31 @@ public sealed class GivenAClassificationCombiner
         result.ShouldHaveSingleItem();
         result[0].Level1.ShouldBe("Unclassified");
     }
+
+    [Fact]
+    public void when_rule_results_contains_duplicate_L1_L2_L3_then_only_first_is_kept()
+    {
+        var first = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), false);
+        var second = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), true);
+        IReadOnlyList<FileClassification> ruleResults = [first, second];
+
+        var result = ClassificationCombiner.Combine(ruleResults, []);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBe(first);
+    }
+
+    [Fact]
+    public void when_same_L1_L2_L3_different_IsSpecial_then_deduped_to_rule_result()
+    {
+        var ruleVersion = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), false);
+        var analyserVersion = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), true);
+        IReadOnlyList<FileClassification> ruleResults = [ruleVersion];
+        IReadOnlyList<FileClassification> analyserResults = [analyserVersion];
+
+        var result = ClassificationCombiner.Combine(ruleResults, analyserResults);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBe(ruleVersion);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
@@ -1,0 +1,76 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAClassificationCombiner
+{
+    private static readonly FileClassification AnyRuleClassification = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), false);
+    private static readonly FileClassification AnyAnalyserClassification = FileClassificationFactory.Create("Nature", Option.Some("Wildlife"), Option.None<string>(), false);
+    private static readonly FileClassification AnySharedClassification = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), false);
+
+    [Fact]
+    public void when_both_inputs_empty_then_result_contains_only_unclassified()
+    {
+        var result = ClassificationCombiner.Combine([], []);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBe(FileClassificationFactory.CreateUnclassified());
+    }
+
+    [Fact]
+    public void when_rule_results_only_then_result_equals_rule_results()
+    {
+        IReadOnlyList<FileClassification> ruleResults = [AnyRuleClassification];
+
+        var result = ClassificationCombiner.Combine(ruleResults, []);
+
+        result.ShouldBe([AnyRuleClassification]);
+    }
+
+    [Fact]
+    public void when_analyser_results_only_then_result_equals_analyser_results()
+    {
+        IReadOnlyList<FileClassification> analyserResults = [AnyAnalyserClassification];
+
+        var result = ClassificationCombiner.Combine([], analyserResults);
+
+        result.ShouldBe([AnyAnalyserClassification]);
+    }
+
+    [Fact]
+    public void when_both_have_distinct_classifications_then_result_is_union()
+    {
+        IReadOnlyList<FileClassification> ruleResults = [AnyRuleClassification];
+        IReadOnlyList<FileClassification> analyserResults = [AnyAnalyserClassification];
+
+        var result = ClassificationCombiner.Combine(ruleResults, analyserResults);
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain(AnyRuleClassification);
+        result.ShouldContain(AnyAnalyserClassification);
+    }
+
+    [Fact]
+    public void when_rule_and_analyser_have_same_L1_L2_L3_then_deduped_to_single_entry()
+    {
+        var ruleVersion = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), false);
+        var analyserVersion = FileClassificationFactory.Create("Memories", Option.Some("Holidays"), Option.None<string>(), true);
+        IReadOnlyList<FileClassification> ruleResults = [ruleVersion];
+        IReadOnlyList<FileClassification> analyserResults = [analyserVersion];
+
+        var result = ClassificationCombiner.Combine(ruleResults, analyserResults);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBe(ruleVersion);
+    }
+
+    [Fact]
+    public void when_rule_result_is_empty_and_analyser_result_is_empty_then_returns_unclassified()
+    {
+        var result = ClassificationCombiner.Combine([], []);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Unclassified");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAKeywordMappingFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAKeywordMappingFactory.cs
@@ -67,4 +67,20 @@ public sealed class GivenAKeywordMappingFactory
 
         result.Match(m => m.Keyword, _ => string.Empty).ShouldBe("holiday");
     }
+
+    [Fact]
+    public void when_keyword_is_null_then_result_is_error()
+    {
+        var result = KeywordMappingFactory.Create(null!, AnyLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Error>();
+    }
+
+    [Fact]
+    public void when_level1_is_null_then_result_is_error()
+    {
+        var result = KeywordMappingFactory.Create(AnyKeyword, null!, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Error>();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAKeywordMappingFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAKeywordMappingFactory.cs
@@ -1,0 +1,70 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Domain;
+
+public sealed class GivenAKeywordMappingFactory
+{
+    private const string AnyKeyword = "holiday";
+    private const string AnyLevel1 = "Memories";
+
+    [Fact]
+    public void when_valid_inputs_then_result_is_success()
+    {
+        var result = KeywordMappingFactory.Create(AnyKeyword, AnyLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Ok>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void when_keyword_is_empty_then_result_is_error(string blankKeyword)
+    {
+        var result = KeywordMappingFactory.Create(blankKeyword, AnyLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Error>();
+    }
+
+    [Fact]
+    public void when_keyword_is_whitespace_then_result_is_error()
+    {
+        var result = KeywordMappingFactory.Create("   ", AnyLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Error>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void when_level1_is_empty_then_result_is_error(string blankLevel1)
+    {
+        var result = KeywordMappingFactory.Create(AnyKeyword, blankLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        _ = result.ShouldBeOfType<Result<KeywordMapping, string>.Error>();
+    }
+
+    [Fact]
+    public void when_valid_inputs_then_all_properties_set_correctly()
+    {
+        var level2 = Option.Some("Holidays");
+        var level3 = Option.Some("Beach");
+
+        var result = KeywordMappingFactory.Create(AnyKeyword, AnyLevel1, level2, level3, true);
+
+        var mapping = result.Match(m => m, _ => null!);
+        mapping.Keyword.ShouldBe(AnyKeyword);
+        mapping.Level1.ShouldBe(AnyLevel1);
+        mapping.Level2.ShouldBe(level2);
+        mapping.Level3.ShouldBe(level3);
+        mapping.IsSpecial.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_keyword_has_whitespace_then_keyword_is_trimmed()
+    {
+        var result = KeywordMappingFactory.Create("  holiday  ", AnyLevel1, Option.None<string>(), Option.None<string>(), false);
+
+        result.Match(m => m.Keyword, _ => string.Empty).ShouldBe("holiday");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ClassificationCombiner.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/ClassificationCombiner.cs
@@ -1,0 +1,33 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Combines rule-based and analyser-based <see cref="FileClassification"/> results into a single de-duplicated list.</summary>
+public static class ClassificationCombiner
+{
+    /// <summary>Unions ruleResults and analyserResults, de-duplicating by (Level1, Level2, Level3) with rule results taking precedence. Returns a single Unclassified entry when the combined result is empty.</summary>
+    public static IReadOnlyList<FileClassification> Combine(IReadOnlyList<FileClassification> ruleResults, IReadOnlyList<FileClassification> analyserResults)
+    {
+        var seen = new HashSet<(string, Option<string>, Option<string>)>();
+        var combined = new List<FileClassification>();
+
+        foreach (FileClassification classification in ruleResults)
+        {
+            var key = (classification.Level1, classification.Level2, classification.Level3);
+            if (seen.Add(key))
+                combined.Add(classification);
+        }
+
+        foreach (FileClassification classification in analyserResults)
+        {
+            var key = (classification.Level1, classification.Level2, classification.Level3);
+            if (seen.Add(key))
+                combined.Add(classification);
+        }
+
+        if (combined.Count == 0)
+            return [FileClassificationFactory.CreateUnclassified()];
+
+        return combined;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/KeywordMapping.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/KeywordMapping.cs
@@ -1,0 +1,6 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Represents a keyword-to-classification mapping used to classify files by matching keywords in their paths.</summary>
+public sealed record KeywordMapping(string Keyword, string Level1, Option<string> Level2, Option<string> Level3, bool IsSpecial);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/KeywordMappingFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/KeywordMappingFactory.cs
@@ -1,0 +1,19 @@
+using AStar.Dev.Functional.Extensions;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="KeywordMapping"/>.</summary>
+public static class KeywordMappingFactory
+{
+    /// <summary>Creates a <see cref="KeywordMapping"/> from the supplied values, returning an error if keyword or level1 are null, empty, or whitespace. The keyword is trimmed before storing.</summary>
+    public static Result<KeywordMapping, string> Create(string keyword, string level1, Option<string> level2, Option<string> level3, bool isSpecial)
+    {
+        if (string.IsNullOrWhiteSpace(keyword))
+            return new Result<KeywordMapping, string>.Error("Keyword must not be empty.");
+
+        if (string.IsNullOrWhiteSpace(level1))
+            return new Result<KeywordMapping, string>.Error("Level1 must not be empty.");
+
+        return new Result<KeywordMapping, string>.Ok(new KeywordMapping(keyword.Trim(), level1, level2, level3, isSpecial));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `KeywordMapping` record DTO: keyword text mapped to resolved L1/L2/L3 category names + `IsSpecial` flag
- Adds `KeywordMappingFactory` with `Result<T,E>` validation — rejects blank keyword or level1, trims keyword before storing
- Adds `ClassificationCombiner` which unions rule-based + analyser-based `FileClassification` results, de-dupes by `(Level1, Level2, Level3)` with rule results taking precedence, and falls back to `[Unclassified]` when combined list is empty
- None of the new types are wired into the pipeline yet — main stays deployable

Closes #439

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1345 passed / 0 failed (net +4 vs baseline)
- [x] `GivenAKeywordMappingFactory` — 8 tests covering null/empty/whitespace keyword, null/empty level1, trimming, all properties set correctly
- [x] `GivenAClassificationCombiner` — 8 tests covering empty→Unclassified fallback, rule-only, analyser-only, distinct union, de-dupe by (L1,L2,L3), rule precedence on collision, IsSpecial excluded from de-dupe key
- [x] ≤6 files changed (5 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)