### PR TITLE
test(onedrive-sync-client): add AppName tests for SplashWindowViewModel (#462)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Splash/GivenASplashWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Splash/GivenASplashWindowViewModel.cs
@@ -36,4 +36,16 @@ public sealed class GivenASplashWindowViewModel
 
         sut.Status.ShouldBe("Configuring database…");
     }
+
+    [Fact]
+    public void when_created_then_app_name_is_empty() =>
+        new Client.Splash.SplashWindowViewModel().AppName.ShouldBeEmpty();
+
+    [Fact]
+    public void when_app_name_is_initialised_with_a_value_then_app_name_matches()
+    {
+        var sut = new Client.Splash.SplashWindowViewModel { AppName = "My App" };
+
+        sut.AppName.ShouldBe("My App");
+    }
 }


### PR DESCRIPTION
# Summary

Add missing unit tests for the `AppName` property on `SplashWindowViewModel`, covering the acceptance criteria from #462. The production implementation (binding + DI wiring) was already merged in #464; this closes the open issue with test coverage.

## Type of change

- [x] Maintenance

## Related issues / links

Closes #462

## How was this tested?

- [x] Unit tests added/updated

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1383 passed, 0 failed
- [x] No new analyzer warnings
- [ ] Public API changes reviewed — N/A (test-only change)
- [ ] Documentation updated (if applicable) — N/A

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit
```

---

## Notes for reviewers

Two tests added to `GivenASplashWindowViewModel`:
- `when_created_then_app_name_is_empty` — default `AppName` is `string.Empty`
- `when_app_name_is_initialised_with_a_value_then_app_name_matches` — init-set value round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)