### PR TITLE
feat(onedrive-sync-client): dynamic app title and splash name from appsettings

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/ApplicationConfiguration/GivenClientConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/ApplicationConfiguration/GivenClientConfiguration.cs
@@ -1,0 +1,44 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.ApplicationConfiguration;
+
+public sealed class GivenClientConfiguration
+{
+    private static IOptions<ClientConfiguration> BuildOptions(string applicationName, string applicationVersion)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AStarDevOneDriveClient:ApplicationName"] = applicationName,
+                ["AStarDevOneDriveClient:ApplicationVersion"] = applicationVersion
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        _ = services.AddOptions<ClientConfiguration>()
+                .Bind(configuration.GetSection("AStarDevOneDriveClient"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+        return services.BuildServiceProvider().GetRequiredService<IOptions<ClientConfiguration>>();
+    }
+
+    [Fact]
+    public void when_bound_then_application_name_is_populated()
+    {
+        var options = BuildOptions("AStar Dev OneDrive Sync Client", "0.3.0");
+
+        options.Value.ApplicationName.ShouldBe("AStar Dev OneDrive Sync Client");
+    }
+
+    [Fact]
+    public void when_bound_then_application_version_is_populated()
+    {
+        var options = BuildOptions("AStar Dev OneDrive Sync Client", "0.3.0");
+
+        options.Value.ApplicationVersion.ShouldBe("0.3.0");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -88,6 +88,10 @@ public class App : Application, IDisposable
                 .Bind(configuration.GetSection("Sync"))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
+        _ = services.AddOptions<ClientConfiguration>()
+                .Bind(configuration.GetSection("AStarDevOneDriveClient"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
 
         return configuration;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         x:Class="AStar.Dev.OneDrive.Sync.Client.Home.MainWindow"
         x:DataType="vmHome:MainWindowViewModel"
-        Title="OneDrive Sync"
+        Title=""
         Width="1100" Height="700"
         MinWidth="800" MinHeight="520"
         Icon="avares://AStar.Dev.OneDrive.Sync.Client/Assets/astar.png"

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using Avalonia.Controls;
+using Microsoft.Extensions.Options;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
@@ -6,9 +8,10 @@ public partial class MainWindow : Window
 {
     public MainWindow() => InitializeComponent();
 
-    public MainWindow(MainWindowViewModel vm)
+    public MainWindow(MainWindowViewModel vm, IOptions<ClientConfiguration> config)
     {
         InitializeComponent();
         DataContext = vm;
+        Title = $"{config.Value.ApplicationName} - V{config.Value.ApplicationVersion}";
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/ClientConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/ApplicationConfiguration/ClientConfiguration.cs
@@ -1,0 +1,7 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
+
+public record ClientConfiguration
+{
+    public required string ApplicationName { get; init; }
+    public required string ApplicationVersion { get; init; }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml
@@ -32,7 +32,7 @@
             </Viewbox>
 
             <StackPanel Spacing="4" HorizontalAlignment="Center">
-                <TextBlock Text="OneDrive Sync"
+                <TextBlock Text="{Binding AppName}"
                            FontSize="20"
                            FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}"

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindow.axaml.cs
@@ -1,13 +1,18 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.ApplicationConfiguration;
 using Avalonia.Controls;
+using Microsoft.Extensions.Options;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Splash;
 
 public partial class SplashWindow : Window
 {
-    private readonly SplashWindowViewModel _viewModel = new();
+    private readonly SplashWindowViewModel _viewModel;
 
-    public SplashWindow()
+    public SplashWindow() : this(Microsoft.Extensions.Options.Options.Create(new ClientConfiguration { ApplicationName = string.Empty, ApplicationVersion = string.Empty })) { }
+
+    public SplashWindow(IOptions<ClientConfiguration> config)
     {
+        _viewModel = new SplashWindowViewModel { AppName = config.Value.ApplicationName };
         InitializeComponent();
         DataContext = _viewModel;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Splash/SplashWindowViewModel.cs
@@ -5,6 +5,8 @@ namespace AStar.Dev.OneDrive.Sync.Client.Splash;
 
 public partial class SplashWindowViewModel : ViewModelBase
 {
+    public string AppName { get; init; } = string.Empty;
+
     [ObservableProperty]
     private string _status = string.Empty;
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AStarDevOneDriveClient": {
     "ApplicationVersion": "0.3.0",
+    "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",
     "UserPreferencesFile": "user-preferences.json",


### PR DESCRIPTION
# Summary

Replaces hardcoded `"OneDrive Sync"` strings in the main window title bar and splash screen with values read from the `AStarDevOneDriveClient` section of `appsettings.json` at startup. Title format: `{ApplicationName} - V{ApplicationVersion}`.

## Type of change

- [x] Feature

## Related issues / links

Closes #460, #461, #462, #463

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally — `Build succeeded. 0 Warning(s). 0 Error(s).`
- [x] Tests pass (`dotnet test`) — `Passed! Failed: 0, Passed: 1379, Skipped: 0, Total: 1379`
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- `ClientConfiguration` record added to `Infrastructure/ApplicationConfiguration/` following the same pattern as `EntraIdConfiguration` and `SyncSettings`.
- `MainWindow` title set in code-behind (view concern, not VM).
- `SplashWindow` retains a parameterless constructor (required by Avalonia's XAML loader); DI uses the `IOptions<ClientConfiguration>` overload.
- `appsettings.json` gains `ApplicationName` field (was missing from the committed version; `ApplicationVersion` was already present).