### PR TITLE
feat(onedrive-sync-client): FileClassificationRules hierarchy EF entities (#440)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAFileClassificationCategoryEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAFileClassificationCategoryEntity.cs
@@ -1,0 +1,58 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
+
+public sealed class GivenAFileClassificationCategoryEntity
+{
+    [Fact]
+    public void when_instantiated_then_name_defaults_to_empty_string() =>
+        new FileClassificationCategoryEntity().Name.ShouldBe(string.Empty);
+
+    [Fact]
+    public void when_instantiated_then_level_defaults_to_zero() =>
+        new FileClassificationCategoryEntity().Level.ShouldBe(0);
+
+    [Fact]
+    public void when_instantiated_then_parent_id_is_null() =>
+        new FileClassificationCategoryEntity().ParentId.ShouldBeNull();
+
+    [Fact]
+    public void when_instantiated_then_parent_navigation_is_null() =>
+        new FileClassificationCategoryEntity().Parent.ShouldBeNull();
+
+    [Fact]
+    public void when_instantiated_then_children_collection_is_not_null() =>
+        new FileClassificationCategoryEntity().Children.ShouldNotBeNull();
+
+    [Fact]
+    public void when_instantiated_then_keywords_collection_is_not_null() =>
+        new FileClassificationCategoryEntity().Keywords.ShouldNotBeNull();
+
+    [Fact]
+    public void when_parent_id_is_set_then_it_reflects_in_the_property()
+    {
+        var entity = new FileClassificationCategoryEntity();
+
+        entity.ParentId = 42;
+
+        entity.ParentId.ShouldBe(42);
+    }
+
+    [Fact]
+    public void when_name_is_set_then_it_reflects_in_the_property()
+    {
+        var entity = new FileClassificationCategoryEntity();
+
+        entity.Name = "Photos";
+
+        entity.Name.ShouldBe("Photos");
+    }
+
+    [Fact]
+    public void when_level_is_set_then_it_reflects_in_the_property()
+    {
+        var entity = new FileClassificationCategoryEntity();
+
+        entity.Level = 2;
+
+        entity.Level.ShouldBe(2);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAFileClassificationKeywordEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAFileClassificationKeywordEntity.cs
@@ -1,0 +1,36 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
+
+public sealed class GivenAFileClassificationKeywordEntity
+{
+    [Fact]
+    public void when_instantiated_then_keyword_defaults_to_empty_string() =>
+        new FileClassificationKeywordEntity().Keyword.ShouldBe(string.Empty);
+
+    [Fact]
+    public void when_instantiated_then_category_id_defaults_to_zero() =>
+        new FileClassificationKeywordEntity().CategoryId.ShouldBe(0);
+
+    [Fact]
+    public void when_instantiated_then_category_navigation_is_null() =>
+        new FileClassificationKeywordEntity().Category.ShouldBeNull();
+
+    [Fact]
+    public void when_category_id_is_set_then_it_reflects_in_the_property()
+    {
+        var entity = new FileClassificationKeywordEntity();
+
+        entity.CategoryId = 7;
+
+        entity.CategoryId.ShouldBe(7);
+    }
+
+    [Fact]
+    public void when_keyword_is_set_then_it_reflects_in_the_property()
+    {
+        var entity = new FileClassificationKeywordEntity();
+
+        entity.Keyword = "holiday";
+
+        entity.Keyword.ShouldBe("holiday");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationCategoryEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationCategoryEntityConfiguration.cs
@@ -1,0 +1,18 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Configuration;
+
+/// <summary>EF Core configuration for <see cref="FileClassificationCategoryEntity"/>.</summary>
+public sealed class FileClassificationCategoryEntityConfiguration : IEntityTypeConfiguration<FileClassificationCategoryEntity>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<FileClassificationCategoryEntity> builder)
+    {
+        _ = builder.HasKey(e => e.Id);
+        _ = builder.Property(e => e.Name).IsRequired();
+        _ = builder.HasIndex(e => new { e.ParentId, e.Name }).IsUnique();
+        _ = builder.HasOne(e => e.Parent).WithMany(e => e.Children).HasForeignKey(e => e.ParentId).IsRequired(false).OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationKeywordEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationKeywordEntityConfiguration.cs
@@ -1,0 +1,17 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Configuration;
+
+/// <summary>EF Core configuration for <see cref="FileClassificationKeywordEntity"/>.</summary>
+public sealed class FileClassificationKeywordEntityConfiguration : IEntityTypeConfiguration<FileClassificationKeywordEntity>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<FileClassificationKeywordEntity> builder)
+    {
+        _ = builder.HasKey(e => e.Id);
+        _ = builder.Property(e => e.Keyword).IsRequired();
+        _ = builder.HasOne(e => e.Category).WithMany(e => e.Keywords).HasForeignKey(e => e.CategoryId).OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationCategoryEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationCategoryEntity.cs
@@ -1,0 +1,26 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+/// <summary>Persisted category node in the file classification hierarchy.</summary>
+public sealed class FileClassificationCategoryEntity
+{
+    /// <summary>Primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Category name (e.g. "Photos", "Documents").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Hierarchy level: 1 = top, 2 = sub, 3 = leaf.</summary>
+    public int Level { get; set; }
+
+    /// <summary>FK to parent category; null for root nodes.</summary>
+    public int? ParentId { get; set; }
+
+    /// <summary>Navigation to parent category.</summary>
+    public FileClassificationCategoryEntity? Parent { get; set; }
+
+    /// <summary>Navigation to child categories.</summary>
+    public ICollection<FileClassificationCategoryEntity> Children { get; set; } = [];
+
+    /// <summary>Navigation to keywords associated with this category.</summary>
+    public ICollection<FileClassificationKeywordEntity> Keywords { get; set; } = [];
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationKeywordEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationKeywordEntity.cs
@@ -1,0 +1,17 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+/// <summary>A keyword matched against path tokens to classify files into a category.</summary>
+public sealed class FileClassificationKeywordEntity
+{
+    /// <summary>Primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Keyword matched against path tokens (e.g. "photos").</summary>
+    public string Keyword { get; set; } = string.Empty;
+
+    /// <summary>FK to the owning category.</summary>
+    public int CategoryId { get; set; }
+
+    /// <summary>Navigation to the owning category.</summary>
+    public FileClassificationCategoryEntity? Category { get; set; }
+}


### PR DESCRIPTION
# Summary

Adds the EF Core entity and configuration layer for the file classification category hierarchy. Two new entities (`FileClassificationCategoryEntity` and `FileClassificationKeywordEntity`) with their corresponding EF configurations are created. No DbSet properties are added to `AppDbContext` yet — the migration is deferred to a follow-on issue.

## Type of change

- [x] Feature

## Related issues / links

Closes #440

## How was this tested?

- [x] Unit tests added/updated

14 new tests across two test classes:
- `GivenAFileClassificationCategoryEntity` (9 tests) — default values, navigation props, collection init
- `GivenAFileClassificationKeywordEntity` (5 tests) — default values, FK property, navigation prop

TDD: RED commit (`82e1fa9`) of failing tests precedes GREEN implementation (`e5118eb`).

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — Data/Entities, Data/Configuration

---

## TDD Checklist (required)

- [x] Builds locally — `0 Warning(s)  0 Error(s)`
- [x] Tests pass (`dotnet test`) — `Passed: 1332, Failed: 9` (9 failures are pre-existing `GivenAnAppBootstrapper` / `PendingModelChangesWarning` from prior model drift on `main`, unrelated to this issue)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable) — N/A
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- `ApplyConfigurationsFromAssembly` auto-discovers both new configurations; this will increase model drift counted by `PendingModelChangesWarning` tests, but those 9 tests were already failing on `main` before this branch.
- A follow-on issue should create the EF migration that covers both the existing `FileClassificationRuleEntity` drift and these two new tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)