### PR TITLE
fix(onedrive-sync-client): prevent spurious Unclassified entry on keyword-matched files (#480)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/FileClassification/GivenFileAutoCategorisor.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Integration.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,42 +12,42 @@ public sealed class GivenFileAutoCategorisor(IntegrationTestFixture fixture) : I
     private const string RootPrefix = "a/b/c/d/e/f/g";
 
     [Fact]
-    public void when_path_contains_documents_token_then_level1_is_documents()
+    public void when_path_contains_documents_token_then_result_is_none()
     {
         var categorisor = fixture.Services.GetRequiredService<IFileAutoCategorisor>();
 
-        var classification = categorisor.Categorise($"{RootPrefix}/Documents/report.pdf");
+        var result = categorisor.Categorise($"{RootPrefix}/Documents/report.pdf");
 
-        classification.Level1.ShouldBe("Unclassified");
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
-    public void when_path_contains_photos_token_then_level1_is_photos()
+    public void when_path_contains_photos_token_with_no_colour_or_person_then_result_is_none()
     {
         var categorisor = fixture.Services.GetRequiredService<IFileAutoCategorisor>();
 
-        var classification = categorisor.Categorise($"{RootPrefix}/Photos/holiday.jpg");
+        var result = categorisor.Categorise($"{RootPrefix}/Photos/holiday.jpg");
 
-        classification.Level1.ShouldBe("Unclassified");
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
-    public void when_path_is_empty_then_level1_is_uncategorised()
+    public void when_path_is_empty_then_result_is_none()
     {
         var categorisor = fixture.Services.GetRequiredService<IFileAutoCategorisor>();
 
-        var classification = categorisor.Categorise(string.Empty);
+        var result = categorisor.Categorise(string.Empty);
 
-        classification.Level1.ShouldNotBeNullOrWhiteSpace();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
-    public void when_path_contains_no_known_tokens_then_level1_is_uncategorised()
+    public void when_path_contains_no_known_tokens_then_result_is_none()
     {
         var categorisor = fixture.Services.GetRequiredService<IFileAutoCategorisor>();
 
-        var classification = categorisor.Categorise($"{RootPrefix}/Unknown/xyz123.txt");
+        var result = categorisor.Categorise($"{RootPrefix}/Unknown/xyz123.txt");
 
-        classification.Level1.ShouldBe("Unclassified");
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/SyncPipeline/GivenSyncedItemRegistrar_WhenRegisteringPhantomFiles.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/SyncPipeline/GivenSyncedItemRegistrar_WhenRegisteringPhantomFiles.cs
@@ -53,7 +53,7 @@ public sealed class GivenSyncedItemRegistrar_WhenRegisteringPhantomFiles(Integra
 
         await registrar.RegisterPhantomAsync(accountId, BuildFileItem("phantom-id-autocategorise"), remotePath, "/local/phantom-autocat/test.txt", [], CancellationToken.None);
 
-        var expectedLevel1 = categorisor.Categorise(remotePath).Level1;
+        var expectedLevel1 = categorisor.Categorise(remotePath).Match(c => c.Level1, () => "Unclassified");
         var items = await repository.GetAllByAccountAsync(accountId, CancellationToken.None);
         var classifications = await GetClassificationsAsync(items["phantom-id-autocategorise"].Id);
         classifications.ShouldContain(c => c.Level1 == expectedLevel1);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAClassificationCombiner.cs
@@ -100,4 +100,14 @@ public sealed class GivenAClassificationCombiner
         result.ShouldHaveSingleItem();
         result[0].ShouldBe(ruleVersion);
     }
+
+    [Fact]
+    public void when_rule_results_have_match_and_analyser_result_is_empty_then_no_unclassified_entry_in_result()
+    {
+        IReadOnlyList<FileClassification> ruleResults = [AnyRuleClassification];
+
+        var result = ClassificationCombiner.Combine(ruleResults, []);
+
+        result.ShouldNotContain(c => c.Level1 == "Unclassified");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
@@ -10,105 +10,117 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     [Fact]
     public void when_categorise_called_with_photos_red_car_path_then_level1_is_color()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Color");
+        classification.Level1.ShouldBe("Color");
     }
 
     [Fact]
     public void when_categorise_called_with_people_person_name_path_then_level1_is_person()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Person");
+        classification.Level1.ShouldBe("Person");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_car_path_then_level2_is_red()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
     }
 
     [Fact]
     public void when_categorise_called_with_people_person_name_path_then_level2_is_john_smith()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_car_path_then_level3_is_red_car()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_dress_path_then_level3_is_red_dress()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
     }
 
     [Fact]
     public void when_categorise_called_with_misc_red_path_then_level3_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
     public void when_categorise_called_with_people_person_name_path_then_level3_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_car_path_then_full_classification_is_correct()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
+        classification.Level1.ShouldBe("Color");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Car");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_dress_path_then_full_classification_is_correct()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red dress on the floor.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
+        classification.Level1.ShouldBe("Color");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Red Dress");
     }
 
     [Fact]
     public void when_categorise_called_with_misc_red_path_then_full_classification_is_correct()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Color");
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level1.ShouldBe("Color");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Red");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
     public void when_categorise_called_with_people_person_name_path_then_full_classification_is_correct()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Person");
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level1.ShouldBe("Person");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
@@ -118,12 +130,11 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     }
 
     [Fact]
-    public void when_categorise_called_with_empty_path_then_returns_valid_classification()
+    public void when_categorise_called_with_empty_path_then_returns_none()
     {
-        FileClassification result = sut.Categorise(string.Empty);
+        Option<FileClassification> result = sut.Categorise(string.Empty);
 
-        result.ShouldNotBeNull();
-        result.Level1.ShouldNotBeNullOrWhiteSpace();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
@@ -133,12 +144,11 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     }
 
     [Fact]
-    public void when_categorise_called_with_only_root_segments_then_returns_valid_classification()
+    public void when_categorise_called_with_only_root_segments_then_returns_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g");
 
-        result.ShouldNotBeNull();
-        result.Level1.ShouldNotBeNullOrWhiteSpace();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
@@ -150,185 +160,204 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     [Fact]
     public void when_categorise_called_with_no_meaningful_tokens_then_level2_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBeNull();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_categorise_called_with_no_meaningful_tokens_then_level3_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_categorise_called_with_photos_red_car_path_then_is_special_is_false()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.IsSpecial.ShouldBeFalse();
+        classification.IsSpecial.ShouldBeFalse();
     }
 
     [Fact]
     public void when_categorise_called_with_people_person_name_path_then_is_special_is_false()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/a file with a persons name: john smith - in it.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.IsSpecial.ShouldBeFalse();
+        classification.IsSpecial.ShouldBeFalse();
     }
 
     [Fact]
     public void when_categorise_called_with_empty_path_then_is_special_is_false()
     {
-        FileClassification result = sut.Categorise(string.Empty);
+        Option<FileClassification> result = sut.Categorise(string.Empty);
 
-        result.IsSpecial.ShouldBeFalse();
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
     public void when_categorise_called_with_places_folder_path_then_level1_is_place()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Places/a scenic lake view.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Places/a scenic lake view.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Place");
+        classification.Level1.ShouldBe("Place");
     }
 
     [Fact]
     public void when_categorise_called_with_landscapes_folder_path_then_level1_is_place()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Landscapes/a scenic lake view.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Landscapes/a scenic lake view.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Place");
+        classification.Level1.ShouldBe("Place");
     }
 
     [Fact]
     public void when_categorise_called_with_events_folder_path_then_level1_is_event()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Events/birthday party.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Events/birthday party.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Event");
+        classification.Level1.ShouldBe("Event");
     }
 
     [Fact]
     public void when_categorise_called_with_portraits_folder_path_then_level1_is_person()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Portraits/a file with a persons name: jane doe.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Portraits/a file with a persons name: jane doe.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Person");
+        classification.Level1.ShouldBe("Person");
     }
 
     [Fact]
     public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level1_is_person()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Person");
+        classification.Level1.ShouldBe("Person");
     }
 
     [Fact]
     public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level2_is_person_name_not_colour()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("John Smith");
     }
 
     [Fact]
     public void when_categorise_called_with_people_folder_and_colour_in_filename_then_level3_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/People/john smith blue shirt.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
     public void when_categorise_called_with_unknown_folder_and_person_name_in_filename_then_level1_is_person()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Uncategorised/jane doe portrait.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Uncategorised/jane doe portrait.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Person");
+        classification.Level1.ShouldBe("Person");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_blue_car_path_then_level1_is_color()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level1.ShouldBe("Color");
+        classification.Level1.ShouldBe("Color");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_blue_car_path_then_level2_is_blue()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_blue_car_path_then_level3_is_blue_car()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a blue car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Blue Car");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Blue Car");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_green_hat_path_then_level2_is_green()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Green");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Green");
     }
 
     [Fact]
     public void when_categorise_called_with_photos_green_hat_path_then_level3_is_green_hat()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a green hat on the table.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBe("Green Hat");
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBe("Green Hat");
     }
 
     [Fact]
     public void when_categorise_called_with_colour_only_filename_then_level2_is_colour()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
+        classification.Level2.Match(v => (string?)v, () => null).ShouldBe("Blue");
     }
 
     [Fact]
     public void when_categorise_called_with_colour_only_filename_then_level3_is_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Misc/blue.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
+        classification.Level3.Match(v => (string?)v, () => null).ShouldBeNull();
     }
 
     [Fact]
     public void when_tag_name_requested_and_level3_is_present_then_tag_name_is_level3()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/a red car on the road.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.TagName.ShouldBe("Red Car");
+        classification.TagName.ShouldBe("Red Car");
     }
 
     [Fact]
     public void when_tag_name_requested_and_level3_is_absent_and_level2_is_present_then_tag_name_is_level2()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Misc/a file with red in it's name.jpg");
+        FileClassification classification = result.Match(c => c, () => throw new InvalidOperationException("Expected Some"));
 
-        result.TagName.ShouldBe("Red");
+        classification.TagName.ShouldBe("Red");
     }
 
     [Fact]
-    public void when_tag_name_requested_and_level2_and_level3_are_absent_then_tag_name_is_level1()
+    public void when_tag_name_requested_and_level2_and_level3_are_absent_then_returns_none()
     {
-        FileClassification result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
 
-        result.TagName.ShouldBe(result.Level1);
+        result.Match(_ => false, () => true).ShouldBeTrue();
     }
 
     [Fact]
@@ -343,6 +372,14 @@ public sealed class GivenARuleBasedFileAutoCategorisor
     public void when_categorise_called_with_generic_path_and_no_keyword_match_then_returns_none()
     {
         Option<FileClassification> result = sut.Categorise("path/to/generic/file.jpg");
+
+        result.Match(_ => false, () => true).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_photos_folder_and_no_colour_or_person_in_filename_then_returns_none()
+    {
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/Photos/img001.jpg");
 
         result.Match(_ => false, () => true).ShouldBeTrue();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenARuleBasedFileAutoCategorisor.cs
@@ -330,4 +330,20 @@ public sealed class GivenARuleBasedFileAutoCategorisor
 
         result.TagName.ShouldBe(result.Level1);
     }
+
+    [Fact]
+    public void when_categorise_called_with_no_meaningful_tokens_then_returns_none()
+    {
+        Option<FileClassification> result = sut.Categorise("a/b/c/d/e/f/g/a/the.jpg");
+
+        result.Match(_ => false, () => true).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_categorise_called_with_generic_path_and_no_keyword_match_then_returns_none()
+    {
+        Option<FileClassification> result = sut.Categorise("path/to/generic/file.jpg");
+
+        result.Match(_ => false, () => true).ShouldBeTrue();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/IFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/IFileAutoCategorisor.cs
@@ -1,8 +1,10 @@
+using AStar.Dev.Functional.Extensions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 
 /// <summary>Derives a <see cref="FileClassification"/> from a full remote file path.</summary>
 public interface IFileAutoCategorisor
 {
-    /// <summary>Derives a <see cref="FileClassification"/> from a full remote file path.</summary>
-    FileClassification Categorise(string remotePath);
+    /// <summary>Derives a <see cref="FileClassification"/> from a full remote file path, or <see cref="Option.None{T}"/> when no meaningful classification can be determined.</summary>
+    Option<FileClassification> Categorise(string remotePath);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RuleBasedFileAutoCategorisor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/RuleBasedFileAutoCategorisor.cs
@@ -10,7 +10,7 @@ public sealed partial class RuleBasedFileAutoCategorisor : IFileAutoCategorisor
     private static partial Regex NonAlphaPattern();
 
     /// <inheritdoc />
-    public FileClassification Categorise(string remotePath)
+    public Option<FileClassification> Categorise(string remotePath)
     {
         string strippedPath = PathNormaliser.StripRootPath(remotePath);
         IReadOnlyList<string> folderSegments = PathNormaliser.GetFolderSegments(strippedPath);
@@ -18,9 +18,13 @@ public sealed partial class RuleBasedFileAutoCategorisor : IFileAutoCategorisor
         List<string> tokens = Tokenise(filenameStem);
 
         string level1 = DeriveLevel1(folderSegments, filenameStem, tokens);
+
+        if (level1 == "Unclassified")
+            return Option.None<FileClassification>();
+
         (Option<string> level2, Option<string> level3) = DeriveLevel2AndLevel3(filenameStem, tokens);
 
-        return FileClassificationFactory.Create(level1, level2, level3, isSpecial: false);
+        return Option.Some(FileClassificationFactory.Create(level1, level2, level3, isSpecial: false));
     }
 
     private static string DeriveLevel1(IReadOnlyList<string> folderSegments, string filenameStem, IReadOnlyList<string> tokens)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -28,7 +29,8 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
         int syncedItemId = await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
 
         var mappings = await classificationRepository.GetAllKeywordMappingsAsync(ct);
-        var classifications = ClassificationCombiner.Combine(FileClassifier.Classify(remotePath, mappings), [fileAutoCategorisor.Categorise(remotePath)]);
+        var analyserResult = fileAutoCategorisor.Categorise(remotePath);
+        var classifications = ClassificationCombiner.Combine(FileClassifier.Classify(remotePath, mappings), analyserResult.Match(c => (IReadOnlyList<FileClassification>)[c], () => []));
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
         syncedItems[item.Id.Id] = phantomItem;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -67,7 +67,8 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
 
     private async Task ClassifyAsync(int syncedItemId, string remotePath, IReadOnlyList<KeywordMapping> mappings, CancellationToken ct)
     {
-        var classifications = ClassificationCombiner.Combine(FileClassifier.Classify(remotePath, mappings), [fileAutoCategorisor.Categorise(remotePath)]);
+        var analyserResult = fileAutoCategorisor.Categorise(remotePath);
+        var classifications = ClassificationCombiner.Combine(FileClassifier.Classify(remotePath, mappings), analyserResult.Match(c => (IReadOnlyList<FileClassification>)[c], () => []));
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.0",
+    "ApplicationVersion": "0.7.1",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

`IFileAutoCategorisor.Categorise` previously always returned a concrete `FileClassification`, even when no rule matched — returning `level1 = "Unclassified"`. Both call sites wrapped this in a single-element array, so `ClassificationCombiner.Combine` always received a non-empty `analyserResults`, meaning the Unclassified sentinel never fired correctly. Files with keyword matches received their matched classifications **plus** a spurious `Unclassified` entry.

Fix: `Categorise` now returns `Option<FileClassification>` — `None` when no meaningful classification is derived, `Some(...)` otherwise. Callers unwrap the option to an empty-or-one-item list before passing to `Combine`.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #480

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally — 0 errors, 0 warnings
- [x] Tests pass — 1424 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed — `IFileAutoCategorisor.Categorise` return type changed; all callers updated
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/
```

---

## Notes for reviewers

- `appsettings.json` version bumped `0.7.0` → `0.7.1` per project convention.
- The `Photos` folder maps to `"Unclassified"` in `Level1Deriver.FolderTypeMap` (intentionally skipped by the guard in `DeriveLevel1`); a new test covers this edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)