### PR TITLE
feat(onedrive-sync-client): IFileClassificationRepository + implementation (#442)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
@@ -1,0 +1,190 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.FileClassification;
+
+public sealed class GivenAFileClassificationRepository(IntegrationTestFixture fixture) : IClassFixture<IntegrationTestFixture>, IAsyncLifetime
+{
+    public async ValueTask InitializeAsync()
+    {
+        var factory = fixture.Services.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var context = await factory.CreateDbContextAsync();
+        context.FileClassificationKeywords.RemoveRange(context.FileClassificationKeywords);
+        context.FileClassificationCategories.RemoveRange(context.FileClassificationCategories);
+        await context.SaveChangesAsync();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task when_adding_a_category_then_it_can_be_retrieved()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddCategoryAsync(category, ct);
+
+        var categories = await repository.GetAllCategoriesAsync(ct);
+        categories.ShouldNotBeEmpty();
+        categories.ShouldContain(c => c.Name == "Finance");
+    }
+
+    [Fact]
+    public async Task when_adding_a_keyword_to_a_leaf_category_then_it_can_be_retrieved()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldNotBeEmpty();
+        keywords.ShouldContain(k => k.Value == "invoice");
+    }
+
+    [Fact]
+    public async Task when_keywords_exist_then_get_all_keyword_mappings_returns_flat_projections()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        var mappings = await repository.GetAllKeywordMappingsAsync(ct);
+
+        mappings.ShouldNotBeEmpty();
+        mappings.ShouldContain(m => m.Keyword == "invoice" && m.Level1 == "Finance");
+    }
+
+    [Fact]
+    public async Task when_adding_a_keyword_to_a_non_leaf_category_then_an_error_is_returned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var parentCategory = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var parentId = await repository.AddCategoryAsync(parentCategory, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var childCategory = FileClassificationCategoryFactory.Create(placeholder, "Invoices", 2, Option.Some(parentId))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddCategoryAsync(childCategory, ct);
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddKeywordAsync(parentId, keyword, ct)
+            .MatchAsync(_ => throw new InvalidOperationException("Expected error but got success."), err => err.ShouldNotBeNullOrWhiteSpace());
+    }
+
+    [Fact]
+    public async Task when_updating_a_keyword_on_a_non_leaf_category_then_an_error_is_returned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var parentCategory = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var parentId = await repository.AddCategoryAsync(parentCategory, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordId = await repository.AddKeywordAsync(parentId, keyword, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var childCategory = FileClassificationCategoryFactory.Create(placeholder, "Invoices", 2, Option.Some(parentId))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddCategoryAsync(childCategory, ct);
+        var updatedKeyword = FileClassificationKeywordFactory.Create("receipt", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.UpdateKeywordAsync(keywordId, updatedKeyword, ct)
+            .MatchAsync(_ => throw new InvalidOperationException("Expected error but got success."), err => err.ShouldNotBeNullOrWhiteSpace());
+    }
+
+    [Fact]
+    public async Task when_deleting_a_category_then_its_keywords_are_also_deleted()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        await repository.DeleteCategoryAsync(categoryId, ct);
+
+        var categories = await repository.GetAllCategoriesAsync(ct);
+        categories.ShouldNotContain(c => c.Id == categoryId);
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_updating_a_category_name_then_the_new_name_is_persisted()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var updatedCategory = FileClassificationCategoryFactory.Create(categoryId, "Accounts", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.UpdateCategoryAsync(categoryId, updatedCategory, ct);
+
+        var categories = await repository.GetAllCategoriesAsync(ct);
+        categories.ShouldContain(c => c.Name == "Accounts");
+        categories.ShouldNotContain(c => c.Name == "Finance");
+    }
+
+    [Fact]
+    public async Task when_deleting_a_keyword_then_it_is_removed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordA = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordB = FileClassificationKeywordFactory.Create("receipt", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordIdA = await repository.AddKeywordAsync(categoryId, keywordA, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddKeywordAsync(categoryId, keywordB, ct);
+
+        await repository.DeleteKeywordAsync(keywordIdA, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldNotContain(k => k.Value == "invoice");
+        keywords.ShouldContain(k => k.Value == "receipt");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
@@ -94,7 +94,9 @@ public sealed class GivenAFileClassificationRepository(IntegrationTestFixture fi
             .Match(ok => ok, err => throw new InvalidOperationException(err));
 
         await repository.AddKeywordAsync(parentId, keyword, ct)
-            .MatchAsync(_ => throw new InvalidOperationException("Expected error but got success."), err => err.ShouldNotBeNullOrWhiteSpace());
+            .MatchAsync(
+                _ => throw new InvalidOperationException("Expected error but got success."),
+                err => { err.ShouldNotBeNullOrWhiteSpace(); return err; });
     }
 
     [Fact]
@@ -118,7 +120,9 @@ public sealed class GivenAFileClassificationRepository(IntegrationTestFixture fi
             .Match(ok => ok, err => throw new InvalidOperationException(err));
 
         await repository.UpdateKeywordAsync(keywordId, updatedKeyword, ct)
-            .MatchAsync(_ => throw new InvalidOperationException("Expected error but got success."), err => err.ShouldNotBeNullOrWhiteSpace());
+            .MatchAsync(
+                _ => throw new InvalidOperationException("Expected error but got success."),
+                err => { err.ShouldNotBeNullOrWhiteSpace(); return err; });
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/PersistenceServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/PersistenceServiceExtensions.cs
@@ -23,6 +23,7 @@ internal static class PersistenceServiceExtensions
         _ = services.AddSingleton<ISyncRuleRepository, SyncRuleRepository>();
         _ = services.AddSingleton<ISyncedItemRepository, SyncedItemRepository>();
         _ = services.AddSingleton<IFileClassificationRuleRepository, FileClassificationRuleRepository>();
+        _ = services.AddSingleton<IFileClassificationRepository, FileClassificationRepository>();
 
         return services;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
@@ -1,0 +1,202 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+
+/// <inheritdoc />
+public sealed class FileClassificationRepository(IDbContextFactory<AppDbContext> dbFactory) : IFileClassificationRepository
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FileClassificationCategory>> GetAllCategoriesAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entities = await db.FileClassificationCategories.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities
+            .Select(e => FileClassificationCategoryFactory.Create(
+                new FileClassificationCategoryId(e.Id),
+                e.Name,
+                e.Level,
+                e.ParentId.HasValue ? Option.Some(new FileClassificationCategoryId(e.ParentId.Value)) : Option.None<FileClassificationCategoryId>())
+                .Match(ok => ok, err => throw new InvalidOperationException($"Persisted category {e.Id} failed validation: {err}")))
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FileClassificationKeyword>> GetKeywordsForCategoryAsync(FileClassificationCategoryId categoryId, CancellationToken cancellationToken = default)
+    {
+        int rawId = categoryId.Id;
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entities = await db.FileClassificationKeywords
+            .AsNoTracking()
+            .Where(k => k.CategoryId == rawId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities
+            .Select(e => new FileClassificationKeyword(e.Keyword, Option.None<bool>()))
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<KeywordMapping>> GetAllKeywordMappingsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var categories = await db.FileClassificationCategories
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var keywords = await db.FileClassificationKeywords
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var categoryById = categories.ToDictionary(c => c.Id);
+
+        return keywords
+            .Select(k => BuildKeywordMapping(k, categoryById))
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<FileClassificationCategoryId, string>> AddCategoryAsync(FileClassificationCategory category, CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entity = new FileClassificationCategoryEntity
+        {
+            Name = category.Name,
+            Level = category.Level,
+            ParentId = category.ParentId.MapOrDefault(pid => (int?)pid.Id, null)
+        };
+
+        db.FileClassificationCategories.Add(entity);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new Result<FileClassificationCategoryId, string>.Ok(new FileClassificationCategoryId(entity.Id));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<FileClassificationCategoryId, string>> UpdateCategoryAsync(FileClassificationCategoryId id, FileClassificationCategory category, CancellationToken cancellationToken = default)
+    {
+        int rawId = id.Id;
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entity = await db.FileClassificationCategories.FindAsync([rawId], cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return new Result<FileClassificationCategoryId, string>.Error("Category not found.");
+
+        entity.Name = category.Name;
+        entity.Level = category.Level;
+        entity.ParentId = category.ParentId.MapOrDefault(pid => (int?)pid.Id, null);
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new Result<FileClassificationCategoryId, string>.Ok(id);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteCategoryAsync(FileClassificationCategoryId id, CancellationToken cancellationToken = default)
+    {
+        int rawId = id.Id;
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entity = await db.FileClassificationCategories.FindAsync([rawId], cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return;
+
+        db.FileClassificationCategories.Remove(entity);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<int, string>> AddKeywordAsync(FileClassificationCategoryId categoryId, FileClassificationKeyword keyword, CancellationToken cancellationToken = default)
+    {
+        int rawCategoryId = categoryId.Id;
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        bool hasChildren = await db.FileClassificationCategories
+            .AnyAsync(c => c.ParentId == rawCategoryId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (hasChildren)
+            return new Result<int, string>.Error("Cannot add keyword to a non-leaf category.");
+
+        var entity = new FileClassificationKeywordEntity
+        {
+            Keyword = keyword.Value,
+            CategoryId = rawCategoryId
+        };
+
+        db.FileClassificationKeywords.Add(entity);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new Result<int, string>.Ok(entity.Id);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<int, string>> UpdateKeywordAsync(int keywordId, FileClassificationKeyword keyword, CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entity = await db.FileClassificationKeywords.FindAsync([keywordId], cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return new Result<int, string>.Error("Keyword not found.");
+
+        bool hasChildren = await db.FileClassificationCategories
+            .AnyAsync(c => c.ParentId == entity.CategoryId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (hasChildren)
+            return new Result<int, string>.Error("Cannot update keyword on a non-leaf category.");
+
+        entity.Keyword = keyword.Value;
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new Result<int, string>.Ok(entity.Id);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteKeywordAsync(int keywordId, CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var entity = await db.FileClassificationKeywords.FindAsync([keywordId], cancellationToken).ConfigureAwait(false);
+        if (entity is null)
+            return;
+
+        db.FileClassificationKeywords.Remove(entity);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static KeywordMapping BuildKeywordMapping(FileClassificationKeywordEntity keyword, Dictionary<int, FileClassificationCategoryEntity> categoryById)
+    {
+        var ancestorNames = new Dictionary<int, string>();
+
+        if (categoryById.TryGetValue(keyword.CategoryId, out var current))
+        {
+            ancestorNames[current.Level] = current.Name;
+
+            while (current.ParentId.HasValue && categoryById.TryGetValue(current.ParentId.Value, out var parent))
+            {
+                ancestorNames[parent.Level] = parent.Name;
+                current = parent;
+            }
+        }
+
+        string level1 = ancestorNames.GetValueOrDefault(1, string.Empty);
+        Option<string> level2 = ancestorNames.TryGetValue(2, out string? level2Name) ? Option.Some(level2Name) : Option.None<string>();
+        Option<string> level3 = ancestorNames.TryGetValue(3, out string? level3Name) ? Option.Some(level3Name) : Option.None<string>();
+
+        return new KeywordMapping(keyword.Keyword, level1, level2, level3, false);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRepository.cs
@@ -1,0 +1,35 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+
+/// <summary>Repository for reading and writing the hierarchical file classification taxonomy.</summary>
+public interface IFileClassificationRepository
+{
+    /// <summary>Returns all category nodes in the hierarchy.</summary>
+    Task<IReadOnlyList<FileClassificationCategory>> GetAllCategoriesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all keywords belonging to the specified category.</summary>
+    Task<IReadOnlyList<FileClassificationKeyword>> GetKeywordsForCategoryAsync(FileClassificationCategoryId categoryId, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all keywords projected as flat <see cref="KeywordMapping"/> records for use in classification pipelines.</summary>
+    Task<IReadOnlyList<KeywordMapping>> GetAllKeywordMappingsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Persists a new category and returns its generated identifier.</summary>
+    Task<Result<FileClassificationCategoryId, string>> AddCategoryAsync(FileClassificationCategory category, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates the mutable fields of an existing category and returns its identifier.</summary>
+    Task<Result<FileClassificationCategoryId, string>> UpdateCategoryAsync(FileClassificationCategoryId id, FileClassificationCategory category, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a category. No-op if the category does not exist.</summary>
+    Task DeleteCategoryAsync(FileClassificationCategoryId id, CancellationToken cancellationToken = default);
+
+    /// <summary>Adds a keyword to a leaf category and returns the generated keyword identifier.</summary>
+    Task<Result<int, string>> AddKeywordAsync(FileClassificationCategoryId categoryId, FileClassificationKeyword keyword, CancellationToken cancellationToken = default);
+
+    /// <summary>Updates a keyword's value. Fails if the owning category is not a leaf.</summary>
+    Task<Result<int, string>> UpdateKeywordAsync(int keywordId, FileClassificationKeyword keyword, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a keyword. No-op if the keyword does not exist.</summary>
+    Task DeleteKeywordAsync(int keywordId, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
# Summary

New `IFileClassificationRepository` and `FileClassificationRepository` for the hierarchical classification taxonomy (categories + keywords). Registered in DI alongside the existing `IFileClassificationRuleRepository` — nothing switches to the new repo yet, old pipeline untouched.

## Type of change

- [x] Feature

## Related issues / links

Closes #442

Part of plan: docs/plans/OneDrive_O.md

## How was this tested?

- [x] Unit tests added/updated

8 new integration tests in `GivenAFileClassificationRepository` covering:
- `GetAllCategoriesAsync` round-trip
- `GetKeywordsForCategoryAsync` for a leaf category
- `GetAllKeywordMappingsAsync` flat projection
- Leaf enforcement — `AddKeywordAsync` rejects non-leaf category
- Leaf enforcement — `UpdateKeywordAsync` rejects when category gains children
- Cascade delete (keywords removed when category deleted)
- `UpdateCategoryAsync` name change
- `DeleteKeywordAsync` targeted removal

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client` (2 new files, 1 edited)
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration` (1 new test file)

---

## TDD Checklist (required)

- [x] Builds locally — `0 Error(s) 0 Warning(s)`
- [x] Tests pass — Unit: 1377/1377, Integration: 26/26 (8 new)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable) — N/A
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration --filter "FullyQualifiedName~GivenAFileClassificationRepository"
```

---

## Notes for reviewers

- `FileClassificationRuleRepository` (old flat-table repo) is untouched — both are registered in DI and coexist.
- Leaf enforcement: `AddKeywordAsync` / `UpdateKeywordAsync` return `Result<T, string>.Error` when `AnyAsync(c => c.ParentId == categoryId)` is true.
- `GetAllKeywordMappingsAsync` loads all categories into a dictionary then walks each keyword's parent chain to resolve Level1/Level2/Level3 names.
- `IsSpecial` in `KeywordMapping` is `false` — the hierarchy entities have no such field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)