### PR TITLE
feat(onedrive-sync-client): hierarchical classification DbSets + migration (#441)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/GivenAnAppDbContext.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/GivenAnAppDbContext.cs
@@ -1,0 +1,68 @@
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data;
+
+public sealed class GivenAnAppDbContext : IDisposable
+{
+    private readonly SqliteConnection connection;
+    private readonly AppDbContext context;
+
+    public GivenAnAppDbContext()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<AppDbContext>().UseSqlite(connection).Options;
+        context = new AppDbContext(options);
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        context.Dispose();
+        connection.Dispose();
+    }
+
+    [Fact]
+    public void when_querying_file_classification_categories_then_dbset_is_accessible()
+    {
+        var result = context.FileClassificationCategories.ToList();
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void when_querying_file_classification_keywords_then_dbset_is_accessible()
+    {
+        var result = context.FileClassificationKeywords.ToList();
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task when_file_classification_category_added_then_it_can_be_retrieved()
+    {
+        context.FileClassificationCategories.Add(new FileClassificationCategoryEntity { Name = "Photos", Level = 1 });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var retrieved = context.FileClassificationCategories.First();
+
+        retrieved.Name.ShouldBe("Photos");
+    }
+
+    [Fact]
+    public async Task when_file_classification_keyword_added_then_it_can_be_retrieved()
+    {
+        var category = new FileClassificationCategoryEntity { Name = "Photos", Level = 1 };
+        context.FileClassificationCategories.Add(category);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        context.FileClassificationKeywords.Add(new FileClassificationKeywordEntity { Keyword = "photos", CategoryId = category.Id });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var retrieved = context.FileClassificationKeywords.First();
+
+        retrieved.Keyword.ShouldBe("photos");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/AppDbContext.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/AppDbContext.cs
@@ -13,6 +13,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
     public DbSet<SyncedItemEntity> SyncedItems => Set<SyncedItemEntity>();
     public DbSet<SyncedItemClassificationEntity> SyncedItemClassifications => Set<SyncedItemClassificationEntity>();
     public DbSet<FileClassificationRuleEntity> FileClassificationRules => Set<FileClassificationRuleEntity>();
+    public DbSet<FileClassificationCategoryEntity> FileClassificationCategories => Set<FileClassificationCategoryEntity>();
+    public DbSet<FileClassificationKeywordEntity> FileClassificationKeywords => Set<FileClassificationKeywordEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605201918_HierarchicalFileClassificationRules.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605201918_HierarchicalFileClassificationRules.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605201918_HierarchicalFileClassificationRules")]
+    partial class HierarchicalFileClassificationRules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605201918_HierarchicalFileClassificationRules.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260605201918_HierarchicalFileClassificationRules.cs
@@ -1,0 +1,159 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class HierarchicalFileClassificationRules : Migration
+    {
+        private static readonly string[] CategoryIndexColumns = ["ParentId", "Name"];
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Step 1 — Create FileClassificationCategories table
+            migrationBuilder.CreateTable(
+                name: "FileClassificationCategories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Level = table.Column<int>(type: "INTEGER", nullable: false),
+                    ParentId = table.Column<int>(type: "INTEGER", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FileClassificationCategories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FileClassificationCategories_FileClassificationCategories_ParentId",
+                        column: x => x.ParentId,
+                        principalTable: "FileClassificationCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            // Step 2 — Create FileClassificationKeywords table
+            migrationBuilder.CreateTable(
+                name: "FileClassificationKeywords",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Keyword = table.Column<string>(type: "TEXT", nullable: false),
+                    CategoryId = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FileClassificationKeywords", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FileClassificationKeywords_FileClassificationCategories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "FileClassificationCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileClassificationCategories_ParentId_Name",
+                table: "FileClassificationCategories",
+                columns: CategoryIndexColumns,
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileClassificationKeywords_CategoryId",
+                table: "FileClassificationKeywords",
+                column: "CategoryId");
+
+            // Step 3 — Seed L1 categories from old flat rules
+            migrationBuilder.Sql(@"
+INSERT INTO FileClassificationCategories (Name, Level, ParentId)
+SELECT DISTINCT Level1, 1, NULL
+FROM FileClassificationRules
+WHERE Level1 IS NOT NULL AND Level1 != '';");
+
+            // Step 4 — Seed L2 categories from old flat rules
+            migrationBuilder.Sql(@"
+INSERT INTO FileClassificationCategories (Name, Level, ParentId)
+SELECT DISTINCT r.Level2, 2, c1.Id
+FROM FileClassificationRules r
+JOIN FileClassificationCategories c1 ON c1.Name = r.Level1 AND c1.Level = 1
+WHERE r.Level2 IS NOT NULL AND r.Level2 != '';");
+
+            // Step 5 — Seed L3 categories from old flat rules
+            migrationBuilder.Sql(@"
+INSERT INTO FileClassificationCategories (Name, Level, ParentId)
+SELECT DISTINCT r.Level3, 3, c2.Id
+FROM FileClassificationRules r
+JOIN FileClassificationCategories c1 ON c1.Name = r.Level1 AND c1.Level = 1
+JOIN FileClassificationCategories c2 ON c2.Name = r.Level2 AND c2.Level = 2 AND c2.ParentId = c1.Id
+WHERE r.Level3 IS NOT NULL AND r.Level3 != '';");
+
+            // Step 6 — Split pipe-delimited keywords in C# (via recursive CTE) and link to most-specific category
+            migrationBuilder.Sql(@"
+WITH RECURSIVE split(rule_id, level1, level2, level3, kw, rest) AS (
+    SELECT
+        Id,
+        Level1,
+        Level2,
+        Level3,
+        CASE WHEN instr(Keywords, '|') > 0
+             THEN substr(Keywords, 1, instr(Keywords, '|') - 1)
+             ELSE Keywords END,
+        CASE WHEN instr(Keywords, '|') > 0
+             THEN substr(Keywords, instr(Keywords, '|') + 1)
+             ELSE '' END
+    FROM FileClassificationRules
+    WHERE Keywords IS NOT NULL AND Keywords != ''
+    UNION ALL
+    SELECT
+        rule_id, level1, level2, level3,
+        CASE WHEN instr(rest, '|') > 0
+             THEN substr(rest, 1, instr(rest, '|') - 1)
+             ELSE rest END,
+        CASE WHEN instr(rest, '|') > 0
+             THEN substr(rest, instr(rest, '|') + 1)
+             ELSE '' END
+    FROM split
+    WHERE rest IS NOT NULL AND rest != ''
+)
+INSERT INTO FileClassificationKeywords (Keyword, CategoryId)
+SELECT DISTINCT
+    trim(s.kw),
+    COALESCE(
+        (SELECT c3.Id
+         FROM FileClassificationCategories c3
+         JOIN FileClassificationCategories c2p ON c3.ParentId = c2p.Id
+         JOIN FileClassificationCategories c1p ON c2p.ParentId = c1p.Id
+         WHERE c3.Level = 3 AND c3.Name = s.level3
+           AND c2p.Name = s.level2 AND c1p.Name = s.level1
+         LIMIT 1),
+        (SELECT c2.Id
+         FROM FileClassificationCategories c2
+         JOIN FileClassificationCategories c1p ON c2.ParentId = c1p.Id
+         WHERE c2.Level = 2 AND c2.Name = s.level2 AND c1p.Name = s.level1
+         LIMIT 1),
+        (SELECT c1.Id
+         FROM FileClassificationCategories c1
+         WHERE c1.Level = 1 AND c1.Name = s.level1
+         LIMIT 1)
+    ) AS CategoryId
+FROM split s
+WHERE trim(s.kw) IS NOT NULL AND trim(s.kw) != '';");
+
+            // Step 7 — Seed analyser L1 nodes (used by auto-categoriser; skip if already present from rule data)
+            migrationBuilder.Sql(@"
+INSERT OR IGNORE INTO FileClassificationCategories (Name, Level, ParentId)
+VALUES
+    ('Person', 1, NULL),
+    ('Color',  1, NULL),
+    ('Object', 1, NULL),
+    ('Place',  1, NULL),
+    ('Event',  1, NULL);");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+            => throw new System.NotSupportedException("HierarchicalFileClassificationRules migration cannot be reversed. Old FileClassificationRules table is still present.");
+    }
+}


### PR DESCRIPTION
# Summary

Adds the two new `DbSet` properties to `AppDbContext` and creates the EF Core migration that builds the hierarchical category + keyword tables from the existing flat `FileClassificationRules` data. The old table is left untouched.

## Type of change

- [x] Feature

## Related issues / links

Closes #441

## How was this tested?

- [x] Unit tests added/updated

4 new tests in `GivenAnAppDbContext`:
- `when_querying_file_classification_categories_then_dbset_is_accessible`
- `when_querying_file_classification_keywords_then_dbset_is_accessible`
- `when_file_classification_category_added_then_it_can_be_retrieved`
- `when_file_classification_keyword_added_then_it_can_be_retrieved`

TDD: RED commit (`6e9b895`) of 4 failing tests precedes GREEN implementation (`f8f7926`).

The 9 previously-failing `GivenAnAppBootstrapper` tests (pre-existing `PendingModelChangesWarning` from prior model drift) are now green — this migration resolves the drift.

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — Data/AppDbContext, Data/Migrations

---

## TDD Checklist (required)

- [x] Builds locally — `0 Warning(s)  0 Error(s)`
- [x] Tests pass (`dotnet test`) — `Passed: 1377, Failed: 0`
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable) — N/A

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Migration Up — 7 steps

1. Create `FileClassificationCategories` (self-referencing PK/FK, unique index on `(ParentId, Name)`)
2. Create `FileClassificationKeywords` (FK to categories, cascade delete)
3. Seed L1 categories — `SELECT DISTINCT Level1` from old flat rules
4. Seed L2 categories — joined to L1 parent
5. Seed L3 categories — joined to L2 parent
6. Split pipe-delimited `Keywords` via recursive CTE → individual `FileClassificationKeywords` rows linked to most-specific category
7. Seed analyser L1 nodes (`Person`, `Color`, `Object`, `Place`, `Event`) via `INSERT OR IGNORE`

`Down` throws `NotSupportedException` — the old `FileClassificationRules` table is still present; a DROP migration is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)