### PR TITLE
fix(onedrive-sync-client): retry IOException during body read with exponential backoff

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderIoExceptionRetry.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderIoExceptionRetry.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Text;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Jobs;
+
+public sealed class GivenAnHttpDownloaderIoExceptionRetry
+{
+    private const string DownloadUrl = "https://example.com/file.txt";
+    private const string LocalPath = "/tmp/downloaded-file.txt";
+    private static readonly DateTimeOffset RemoteModified = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task when_io_exception_thrown_reading_body_once_then_download_is_retried_and_succeeds()
+    {
+        int callCount = 0;
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new FakeHttpMessageHandler(_ =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new IoThrowingContent() }
+                    : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("hello", Encoding.UTF8) };
+            })));
+
+        var sut = new HttpDownloader(factory, new MockFileSystem(), Substitute.For<ILogger<HttpDownloader>>());
+
+        var result = await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<System.Reactive.Unit, string>.Ok>();
+        callCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_io_exception_persists_past_max_retries_then_result_is_error()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new FakeHttpMessageHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new IoThrowingContent() })));
+
+        var sut = new HttpDownloader(factory, new MockFileSystem(), Substitute.For<ILogger<HttpDownloader>>());
+
+        var result = await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<System.Reactive.Unit, string>.Error>();
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+
+    private sealed class IoThrowingContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.FromException(new IOException("Connection reset by peer"));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+            return false;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync() =>
+            Task.FromResult<Stream>(new IoThrowingStream());
+    }
+
+    private sealed class IoThrowingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new IOException("Connection reset by peer");
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken ct) => Task.FromException<int>(new IOException("Connection reset by peer"));
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => ValueTask.FromException<int>(new IOException("Connection reset by peer"));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -75,10 +75,17 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
                 return new Result<Unit, string>.Ok(Unit.Default);
             }
+            catch (IOException) when (attempt <= MaxRetries)
+            {
+                TryDeleteTemp(tempPath);
+                var delay = GetBackoffDelay(attempt);
+                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, MaxRetries);
+                await Task.Delay(delay, ct);
+            }
             catch (IOException ex)
             {
                 TryDeleteTemp(tempPath);
-                return new Result<Unit, string>.Error($"File write failed for '{localPath}': {ex.Message}");
+                return new Result<Unit, string>.Error($"IO error downloading '{localPath}': {ex.Message}");
             }
             catch (HttpRequestException) when (attempt <= MaxRetries)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.2",
+    "ApplicationVersion": "0.7.3",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
## Summary

- `HttpDownloader.DownloadAsync` caught `IOException` (thrown when reading the HTTP response body, e.g. "connection reset by peer") once and returned a terminal `Result.Error` with no retry
- `HttpRequestException` already retried up to `MaxRetries = 5` times with exponential backoff — `IOException` now uses the same policy
- Split the single `catch (IOException)` into a retry path (`when attempt <= MaxRetries`) and a terminal path that returns `Result.Error` once retries are exhausted

## Type of change

- [x] Bug fix

## Related issues / links

Closes #487

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation

New test class `GivenAnHttpDownloaderIoExceptionRetry`:
- `when_io_exception_thrown_reading_body_once_then_download_is_retried_and_succeeds` — was red before fix
- `when_io_exception_persists_past_max_retries_then_result_is_error` — verifies terminal path

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1430/1430
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

The retry path reuses the existing `DownloadNetworkError` (event 2705) log message — both `HttpRequestException` and `IOException` during body read are network errors and the same message is appropriate.