### PR TITLE
fix(onedrive-sync-client): use GUID temp path to prevent concurrent download collision

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
@@ -65,6 +65,42 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
     }
 
     [Fact]
+    public async Task when_two_concurrent_downloads_of_same_file_then_distinct_temp_paths_are_used()
+    {
+        var writtenPaths = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var mockFs = new MockFileSystem();
+
+        var spyFileStreamFactory = Substitute.For<IFileStreamFactory>();
+        spyFileStreamFactory
+            .New(Arg.Any<string>(), Arg.Any<FileMode>(), Arg.Any<FileAccess>(), Arg.Any<FileShare>(), Arg.Any<int>(), Arg.Any<bool>())
+            .Returns(callInfo =>
+            {
+                var path = callInfo.ArgAt<string>(0);
+                writtenPaths.Add(path);
+                return mockFs.FileStream.New(path, callInfo.ArgAt<FileMode>(1), callInfo.ArgAt<FileAccess>(2), callInfo.ArgAt<FileShare>(3), callInfo.ArgAt<int>(4), callInfo.ArgAt<bool>(5));
+            });
+
+        var spyFs = Substitute.For<IFileSystem>();
+        spyFs.FileStream.Returns(spyFileStreamFactory);
+        spyFs.File.Returns(mockFs.File);
+        spyFs.Directory.Returns(mockFs.Directory);
+        spyFs.Path.Returns(mockFs.Path);
+
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new FakeHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("content", Encoding.UTF8) })));
+
+        var sut = new HttpDownloader(factory, spyFs, Substitute.For<ILogger<HttpDownloader>>());
+
+        await Task.WhenAll(
+            sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken),
+            sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken));
+
+        writtenPaths.Distinct().Count().ShouldBe(2);
+    }
+
+    [Fact]
     public async Task when_file_move_fails_all_retries_then_result_is_error()
     {
         var sut = new HttpDownloader(CreateOkFactory(), CreateAlwaysFailMoveFileSystem(), Substitute.For<ILogger<HttpDownloader>>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderTempFileHandling.cs
@@ -48,7 +48,8 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
-        mockFileSystem.File.Exists(TempPath).ShouldBeFalse();
+        mockFileSystem.Directory.GetFiles(mockFileSystem.Path.GetDirectoryName(LocalPath)!)
+            .ShouldNotContain(f => f.EndsWith(".download"));
     }
 
     [Fact]
@@ -118,7 +119,7 @@ public sealed class GivenAnHttpDownloaderTempFileHandling
 
         await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
 
-        fakeFs.File.Received(1).Delete(TempPath);
+        fakeFs.File.Received(1).Delete(Arg.Is<string>(p => p.StartsWith(LocalPath + ".") && p.EndsWith(".download")));
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -30,7 +30,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
         using var http = httpClientFactory.CreateClient();
         http.DefaultRequestHeaders.Add("User-Agent", UserAgent);
 
-        string tempPath = localPath + ".download";
+        string tempPath = localPath + "." + Guid.NewGuid().ToString("N") + ".download";
         int attempt = 0;
 
         while (true)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.1",
+    "ApplicationVersion": "0.7.2",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

On Linux, `File.Delete` (`unlink`) succeeds even on a `flock`-locked file. When two sync runs downloaded the same file concurrently, the second run failed to open the shared `.download` temp file, then called `TryDeleteTemp` which successfully unlinked it. The first run — still writing to the now-unlinked fd — then failed `File.Move` with "could not find file".

Fix: each `DownloadAsync` call generates a unique GUID-based temp path (`<localPath>.<guid>.download`), so concurrent downloads never share a temp file and the Linux unlink race is eliminated.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #483 

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

New test `when_two_concurrent_downloads_of_same_file_then_distinct_temp_paths_are_used` was committed as a failing test first (TDD), then the fix made it pass. Two existing tests that hardcoded the `.download` suffix were updated to match the new GUID pattern.

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — `HttpDownloader` only.

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1425/1425
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit --filter "GivenAnHttpDownloader"
```

---

## Notes for reviewers

Root cause is Linux-specific: `unlink` removes the directory entry of a locked file, leaving the writing process with a valid fd but no path. Windows NTFS denies `DeleteFile` on an open handle, so this race doesn't surface there. The GUID fix is portable and prevents collision on all platforms.