### PR TITLE
fix(onedrive-sync-client): remove old rule domain records (#446)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRule.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRule.cs
@@ -1,4 +1,0 @@
-namespace AStar.Dev.OneDrive.Sync.Client.Domain;
-
-/// <summary>A rule that maps a set of path keywords to a <see cref="FileClassification"/>.</summary>
-public sealed record FileClassificationRule(IReadOnlyList<string> Keywords, FileClassification Classification);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleEntry.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleEntry.cs
@@ -1,4 +1,0 @@
-namespace AStar.Dev.OneDrive.Sync.Client.Domain;
-
-/// <summary>Pairs a persisted <see cref="FileClassificationRule"/> with its database Id.</summary>
-public sealed record FileClassificationRuleEntry(int Id, FileClassificationRule Rule);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassificationRuleFactory.cs
@@ -1,8 +1,0 @@
-namespace AStar.Dev.OneDrive.Sync.Client.Domain;
-
-/// <summary>Factory for <see cref="FileClassificationRule"/>.</summary>
-public static class FileClassificationRuleFactory
-{
-    /// <summary>Creates a <see cref="FileClassificationRule"/>.</summary>
-    public static FileClassificationRule Create(IReadOnlyList<string> keywords, FileClassification classification) => new(keywords, classification);
-}


### PR DESCRIPTION
# Summary

Delete the three old domain records and factory that became unreferenced after Ph9. Pure cleanup — no logic changes.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #446

## How was this tested?

- [ ] Unit tests added/updated
- [x] Manual validation
- [ ] Not applicable

## Impacted areas

apps/desktop/AStar.Dev.OneDrive.Sync.Client

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- `grep -r "FileClassificationRule\|FileClassificationRuleEntry\|FileClassificationRuleFactory" --include=*.cs | grep -v "Tests/"` returns no references to the deleted types.
- Unit: 1378 passed, Integration: 22 passed — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)