### PR TITLE
feat(onedrive-sync-client): persist IsSpecialOverride for file classification keywords (#466)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenAFileClassificationRepository.cs
@@ -238,4 +238,108 @@ public sealed class GivenAFileClassificationRepository(IntegrationTestFixture fi
 
         exception.ShouldBeNull();
     }
+
+    [Fact]
+    public async Task when_adding_a_keyword_with_is_special_override_true_then_retrieved_keyword_has_is_special_override_some_true()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.Some(true))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldContain(k => k.Keyword.IsSpecialOverride == Option.Some(true));
+    }
+
+    [Fact]
+    public async Task when_adding_a_keyword_with_is_special_override_false_then_retrieved_keyword_has_is_special_override_some_false()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("receipt", Option.Some(false))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldContain(k => k.Keyword.IsSpecialOverride == Option.Some(false));
+    }
+
+    [Fact]
+    public async Task when_adding_a_keyword_with_is_special_override_none_then_retrieved_keyword_has_is_special_override_some_false()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("statement", Option.None<bool>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.AddKeywordAsync(categoryId, keyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldContain(k => k.Keyword.IsSpecialOverride == Option.Some(false));
+    }
+
+    [Fact]
+    public async Task when_updating_a_keyword_to_is_special_override_true_then_retrieved_keyword_has_is_special_override_some_true()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.Some(false))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordId = await repository.AddKeywordAsync(categoryId, keyword, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var updatedKeyword = FileClassificationKeywordFactory.Create("invoice", Option.Some(true))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.UpdateKeywordAsync(keywordId, updatedKeyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldContain(k => k.Keyword.IsSpecialOverride == Option.Some(true));
+    }
+
+    [Fact]
+    public async Task when_updating_a_keyword_to_is_special_override_false_then_retrieved_keyword_has_is_special_override_some_false()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repository = fixture.Services.GetRequiredService<IFileClassificationRepository>();
+        var placeholder = new FileClassificationCategoryId(0);
+        var category = FileClassificationCategoryFactory.Create(placeholder, "Finance", 1, Option.None<FileClassificationCategoryId>())
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var categoryId = await repository.AddCategoryAsync(category, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var keyword = FileClassificationKeywordFactory.Create("invoice", Option.Some(true))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+        var keywordId = await repository.AddKeywordAsync(categoryId, keyword, ct)
+            .MatchAsync(ok => ok, err => throw new InvalidOperationException(err));
+        var updatedKeyword = FileClassificationKeywordFactory.Create("invoice", Option.Some(false))
+            .Match(ok => ok, err => throw new InvalidOperationException(err));
+
+        await repository.UpdateKeywordAsync(keywordId, updatedKeyword, ct);
+
+        var keywords = await repository.GetKeywordsForCategoryAsync(categoryId, ct);
+        keywords.ShouldContain(k => k.Keyword.IsSpecialOverride == Option.Some(false));
+    }
 }
+

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/CLAUDE.md
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/CLAUDE.md
@@ -1,0 +1,9 @@
+# Rules for Updates
+
+## BugFix
+
+When a bug is fixed, the `appsettings.json` must be update so the `AStarDevOneDriveClient > ApplicationVersion` changes: old ApplicationVersion: 0.3.3, after bug fix: ApplicationVersion: 0.3.4
+
+## Feature
+
+When a feature is implemented, the `appsettings.json` must be update so the `AStarDevOneDriveClient > ApplicationVersion` changes: old ApplicationVersion: 0.3.3, after bug fix: ApplicationVersion: 0.4.0

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationKeywordEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/FileClassificationKeywordEntityConfiguration.cs
@@ -12,6 +12,7 @@ public sealed class FileClassificationKeywordEntityConfiguration : IEntityTypeCo
     {
         _ = builder.HasKey(e => e.Id);
         _ = builder.Property(e => e.Keyword).IsRequired();
+        _ = builder.Property(e => e.IsSpecial).IsRequired();
         _ = builder.HasOne(e => e.Category).WithMany(e => e.Keywords).HasForeignKey(e => e.CategoryId).OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationKeywordEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/FileClassificationKeywordEntity.cs
@@ -12,6 +12,9 @@ public sealed class FileClassificationKeywordEntity
     /// <summary>FK to the owning category.</summary>
     public int CategoryId { get; set; }
 
+    /// <summary>Whether this keyword overrides the special classification flag.</summary>
+    public bool IsSpecial { get; set; }
+
     /// <summary>Navigation to the owning category.</summary>
     public FileClassificationCategoryEntity? Category { get; set; }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260606195335_AddIsSpecialToFileClassificationKeyword.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260606195335_AddIsSpecialToFileClassificationKeyword.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606195335_AddIsSpecialToFileClassificationKeyword")]
+    partial class AddIsSpecialToFileClassificationKeyword
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260606195335_AddIsSpecialToFileClassificationKeyword.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260606195335_AddIsSpecialToFileClassificationKeyword.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsSpecialToFileClassificationKeyword : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSpecial",
+                table: "FileClassificationKeywords",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSpecial",
+                table: "FileClassificationKeywords");
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/FileClassificationRepository.cs
@@ -39,7 +39,7 @@ public sealed class FileClassificationRepository(IDbContextFactory<AppDbContext>
             .ConfigureAwait(false);
 
         return entities
-            .Select(e => new FileClassificationKeywordEntry(e.Id, new FileClassificationKeyword(e.Keyword, Option.None<bool>())))
+            .Select(e => new FileClassificationKeywordEntry(e.Id, new FileClassificationKeyword(e.Keyword, Option.Some(e.IsSpecial))))
             .ToList()
             .AsReadOnly();
     }
@@ -134,7 +134,8 @@ public sealed class FileClassificationRepository(IDbContextFactory<AppDbContext>
         var entity = new FileClassificationKeywordEntity
         {
             Keyword = keyword.Value,
-            CategoryId = rawCategoryId
+            CategoryId = rawCategoryId,
+            IsSpecial = keyword.IsSpecialOverride.Match(v => v, () => false)
         };
 
         db.FileClassificationKeywords.Add(entity);
@@ -160,6 +161,7 @@ public sealed class FileClassificationRepository(IDbContextFactory<AppDbContext>
             return new Result<int, string>.Error("Cannot update keyword on a non-leaf category.");
 
         entity.Keyword = keyword.Value;
+        entity.IsSpecial = keyword.IsSpecialOverride.Match(v => v, () => false);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return new Result<int, string>.Ok(entity.Id);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.4.0",
+    "ApplicationVersion": "0.5.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Persists `IsSpecialOverride` on `FileClassificationKeyword` to the database. Previously the flag was shown in the UI (badge + checkbox) but silently dropped on every save/load cycle.

## Type of change

- [x] Feature

## Related issues / links

Closes #466

## How was this tested?

- [x] Unit tests added/updated

5 new integration tests covering round-trip persistence:
- Add with `IsSpecialOverride = Some(true)` → retrieves `Some(true)`
- Add with `IsSpecialOverride = Some(false)` → retrieves `Some(false)`
- Add with `IsSpecialOverride = None` → retrieves `Some(false)` (None normalised to false)
- Update to `Some(true)` → retrieves `Some(true)`
- Update to `Some(false)` → retrieves `Some(false)`

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 31/31 pass, 0 warnings
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/
```

---

## Notes for reviewers

- Migration `AddIsSpecialToFileClassificationKeyword` adds `IsSpecial bool NOT NULL DEFAULT 0` — safe for existing rows (defaults to `false`).
- `None<bool>()` on insert/update normalises to `false`; reads always return `Some(bool)` since the column is now always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)