### PR TITLE
fix(onedrive-sync-client): treat plus as token separator and sort categories alphabetically within level (#490)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
@@ -386,4 +386,45 @@ public sealed class GivenAFileClassificationRulesViewModel
 
         sut.Categories[0].Keywords.Count.ShouldBe(1);
     }
+
+    [Fact]
+    public async Task when_load_async_called_with_categories_at_same_level_then_categories_ordered_alphabetically_by_name()
+    {
+        IReadOnlyList<FileClassificationCategory> categories =
+        [
+            new(new FileClassificationCategoryId(1), "Zebra", 1, Option.None<FileClassificationCategoryId>()),
+            new(new FileClassificationCategoryId(2), "Alpha", 1, Option.None<FileClassificationCategoryId>()),
+            new(new FileClassificationCategoryId(3), "Media", 1, Option.None<FileClassificationCategoryId>())
+        ];
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(categories));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+
+        await sut.LoadAsync(CancellationToken.None);
+
+        sut.Categories[0].Name.ShouldBe("Alpha");
+        sut.Categories[1].Name.ShouldBe("Media");
+        sut.Categories[2].Name.ShouldBe("Zebra");
+    }
+
+    [Fact]
+    public async Task when_load_async_called_with_children_at_same_level_then_children_ordered_alphabetically_by_name()
+    {
+        IReadOnlyList<FileClassificationCategory> categories =
+        [
+            new(new FileClassificationCategoryId(1), "Media", 1, Option.None<FileClassificationCategoryId>()),
+            new(new FileClassificationCategoryId(2), "Videos", 2, Option.Some(new FileClassificationCategoryId(1))),
+            new(new FileClassificationCategoryId(3), "Audio", 2, Option.Some(new FileClassificationCategoryId(1))),
+            new(new FileClassificationCategoryId(4), "Photos", 2, Option.Some(new FileClassificationCategoryId(1)))
+        ];
+        repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult(categories));
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+
+        await sut.LoadAsync(CancellationToken.None);
+
+        sut.Categories[0].Children[0].Name.ShouldBe("Audio");
+        sut.Categories[0].Children[1].Name.ShouldBe("Photos");
+        sut.Categories[0].Children[2].Name.ShouldBe("Videos");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Domain/GivenAFileClassifier.cs
@@ -181,4 +181,37 @@ public sealed class GivenAFileClassifier
         result.ShouldHaveSingleItem();
         result[0].Level1.ShouldBe("Colour");
     }
+
+    [Fact]
+    public void when_classifying_path_with_plus_separator_then_plus_delimited_parts_produce_tokens()
+    {
+        IReadOnlyList<KeywordMapping> mappings = [Mapping("tuscany", "Travel")];
+
+        var result = FileClassifier.Classify("/photos/italy+tuscany+2024.jpg", mappings);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Travel");
+    }
+
+    [Fact]
+    public void when_keyword_matches_token_from_plus_separated_filename_then_mapping_fires()
+    {
+        IReadOnlyList<KeywordMapping> mappings = [Mapping("beach", "Scenery")];
+
+        var result = FileClassifier.Classify("/photos/summer+beach+sunset.jpg", mappings);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Scenery");
+    }
+
+    [Fact]
+    public void when_path_has_no_plus_then_behaviour_unchanged_after_separator_addition()
+    {
+        IReadOnlyList<KeywordMapping> mappings = [Mapping("car", "Vehicle")];
+
+        var result = FileClassifier.Classify("/docs/red-car-landscape.jpg", mappings);
+
+        result.ShouldHaveSingleItem();
+        result[0].Level1.ShouldBe("Vehicle");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -70,7 +70,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
 
             var nodeDict = new Dictionary<FileClassificationCategoryId, CategoryNodeViewModel>();
 
-            foreach (var category in all.OrderBy(c => c.Level))
+            foreach (var category in all.OrderBy(c => c.Level).ThenBy(c => c.Name))
             {
                 var node = new CategoryNodeViewModel(category.Id, category.Name, category.Level, repository, self => RemoveFromParent(self, nodeDict));
                 nodeDict[category.Id] = node;
@@ -78,7 +78,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
 
             Categories.Clear();
 
-            foreach (var category in all.OrderBy(c => c.Level))
+            foreach (var category in all.OrderBy(c => c.Level).ThenBy(c => c.Name))
             {
                 var node = nodeDict[category.Id];
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/FileClassifier.cs
@@ -3,7 +3,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Domain;
 /// <summary>Classifies a remote file path against a set of configured rules.</summary>
 public static class FileClassifier
 {
-    private static readonly char[] Separators = ['/', '-', '_', '.', ' '];
+    private static readonly char[] Separators = ['/', '-', '_', '.', '+', ' '];
 
     /// <summary>
     /// Tokenises <paramref name="remotePath"/> and matches each <see cref="KeywordMapping"/> whose keyword appears in the tokens.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.3",
+    "ApplicationVersion": "0.7.4",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Two production changes that existed as an uncommitted patch with zero test coverage are now TDD-legitimised. Failing tests were committed first against the unpatched HEAD, then the patch was applied to make them pass.

Changes:
- `FileClassifier.Separators` — `'+'` added so plus-delimited filenames (e.g. `italy+tuscany+2024.jpg`) are tokenised correctly.
- `FileClassificationRulesViewModel.LoadAsync` — both category-iteration loops change `OrderBy(c => c.Level)` to `OrderBy(c => c.Level).ThenBy(c => c.Name)` so categories at the same level are displayed in deterministic alphabetical order.
- `appsettings.json` — `ApplicationVersion` bumped `0.7.3` → `0.7.4` per the app's CLAUDE.md bugfix rule.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #490

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

Five new unit tests added (commit `57e546b` precedes the production fix `8bfb580`):

**GivenAFileClassifier:**
- `when_classifying_path_with_plus_separator_then_plus_delimited_parts_produce_tokens` — FAILED before patch, passes after.
- `when_keyword_matches_token_from_plus_separated_filename_then_mapping_fires` — FAILED before patch, passes after.
- `when_path_has_no_plus_then_behaviour_unchanged_after_separator_addition` — passes before AND after (regression guard).

**GivenAFileClassificationRulesViewModel:**
- `when_load_async_called_with_categories_at_same_level_then_categories_ordered_alphabetically_by_name` — FAILED before patch, passes after.
- `when_load_async_called_with_children_at_same_level_then_children_ordered_alphabetically_by_name` — FAILED before patch, passes after.

Pre-patch run: Failed: 4, Passed: 1431, Total: 1435
Post-patch run: Failed: 0, Passed: 1435, Total: 1435
Integration:   Failed: 0, Passed: 31,   Total: 31

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — `Domain/FileClassifier.cs`, `Classifications/FileClassificationRulesViewModel.cs`, `appsettings.json`
`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — `Domain/GivenAFileClassifier.cs`, `Classifications/GivenAFileClassificationRulesViewModel.cs`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)