### PR TITLE
fix(onedrive-sync-client): prevent concurrent syncs for same account across manual and scheduled paths

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -447,6 +447,69 @@ public sealed class GivenASyncScheduler
         capturedToken.IsCancellationRequested.ShouldBeTrue();
     }
 
+    [Fact]
+    public async Task when_trigger_account_called_while_same_account_already_syncing_then_sync_service_not_called_again()
+    {
+        var syncStarted = new TaskCompletionSource();
+        var syncRelease = new TaskCompletionSource();
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                syncStarted.TrySetResult();
+                await syncRelease.Task;
+            });
+
+        var scheduler = CreateScheduler(mockSyncService, Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
+        var account = new OneDriveAccount { Id = new AccountId("dup-account") };
+
+        var firstSync = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+        await syncStarted.Task;
+
+        var secondSync = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+
+        syncRelease.SetResult();
+        await firstSync;
+        await secondSync;
+
+        await mockSyncService.Received(1).SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_scheduled_sync_runs_while_account_already_syncing_manually_then_account_is_skipped()
+    {
+        const string accountId = "shared-account";
+        var syncStarted = new TaskCompletionSource();
+        var syncRelease = new TaskCompletionSource();
+        var callCount = 0;
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                Interlocked.Increment(ref callCount);
+                syncStarted.TrySetResult();
+                await syncRelease.Task;
+            });
+
+        var mockRepository = Substitute.For<IAccountRepository>();
+        mockRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([new AccountEntity { Id = new AccountId(accountId), Profile = AccountProfileFactory.Create("Test", "test@test.com") }]);
+
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+        var account = new OneDriveAccount { Id = new AccountId(accountId) };
+
+        var manualSync = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+        await syncStarted.Task;
+
+        var scheduledPass = scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
+
+        syncRelease.SetResult();
+        await manualSync;
+        await scheduledPass;
+
+        callCount.ShouldBe(1);
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -81,6 +81,10 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 2204, Level = LogLevel.Information, Message = "[SyncScheduler] Sync cancellation requested for {AccountId}")]
     public static partial void SyncSchedulerCancelled(ILogger logger, string accountId);
 
+    /// <summary>Logs that a sync was skipped because a sync for the same account is already in progress.</summary>
+    [LoggerMessage(EventId = 2205, Level = LogLevel.Warning, Message = "[SyncScheduler] Skipping sync for {AccountId} — already in progress")]
+    public static partial void SyncSchedulerSkippedAlreadyRunning(ILogger logger, string accountId);
+
     // Local Change Detection (2300-2399)
 
     /// <summary>Logs new/modified local files found.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -37,6 +37,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     public void StartSync(TimeSpan? interval = null)
     {
         _interval = interval ?? DefaultInterval;
+        _timer?.Dispose();
 
         try
         {
@@ -90,7 +91,12 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     public async Task TriggerAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        _activeSyncs.TryAdd(account.Id.Id, cts);
+        if (!_activeSyncs.TryAdd(account.Id.Id, cts))
+        {
+            OneDriveSyncClientMessages.SyncSchedulerSkippedAlreadyRunning(logger, account.Id.Id);
+            return;
+        }
+
         SyncStarted?.Invoke(this, account.Id.Id);
         try
         {
@@ -157,10 +163,17 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
                 var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct).ConfigureAwait(false);
                 var account = MapEntityToAccount(entity, rules);
 
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                if (!_activeSyncs.TryAdd(account.Id.Id, cts))
+                {
+                    OneDriveSyncClientMessages.SyncSchedulerSkippedAlreadyRunning(logger, account.Id.Id);
+                    continue;
+                }
+
                 SyncStarted?.Invoke(this, account.Id.Id);
                 try
                 {
-                    await syncService.SyncAccountAsync(account, ct);
+                    await syncService.SyncAccountAsync(account, cts.Token);
                 }
                 catch (Exception ex)
                 {
@@ -168,6 +181,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
                 }
                 finally
                 {
+                    _activeSyncs.TryRemove(account.Id.Id, out _);
                     SyncCompleted?.Invoke(this, account.Id.Id);
                 }
             }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.1",
+    "ApplicationVersion": "0.7.2",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Two independent sync paths in `SyncScheduler` were not mutually exclusive at the per-account level, causing the same account to be synced concurrently — a race that produced the download collisions reported in #483.

**Root causes fixed:**

1. **`TriggerAccountAsync`** called `_activeSyncs.TryAdd` but ignored the return value, so a manual trigger could proceed even if the account was already syncing via another path.
2. **`RunSyncPassAsync`** never checked `_activeSyncs` per account, so a scheduled pass would call `syncService.SyncAccountAsync` for an account already being synced via a manual trigger.
3. **`StartSync`** did not dispose the previous `Timer` before creating a new one — repeated calls (e.g. app start + settings change) left orphaned timers firing independently.

**Fix:** Both paths now go through `_activeSyncs.TryAdd` as the per-account guard. A skipped account logs warning event 2205. `StartSync` disposes the existing timer first.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #484

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

Two failing tests committed first (TDD):
- `when_trigger_account_called_while_same_account_already_syncing_then_sync_service_not_called_again`
- `when_scheduled_sync_runs_while_account_already_syncing_manually_then_account_is_skipped`

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — `SyncScheduler` and `OneDriveSyncClientMessages` only.

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1426/1426
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit --filter "GivenASyncScheduler"
```

---

## Notes for reviewers

`_runningFlag` is intentionally retained — it still prevents redundant full-pass iterations (e.g. two timer ticks firing back-to-back). The per-account `_activeSyncs` guard is additive, not a replacement for it.