### PR TITLE
fix(onedrive-sync-client): prevent scheduled sync starting while manual sync is running

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -510,6 +510,34 @@ public sealed class GivenASyncScheduler
         callCount.ShouldBe(1);
     }
 
+    [Fact]
+    public async Task when_trigger_now_called_while_manual_sync_is_running_then_scheduled_pass_does_not_start()
+    {
+        var syncStarted = new TaskCompletionSource();
+        var syncRelease = new TaskCompletionSource();
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                syncStarted.TrySetResult();
+                await syncRelease.Task;
+            });
+
+        var mockRepository = Substitute.For<IAccountRepository>();
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var account = new OneDriveAccount { Id = new AccountId("manual-running") };
+
+        var manualSync = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+        await syncStarted.Task;
+
+        await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
+
+        await mockRepository.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
+
+        syncRelease.SetResult();
+        await manualSync;
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -137,7 +137,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         }
     }
 
-    private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1;
+    private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1 || !_activeSyncs.IsEmpty;
 
     private static OneDriveAccount MapEntityToAccount(AccountEntity entity, IReadOnlyList<SyncRuleEntity> rules) => new()
     {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.2",
+    "ApplicationVersion": "0.7.3",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

`SyncIsAlreadyRunning()` only checked `_runningFlag`, which is exclusively set by `RunSyncPassAsync` (the scheduled path). `TriggerAccountAsync` (the manual path) never sets the flag — it only registers the account in `_activeSyncs`. As a result, when the timer fires while a manual sync is actively running, `SyncIsAlreadyRunning()` returns `false` and `RunSyncPassAsync` is entered.

The previous fix (PR #485) added a per-account `TryAdd` guard inside `RunSyncPassAsync`, which correctly prevents the same account from being synced twice. But `RunSyncPassAsync` still started — loading accounts from the database and attempting `TryAdd` for each — meaning the scheduled pass was effectively running concurrently with the manual sync.

**Root cause:** `SyncIsAlreadyRunning()` must also return `true` when `_activeSyncs` is non-empty (i.e., any account is currently syncing via any path).

**Fix:** One-line change:
```csharp
// Before
private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1;

// After
private bool SyncIsAlreadyRunning() => Interlocked.Read(ref _runningFlag) == 1 || !_activeSyncs.IsEmpty;
```

This makes both `OnTimerTickAsync` and `TriggerNowAsync` return immediately without entering `RunSyncPassAsync` whenever any sync (manual or scheduled) is in progress.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #484

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

New test: `when_trigger_now_called_while_manual_sync_is_running_then_scheduled_pass_does_not_start` — confirmed red before fix, green after.

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1428/1428
- [x] No new analyzer warnings
- [x] Public API changes reviewed — no interface changes
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit
```

---

## Notes for reviewers

`_activeSyncs.IsEmpty` is a O(1) lock-free check on `ConcurrentDictionary` — no perf concern.

The `_runningFlag` is kept: it still prevents two concurrent timer-triggered `RunSyncPassAsync` calls from racing between the `IsEmpty` check and `TryAdd`.