### PR TITLE
feat(onedrive-sync-client): export / import file classifications (#467)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
@@ -191,4 +191,51 @@ public sealed class GivenAFileClassificationRepository(IntegrationTestFixture fi
         keywords.ShouldNotContain(k => k.Keyword.Value == "invoice");
         keywords.ShouldContain(k => k.Keyword.Value == "receipt");
     }
+
+    [Fact]
+    public async Task when_delete_all_called_with_data_then_all_categories_removed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddCategoryAsync(category, ct);
+
+        await repository.DeleteAllAsync(ct);
+
+        var categories = await repository.GetAllCategoriesAsync(ct);
+        categories.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_delete_all_called_with_data_then_all_keywords_removed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        await repository.DeleteAllAsync(ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_delete_all_called_with_empty_db_then_no_error_thrown()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+
+        var exception = await Record.ExceptionAsync(() => repository.DeleteAllAsync(ct));
+
+        exception.ShouldBeNull();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationExportImportService.cs
@@ -1,0 +1,185 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using System.Text.Json;
+using Testably.Abstractions.Testing;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Classifications;
+
+public sealed class GivenAFileClassificationExportImportService
+{
+    private const string ExportFilePath = "/export/classifications.json";
+
+    private readonly IFileClassificationRepository repository;
+    private readonly MockFileSystem fileSystem;
+    private readonly FileClassificationExportImportService sut;
+
+    public GivenAFileClassificationExportImportService()
+    {
+        repository = Substitute.For<IFileClassificationRepository>();
+        fileSystem = new MockFileSystem();
+        fileSystem.Directory.CreateDirectory("/export");
+
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<IReadOnlyList<FileClassificationCategory>>([]));
+        repository.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<IReadOnlyList<FileClassificationKeywordEntry>>([]));
+        repository.AddCategoryAsync(Arg.Any<FileClassificationCategory>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<Result<FileClassificationCategoryId, string>>(new Result<FileClassificationCategoryId, string>.Ok(new FileClassificationCategoryId(1))));
+        repository.DeleteAllAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.CompletedTask);
+
+        sut = new FileClassificationExportImportService(repository, fileSystem);
+    }
+
+    [Fact]
+    public async Task when_exporting_empty_taxonomy_then_json_has_empty_categories_array()
+    {
+        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+
+        var written = fileSystem.File.ReadAllText(ExportFilePath);
+        using var doc = JsonDocument.Parse(written);
+        doc.RootElement.GetProperty("categories").GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task when_exporting_with_root_categories_then_json_contains_category_names()
+    {
+        IReadOnlyList<FileClassificationCategory> categories =
+        [
+            new(new FileClassificationCategoryId(1), "Photos", 1, Option.None<FileClassificationCategoryId>()),
+            new(new FileClassificationCategoryId(2), "Documents", 1, Option.None<FileClassificationCategoryId>())
+        ];
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(categories));
+
+        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+
+        var written = fileSystem.File.ReadAllText(ExportFilePath);
+        using var doc = JsonDocument.Parse(written);
+        var categoryNames = doc.RootElement.GetProperty("categories")
+                               .EnumerateArray()
+                               .Select(e => e.GetProperty("name").GetString())
+                               .ToList();
+        categoryNames.ShouldContain("Photos");
+        categoryNames.ShouldContain("Documents");
+    }
+
+    [Fact]
+    public async Task when_exporting_with_nested_categories_then_json_reflects_hierarchy()
+    {
+        IReadOnlyList<FileClassificationCategory> categories =
+        [
+            new(new FileClassificationCategoryId(1), "Photos", 1, Option.None<FileClassificationCategoryId>()),
+            new(new FileClassificationCategoryId(2), "Holidays", 2, Option.Some(new FileClassificationCategoryId(1)))
+        ];
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(categories));
+
+        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+
+        var written = fileSystem.File.ReadAllText(ExportFilePath);
+        using var doc = JsonDocument.Parse(written);
+        var rootCategories = doc.RootElement.GetProperty("categories").EnumerateArray().ToList();
+        rootCategories.Count.ShouldBe(1);
+        var photosChildren = rootCategories[0].GetProperty("children").EnumerateArray().ToList();
+        photosChildren.Count.ShouldBe(1);
+        photosChildren[0].GetProperty("name").GetString().ShouldBe("Holidays");
+    }
+
+    [Fact]
+    public async Task when_exporting_with_keywords_then_json_contains_keyword_values()
+    {
+        IReadOnlyList<FileClassificationCategory> categories =
+        [
+            new(new FileClassificationCategoryId(1), "Photos", 1, Option.None<FileClassificationCategoryId>())
+        ];
+        IReadOnlyList<FileClassificationKeywordEntry> keywords =
+        [
+            new FileClassificationKeywordEntry(1, new FileClassificationKeyword("holiday", Option.None<bool>())),
+            new FileClassificationKeywordEntry(2, new FileClassificationKeyword("vacation", Option.None<bool>()))
+        ];
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(categories));
+        repository.GetKeywordsForCategoryAsync(new FileClassificationCategoryId(1), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(keywords));
+
+        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+
+        var written = fileSystem.File.ReadAllText(ExportFilePath);
+        using var doc = JsonDocument.Parse(written);
+        var keywordValues = doc.RootElement.GetProperty("categories")
+                               .EnumerateArray()
+                               .First()
+                               .GetProperty("keywords")
+                               .EnumerateArray()
+                               .Select(e => e.GetString())
+                               .ToList();
+        keywordValues.ShouldContain("holiday");
+        keywordValues.ShouldContain("vacation");
+    }
+
+    [Fact]
+    public async Task when_importing_then_delete_all_called_before_any_add()
+    {
+        var callOrder = new List<string>();
+        repository.DeleteAllAsync(Arg.Any<CancellationToken>())
+                  .Returns(_ => { callOrder.Add("delete"); return Task.CompletedTask; });
+        repository.AddCategoryAsync(Arg.Any<FileClassificationCategory>(), Arg.Any<CancellationToken>())
+                  .Returns(_ => { callOrder.Add("add"); return Task.FromResult<Result<FileClassificationCategoryId, string>>(new Result<FileClassificationCategoryId, string>.Ok(new FileClassificationCategoryId(1))); });
+
+        var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[]}]}""";
+        fileSystem.File.WriteAllText(ExportFilePath, importJson);
+
+        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+
+        callOrder[0].ShouldBe("delete");
+    }
+
+    [Fact]
+    public async Task when_importing_root_category_then_add_category_called()
+    {
+        var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[]}]}""";
+        fileSystem.File.WriteAllText(ExportFilePath, importJson);
+
+        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+
+        await repository.Received(1).AddCategoryAsync(Arg.Is<FileClassificationCategory>(c => c.Name == "Photos"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_importing_nested_category_then_child_added_with_parent_id()
+    {
+        var parentId = new FileClassificationCategoryId(42);
+        repository.AddCategoryAsync(Arg.Is<FileClassificationCategory>(c => c.Name == "Photos" && c.Level == 1), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<Result<FileClassificationCategoryId, string>>(new Result<FileClassificationCategoryId, string>.Ok(parentId)));
+
+        var importJson = """{"version":1,"categories":[{"name":"Photos","children":[{"name":"Holidays","children":[],"keywords":[]}],"keywords":[]}]}""";
+        fileSystem.File.WriteAllText(ExportFilePath, importJson);
+
+        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+
+        await repository.Received(1).AddCategoryAsync(
+            Arg.Is<FileClassificationCategory>(c => c.Name == "Holidays" && c.ParentId == Option.Some(parentId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_importing_keyword_then_add_keyword_called_for_leaf_category()
+    {
+        var leafCategoryId = new FileClassificationCategoryId(7);
+        repository.AddCategoryAsync(Arg.Is<FileClassificationCategory>(c => c.Name == "Photos"), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<Result<FileClassificationCategoryId, string>>(new Result<FileClassificationCategoryId, string>.Ok(leafCategoryId)));
+        repository.AddKeywordAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<FileClassificationKeyword>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<Result<int, string>>(new Result<int, string>.Ok(1)));
+
+        var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":["holiday","vacation"]}]}""";
+        fileSystem.File.WriteAllText(ExportFilePath, importJson);
+
+        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+
+        await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "holiday"), Arg.Any<CancellationToken>());
+        await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "vacation"), Arg.Any<CancellationToken>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
@@ -2,16 +2,25 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Avalonia.Platform.Storage;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Classifications;
 
 public sealed class GivenAFileClassificationRulesViewModel
 {
     private readonly IFileClassificationRepository repository;
+    private readonly IFileClassificationExportImportService exportImportService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IConfirmationDialogService confirmationDialogService;
 
     public GivenAFileClassificationRulesViewModel()
     {
         repository = Substitute.For<IFileClassificationRepository>();
+        exportImportService = Substitute.For<IFileClassificationExportImportService>();
+        filePickerService = Substitute.For<IFilePickerService>();
+        confirmationDialogService = Substitute.For<IConfirmationDialogService>();
+
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult<IReadOnlyList<FileClassificationCategory>>([]));
         repository.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
@@ -30,7 +39,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -47,7 +56,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -70,7 +79,7 @@ public sealed class GivenAFileClassificationRulesViewModel
                   .Returns(Task.FromResult(categories));
         repository.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(keywords));
-        FileClassificationRulesViewModel sut = new(repository);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -80,7 +89,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_category_persisted_and_added()
     {
-        FileClassificationRulesViewModel sut = new(repository)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService)
         {
             NewCategoryName = "Media"
         };
@@ -94,7 +103,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_new_category_name_cleared()
     {
-        FileClassificationRulesViewModel sut = new(repository)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService)
         {
             NewCategoryName = "Media"
         };
@@ -107,7 +116,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_new_category_name_empty_then_add_category_command_disabled()
     {
-        FileClassificationRulesViewModel sut = new(repository)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService)
         {
             NewCategoryName = string.Empty
         };
@@ -118,7 +127,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_no_categories_then_has_no_categories_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
 
         sut.HasNoCategories.ShouldBeTrue();
     }
@@ -132,10 +141,84 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
 
         await sut.LoadAsync(CancellationToken.None);
 
         sut.HasNoCategories.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_import_command_invoked_and_file_picker_returns_null_then_delete_all_not_called()
+    {
+        IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
+        filePickerService.PickOpenFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                         .Returns(Task.FromResult<string?>(null));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
+
+        await sut.ImportAsync(storageProvider, CancellationToken.None);
+
+        await repository.DidNotReceive().DeleteAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_import_command_invoked_and_confirmation_declined_then_delete_all_not_called()
+    {
+        IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
+        filePickerService.PickOpenFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                         .Returns(Task.FromResult<string?>("/some/file.json"));
+        confirmationDialogService.ConfirmAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                                 .Returns(Task.FromResult(false));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
+
+        await sut.ImportAsync(storageProvider, CancellationToken.None);
+
+        await repository.DidNotReceive().DeleteAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_import_command_invoked_and_confirmed_then_load_async_called_after_import()
+    {
+        IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
+        const string importFilePath = "/some/file.json";
+        filePickerService.PickOpenFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                         .Returns(Task.FromResult<string?>(importFilePath));
+        confirmationDialogService.ConfirmAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                                 .Returns(Task.FromResult(true));
+        exportImportService.ImportAsync(importFilePath, Arg.Any<CancellationToken>())
+                           .Returns(Task.CompletedTask);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
+
+        await sut.ImportAsync(storageProvider, CancellationToken.None);
+
+        await exportImportService.Received(1).ImportAsync(importFilePath, Arg.Any<CancellationToken>());
+        await repository.Received(1).GetAllCategoriesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_export_command_invoked_and_file_picker_returns_null_then_export_not_called()
+    {
+        IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
+        filePickerService.PickSaveFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                         .Returns(Task.FromResult<string?>(null));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
+
+        await sut.ExportAsync(storageProvider, CancellationToken.None);
+
+        await exportImportService.DidNotReceive().ExportAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_export_command_invoked_with_valid_path_then_export_service_called()
+    {
+        IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
+        const string exportFilePath = "/some/export.json";
+        filePickerService.PickSaveFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                         .Returns(Task.FromResult<string?>(exportFilePath));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService);
+
+        await sut.ExportAsync(storageProvider, CancellationToken.None);
+
+        await exportImportService.Received(1).ExportAsync(exportFilePath, Arg.Any<CancellationToken>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -55,7 +55,7 @@ public sealed class GivenAMainWindowViewModel
         repo.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<FileClassificationKeywordEntry>>([]));
 
-        return new FileClassificationRulesViewModel(repo);
+        return new FileClassificationRulesViewModel(repo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>());
     }
 
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -83,7 +83,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
         var settings = new SettingsViewModel(settingsServiceForViewModel, themeServiceForViewModel, schedulerForViewModel, accountRepository, localizationService, Substitute.For<IFolderPickerService>());
         var statusBar = new StatusBarViewModel(accounts, localizationService);
 
-        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo), statusBar, Substitute.For<ILogger<MainWindowViewModel>>());
+        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>()), statusBar, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     private AppBootstrapper CreateSut() => new(dbContextFactory, settingsService, themeService, localizationService, syncScheduler, CreateMainWindowViewModel(), Substitute.For<ILogger<AppBootstrapper>>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -62,7 +62,7 @@ public sealed class GivenAnApplicationInitializer
         repo.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<FileClassificationKeywordEntry>>([]));
 
-        return new FileClassificationRulesViewModel(repo);
+        return new FileClassificationRulesViewModel(repo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>());
     }
 
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
@@ -1,0 +1,99 @@
+using System.IO.Abstractions;
+using System.Text.Json;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+/// <inheritdoc />
+public sealed class FileClassificationExportImportService(IFileClassificationRepository repository, IFileSystem fileSystem) : IFileClassificationExportImportService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
+
+    /// <inheritdoc />
+    public async Task ExportAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var allCategories = await repository.GetAllCategoriesAsync(cancellationToken).ConfigureAwait(false);
+
+        var parentIds = allCategories
+            .Where(c => c.ParentId is Option<FileClassificationCategoryId>.Some)
+            .Select(c => ((Option<FileClassificationCategoryId>.Some)c.ParentId).Value)
+            .ToHashSet();
+
+        var nodesByCategoryId = new Dictionary<FileClassificationCategoryId, ClassificationCategoryNode>();
+        foreach (var category in allCategories)
+            nodesByCategoryId[category.Id] = new ClassificationCategoryNode { Name = category.Name, Children = [], Keywords = [] };
+
+        foreach (var category in allCategories)
+        {
+            bool isLeaf = !parentIds.Contains(category.Id);
+            if (!isLeaf)
+                continue;
+
+            var keywords = await repository.GetKeywordsForCategoryAsync(category.Id, cancellationToken).ConfigureAwait(false);
+            nodesByCategoryId[category.Id].Keywords.AddRange(keywords.Select(k => k.Keyword.Value));
+        }
+
+        var rootNodes = new List<ClassificationCategoryNode>();
+        foreach (var category in allCategories)
+        {
+            var node = nodesByCategoryId[category.Id];
+            if (category.ParentId is Option<FileClassificationCategoryId>.Some someParent && nodesByCategoryId.TryGetValue(someParent.Value, out var parentNode))
+                parentNode.Children.Add(node);
+            else
+                rootNodes.Add(node);
+        }
+
+        var exportRoot = new ClassificationExportRoot { Version = 1, Categories = rootNodes };
+        string json = JsonSerializer.Serialize(exportRoot, SerializerOptions);
+        fileSystem.File.WriteAllText(filePath, json);
+    }
+
+    /// <inheritdoc />
+    public async Task ImportAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        string json = fileSystem.File.ReadAllText(filePath);
+        var exportRoot = JsonSerializer.Deserialize<ClassificationExportRoot>(json, SerializerOptions);
+        if (exportRoot is null)
+            return;
+
+        await repository.DeleteAllAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var node in exportRoot.Categories)
+            await InsertNodeAsync(node, 1, Option.None<FileClassificationCategoryId>(), cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertNodeAsync(ClassificationCategoryNode node, int level, Option<FileClassificationCategoryId> parentId, CancellationToken cancellationToken)
+    {
+        var placeholder = new FileClassificationCategoryId(0);
+        var categoryResult = FileClassificationCategoryFactory.Create(placeholder, node.Name, level, parentId);
+        if (categoryResult is not Result<FileClassificationCategory, string>.Ok okCategory)
+            return;
+
+        var addResult = await repository.AddCategoryAsync(okCategory.Value, cancellationToken).ConfigureAwait(false);
+        if (addResult is not Result<FileClassificationCategoryId, string>.Ok okId)
+            return;
+
+        FileClassificationCategoryId newId = okId.Value;
+
+        foreach (var child in node.Children)
+            await InsertNodeAsync(child, level + 1, Option.Some(newId), cancellationToken).ConfigureAwait(false);
+
+        foreach (string keyword in node.Keywords)
+            await repository.AddKeywordAsync(newId, new FileClassificationKeyword(keyword, Option.None<bool>()), cancellationToken).ConfigureAwait(false);
+    }
+}
+
+internal sealed record ClassificationExportRoot
+{
+    public int Version { get; init; }
+    public List<ClassificationCategoryNode> Categories { get; init; } = [];
+}
+
+internal sealed record ClassificationCategoryNode
+{
+    public string Name { get; init; } = string.Empty;
+    public List<ClassificationCategoryNode> Children { get; set; } = [];
+    public List<string> Keywords { get; set; } = [];
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -2,6 +2,8 @@ using System.Collections.ObjectModel;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -11,10 +13,16 @@ namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
 public sealed partial class FileClassificationRulesViewModel : ObservableObject
 {
     private readonly IFileClassificationRepository repository;
+    private readonly IFileClassificationExportImportService exportImportService;
+    private readonly IFilePickerService filePickerService;
+    private readonly IConfirmationDialogService confirmationDialogService;
 
-    public FileClassificationRulesViewModel(IFileClassificationRepository repository)
+    public FileClassificationRulesViewModel(IFileClassificationRepository repository, IFileClassificationExportImportService exportImportService, IFilePickerService filePickerService, IConfirmationDialogService confirmationDialogService)
     {
         this.repository = repository;
+        this.exportImportService = exportImportService;
+        this.filePickerService = filePickerService;
+        this.confirmationDialogService = confirmationDialogService;
         Categories.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasNoCategories));
     }
 
@@ -62,6 +70,31 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
             foreach (var entry in keywords)
                 leafNode.Keywords.Add(new KeywordRowViewModel(entry.Id, entry.Keyword, repository, self => leafNode.Keywords.Remove(self)));
         }
+    }
+
+    /// <summary>Exports the current taxonomy to a user-selected JSON file.</summary>
+    public async Task ExportAsync(IStorageProvider storageProvider, CancellationToken ct = default)
+    {
+        var path = await filePickerService.PickSaveFileAsync(storageProvider, "Export classifications", "classifications.json", "json", ct).ConfigureAwait(false);
+        if (path is null)
+            return;
+
+        await exportImportService.ExportAsync(path, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Imports a taxonomy from a user-selected JSON file, replacing all existing data after confirmation.</summary>
+    public async Task ImportAsync(IStorageProvider storageProvider, CancellationToken ct = default)
+    {
+        var path = await filePickerService.PickOpenFileAsync(storageProvider, "Import classifications", "json", ct).ConfigureAwait(false);
+        if (path is null)
+            return;
+
+        bool confirmed = await confirmationDialogService.ConfirmAsync("Import classifications", "This will delete ALL classifications. Continue?", ct).ConfigureAwait(false);
+        if (!confirmed)
+            return;
+
+        await exportImportService.ImportAsync(path, ct).ConfigureAwait(false);
+        await LoadAsync(ct).ConfigureAwait(false);
     }
 
     private bool CanAddCategory => !string.IsNullOrWhiteSpace(NewCategoryName);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml
@@ -7,18 +7,39 @@
              HorizontalContentAlignment="Stretch">
 
     <Grid RowDefinitions="Auto,*">
-        <StackPanel Grid.Row="0"
-                    Spacing="4"
-                    Margin="24,20,24,12">
-            <TextBlock Text="File classifications"
-                       FontSize="{StaticResource FontSizeXl}"
-                       FontWeight="Medium"
-                       Foreground="{DynamicResource TextPrimaryBrush}"/>
-            <TextBlock Text="Manage the category hierarchy and keywords used to classify files during sync."
-                       FontSize="{StaticResource FontSizeSm}"
-                       Foreground="{DynamicResource TextTertiaryBrush}"
-                       TextWrapping="Wrap"/>
-        </StackPanel>
+        <Grid Grid.Row="0"
+              ColumnDefinitions="*,Auto"
+              Margin="24,20,24,12">
+            <StackPanel Grid.Column="0"
+                        Spacing="4">
+                <TextBlock Text="File classifications"
+                           FontSize="{StaticResource FontSizeXl}"
+                           FontWeight="Medium"
+                           Foreground="{DynamicResource TextPrimaryBrush}"/>
+                <TextBlock Text="Manage the category hierarchy and keywords used to classify files during sync."
+                           FontSize="{StaticResource FontSizeSm}"
+                           Foreground="{DynamicResource TextTertiaryBrush}"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                <Button Content="Export"
+                        Padding="8,4"
+                        CornerRadius="{StaticResource RadiusMd}"
+                        Background="Transparent"
+                        BorderBrush="{DynamicResource BorderDefaultBrush}"
+                        BorderThickness="1"
+                        FontSize="{StaticResource FontSizeSm}"
+                        Click="OnExportClick"/>
+                <Button Content="Import"
+                        Padding="8,4"
+                        CornerRadius="{StaticResource RadiusMd}"
+                        Background="{DynamicResource TextAccentBrush}"
+                        Foreground="White"
+                        BorderThickness="0"
+                        FontSize="{StaticResource FontSizeSm}"
+                        Click="OnImportClick"/>
+            </StackPanel>
+        </Grid>
 
         <ScrollViewer Grid.Row="1"
                       VerticalScrollBarVisibility="Auto"

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationsView.axaml.cs
@@ -1,8 +1,33 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
 
 public partial class FileClassificationsView : UserControl
 {
     public FileClassificationsView() => InitializeComponent();
+
+    private async void OnExportClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not FileClassificationRulesViewModel vm)
+            return;
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is null)
+            return;
+
+        await vm.ExportAsync(topLevel.StorageProvider);
+    }
+
+    private async void OnImportClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not FileClassificationRulesViewModel vm)
+            return;
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is null)
+            return;
+
+        await vm.ImportAsync(topLevel.StorageProvider);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileClassificationExportImportService.cs
@@ -1,0 +1,11 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+/// <summary>Exports and imports the file classification taxonomy to/from a JSON file.</summary>
+public interface IFileClassificationExportImportService
+{
+    /// <summary>Serializes the current taxonomy to a JSON file at <paramref name="filePath"/>.</summary>
+    Task ExportAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>Reads a JSON taxonomy file and replaces ALL existing categories and keywords.</summary>
+    Task ImportAsync(string filePath, CancellationToken cancellationToken = default);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
@@ -178,6 +178,15 @@ public sealed class FileClassificationRepository(IDbContextFactory<AppDbContext>
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    public async Task DeleteAllAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        db.FileClassificationKeywords.RemoveRange(db.FileClassificationKeywords);
+        db.FileClassificationCategories.RemoveRange(db.FileClassificationCategories);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     private static KeywordMapping BuildKeywordMapping(FileClassificationKeywordEntity keyword, Dictionary<int, FileClassificationCategoryEntity> categoryById)
     {
         var ancestorNames = new Dictionary<int, string>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/IFileClassificationRepository.cs
@@ -32,4 +32,7 @@ public interface IFileClassificationRepository
 
     /// <summary>Deletes a keyword. No-op if the keyword does not exist.</summary>
     Task DeleteKeywordAsync(int keywordId, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes all keywords and all categories. Used before importing a new taxonomy.</summary>
+    Task DeleteAllAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
@@ -1,0 +1,62 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+/// <inheritdoc />
+public sealed class AvaloniaConfirmationDialogService : IConfirmationDialogService
+{
+    /// <inheritdoc />
+    public async Task<bool> ConfirmAsync(string title, string message, CancellationToken ct = default)
+    {
+        var mainWindow = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+        if (mainWindow is null)
+            return false;
+
+        var tcs = new TaskCompletionSource<bool>();
+
+        var messageBlock = new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 16)
+        };
+
+        var cancelButton = new Button { Content = "Cancel", Margin = new Thickness(0, 0, 8, 0) };
+        var yesButton = new Button { Content = "Yes" };
+
+        var buttonRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Children = { cancelButton, yesButton }
+        };
+
+        var content = new StackPanel
+        {
+            Margin = new Thickness(24),
+            Children = { messageBlock, buttonRow }
+        };
+
+        var dialog = new Window
+        {
+            Title = title,
+            Content = content,
+            Width = 400,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false
+        };
+
+        cancelButton.Click += (_, _) => { tcs.SetResult(false); dialog.Close(); };
+        yesButton.Click += (_, _) => { tcs.SetResult(true); dialog.Close(); };
+        dialog.Closed += (_, _) => tcs.TrySetResult(false);
+
+        await dialog.ShowDialog(mainWindow).ConfigureAwait(false);
+
+        return await tcs.Task.ConfigureAwait(false);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaFilePickerService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaFilePickerService.cs
@@ -1,0 +1,33 @@
+using Avalonia.Platform.Storage;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+/// <inheritdoc />
+public sealed class AvaloniaFilePickerService : IFilePickerService
+{
+    /// <inheritdoc />
+    public async Task<string?> PickSaveFileAsync(IStorageProvider storageProvider, string title, string suggestedName, string extensionFilter, CancellationToken ct = default)
+    {
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = title,
+            SuggestedFileName = suggestedName,
+            FileTypeChoices = [new FilePickerFileType(extensionFilter.ToUpperInvariant()) { Patterns = [$"*.{extensionFilter}"] }]
+        }).ConfigureAwait(false);
+
+        return file?.Path?.LocalPath;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> PickOpenFileAsync(IStorageProvider storageProvider, string title, string extensionFilter, CancellationToken ct = default)
+    {
+        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false,
+            FileTypeFilter = [new FilePickerFileType(extensionFilter.ToUpperInvariant()) { Patterns = [$"*.{extensionFilter}"] }]
+        }).ConfigureAwait(false);
+
+        return files is [{ } file] ? file.Path?.LocalPath : null;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IConfirmationDialogService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IConfirmationDialogService.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+/// <summary>Abstracts platform-level confirmation dialogs to keep consumers testable without Avalonia infrastructure.</summary>
+public interface IConfirmationDialogService
+{
+    /// <summary>Shows a yes/no confirmation dialog. Returns <c>true</c> if the user confirmed; <c>false</c> if cancelled or denied.</summary>
+    Task<bool> ConfirmAsync(string title, string message, CancellationToken ct = default);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFilePickerService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFilePickerService.cs
@@ -1,0 +1,13 @@
+using Avalonia.Platform.Storage;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+/// <summary>Abstracts platform-level file picking to keep consumers testable without Avalonia infrastructure.</summary>
+public interface IFilePickerService
+{
+    /// <summary>Opens a save-file dialog and returns the selected path, or <c>null</c> if the user cancelled.</summary>
+    Task<string?> PickSaveFileAsync(IStorageProvider storageProvider, string title, string suggestedName, string extensionFilter, CancellationToken ct = default);
+
+    /// <summary>Opens an open-file dialog and returns the selected path, or <c>null</c> if the user cancelled.</summary>
+    Task<string?> PickOpenFileAsync(IStorageProvider storageProvider, string title, string extensionFilter, CancellationToken ct = default);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
@@ -63,6 +64,9 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<ISyncPipeline, ParallelSyncPipeline>();
         _ = services.AddSingleton<IAppBootstrapper, AppBootstrapper>();
         _ = services.AddSingleton<IFileAutoCategorisor, RuleBasedFileAutoCategorisor>();
+        _ = services.AddSingleton<IFilePickerService, AvaloniaFilePickerService>();
+        _ = services.AddSingleton<IConfirmationDialogService, AvaloniaConfirmationDialogService>();
+        _ = services.AddSingleton<IFileClassificationExportImportService, FileClassificationExportImportService>();
         _ = services.AddOneDriveClient();
 
         return services;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.3.0",
+    "ApplicationVersion": "0.4.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
## Summary

- Adds **Export** and **Import** buttons to the File Classifications view header (right-aligned)
- Export serialises the full category/keyword taxonomy to a user-selected `.json` file
- Import reads a JSON file, shows a confirmation dialog ("This will delete ALL classifications. Continue?"), wipes all existing data, then re-inserts depth-first
- `ApplicationVersion` bumped to `0.4.0`

### New types
- `IFileClassificationExportImportService` / `FileClassificationExportImportService` — export/import logic via `IFileSystem`
- `IFilePickerService` / `AvaloniaFilePickerService` — save/open file dialogs
- `IConfirmationDialogService` / `AvaloniaConfirmationDialogService` — programmatic yes/no dialog Window
- `IFileClassificationRepository.DeleteAllAsync` — wipes keywords then categories in one DbContext scope

Closes #467

## Test plan

- [ ] Unit: 1396 passed, 0 failed — export produces correct nested JSON; import calls `DeleteAllAsync` before insert; ViewModel aborts on null path or declined confirmation
- [ ] Integration: 26 passed, 0 failed — `DeleteAllAsync` removes all categories and keywords; no error on empty DB
- [ ] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)