### PR TITLE
fix(onedrive-sync-client): marshal confirmation dialog to UI thread (#470)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Threading;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
@@ -11,6 +12,9 @@ public sealed class AvaloniaConfirmationDialogService : IConfirmationDialogServi
 {
     /// <inheritdoc />
     public async Task<bool> ConfirmAsync(string title, string message, CancellationToken ct = default)
+        => await Dispatcher.UIThread.InvokeAsync(() => ShowDialogAsync(title, message, ct));
+
+    private static async Task<bool> ShowDialogAsync(string title, string message, CancellationToken ct)
     {
         var mainWindow = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
         if (mainWindow is null)
@@ -54,6 +58,8 @@ public sealed class AvaloniaConfirmationDialogService : IConfirmationDialogServi
         cancelButton.Click += (_, _) => { tcs.SetResult(false); dialog.Close(); };
         yesButton.Click += (_, _) => { tcs.SetResult(true); dialog.Close(); };
         dialog.Closed += (_, _) => tcs.TrySetResult(false);
+
+        ct.Register(() => { tcs.TrySetResult(false); dialog.Close(); });
 
         await dialog.ShowDialog(mainWindow).ConfigureAwait(false);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.5.0",
+    "ApplicationVersion": "0.5.1",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
## Summary

- `AvaloniaConfirmationDialogService.ConfirmAsync` was constructing Avalonia UI objects (`Window`, `TextBlock`, `Button`, `StackPanel`) on a thread-pool thread after a `ConfigureAwait(false)` continuation in `FileClassificationRulesViewModel.ImportAsync`
- Avalonia forbids UI object creation off the UI thread → `InvalidOperationException: The calling thread cannot access this object because a different thread owns it`
- Fix: extracted dialog construction into `ShowDialogAsync` and wraps the call in `Dispatcher.UIThread.InvokeAsync`; also wires `CancellationToken` to close the dialog if cancelled

## Test plan

- [ ] Import classifications → file picker opens, confirmation dialog appears after file selected, import proceeds on confirm / cancels on dismiss
- [ ] `dotnet build` — 0 errors, 0 warnings ✅
- [ ] `dotnet test` — 1396 passed, 0 failed ✅

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)