### PR TITLE
fix(onedrive-sync-client): replace Result pattern matching with Match/Tap combinators (#491)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAKeywordRowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAKeywordRowViewModel.cs
@@ -1,0 +1,113 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Classifications;
+
+public sealed class GivenAKeywordRowViewModel
+{
+    private readonly IFileClassificationRepository repository;
+
+    public GivenAKeywordRowViewModel()
+    {
+        repository = Substitute.For<IFileClassificationRepository>();
+        repository.UpdateKeywordAsync(Arg.Any<int>(), Arg.Any<FileClassificationKeyword>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<Result<int, string>>(new Result<int, string>.Ok(1)));
+        repository.DeleteKeywordAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                  .Returns(Task.CompletedTask);
+    }
+
+    private static KeywordRowViewModel CreateSut(IFileClassificationRepository repo, string value = "cats", bool isSpecial = false) =>
+        new(keywordId: 1, keyword: new FileClassificationKeyword(value, isSpecial ? Option.Some(true) : Option.None<bool>()), repository: repo, onDeleteSelf: _ => { });
+
+    [Fact]
+    public async Task when_save_command_executed_with_valid_value_then_repository_update_called()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+        sut.Value = "dogs";
+        sut.IsEditing = true;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        await repository.Received(1).UpdateKeywordAsync(1, Arg.Is<FileClassificationKeyword>(k => k.Value == "dogs"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_save_command_executed_with_valid_value_then_is_editing_set_to_false()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+        sut.Value = "dogs";
+        sut.IsEditing = true;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        sut.IsEditing.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_save_command_executed_with_empty_value_then_repository_not_called()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+        sut.Value = string.Empty;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        await repository.DidNotReceive().UpdateKeywordAsync(Arg.Any<int>(), Arg.Any<FileClassificationKeyword>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_save_command_executed_with_empty_value_then_is_editing_unchanged()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+        sut.IsEditing = true;
+        sut.Value = string.Empty;
+
+        await sut.SaveCommand.ExecuteAsync(null);
+
+        sut.IsEditing.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_cancel_command_executed_then_value_restored_to_original()
+    {
+        KeywordRowViewModel sut = CreateSut(repository, value: "cats");
+        sut.Value = "changed";
+
+        sut.CancelCommand.Execute(null);
+
+        sut.Value.ShouldBe("cats");
+    }
+
+    [Fact]
+    public void when_cancel_command_executed_then_is_editing_set_to_false()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+        sut.IsEditing = true;
+
+        sut.CancelCommand.Execute(null);
+
+        sut.IsEditing.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task when_delete_command_executed_then_repository_delete_called()
+    {
+        KeywordRowViewModel sut = CreateSut(repository);
+
+        await sut.DeleteCommand.ExecuteAsync(null);
+
+        await repository.Received(1).DeleteKeywordAsync(1, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_delete_command_executed_then_on_delete_self_callback_invoked()
+    {
+        bool callbackInvoked = false;
+        KeywordRowViewModel sut = new(keywordId: 1, keyword: new FileClassificationKeyword("cats", Option.None<bool>()), repository: repository, onDeleteSelf: _ => callbackInvoked = true);
+
+        await sut.DeleteCommand.ExecuteAsync(null);
+
+        callbackInvoked.ShouldBeTrue();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadServiceLogging.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnUploadServiceLogging.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using WireMock.Util;
+using WireMock.Types;
+using WireMockBodyType = WireMock.Types.BodyType;
+using WireMockRequest = WireMock.RequestBuilders.Request;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.TestHelpers;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Jobs;
+
+public sealed class GivenAnUploadServiceLogging
+{
+    private const string DriveIdValue   = "drive-001";
+    private const string ParentFolderId = "folder-001";
+    private const string RemotePath     = "test-file.bin";
+    private const string ExpectedItemId = "item-abc-123";
+    private const string LocalFilePath  = "/mock/test-file.bin";
+
+    private static IHttpClientFactory CreateChunkClientFactory()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient());
+
+        return factory;
+    }
+
+    private static GraphServiceClient BuildGraphClient(WireMockServer server) =>
+        new(new HttpClientRequestAdapter(new AnonymousAuthenticationProvider(), httpClient: new HttpClient { BaseAddress = new Uri(server.Urls[0]) }));
+
+    private static string SessionJson(WireMockServer server) =>
+        $"{{\"uploadUrl\":\"{server.Urls[0]}/chunk-upload\"}}";
+
+    private static string ItemIdJson() =>
+        $"{{\"id\":\"{ExpectedItemId}\"}}";
+
+    [Fact]
+    public async Task when_upload_succeeds_then_completed_log_event_2802_is_emitted()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
+        using var server = WireMockServer.Start();
+
+        server.Given(WireMockRequest.Create().UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(SessionJson(server)).WithHeader("Content-Type", "application/json"));
+
+        server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
+              .RespondWith(Response.Create().WithCallback(_ => Created201Response()));
+
+        var logger = new TestLogger<UploadService>();
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, logger);
+
+        await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+
+        logger.Entries.ShouldContain(e => e.Level == LogLevel.Information && e.EventId.Id == 2802);
+    }
+
+    [Fact]
+    public async Task when_upload_fails_then_completed_log_event_2802_is_not_emitted()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(LocalFilePath).Which(m => m.HasBytesContent(new byte[64]));
+        using var server = WireMockServer.Start();
+
+        server.Given(WireMockRequest.Create().UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(SessionJson(server)).WithHeader("Content-Type", "application/json"));
+
+        server.Given(WireMockRequest.Create().UsingPut().WithPath("/chunk-upload"))
+              .RespondWith(Response.Create().WithStatusCode(201).WithHeader("Content-Type", "application/json").WithBody("{}"));
+
+        var logger = new TestLogger<UploadService>();
+        var sut = new UploadService(CreateChunkClientFactory(), mockFileSystem, logger);
+
+        await sut.UploadAsync(BuildGraphClient(server), new DriveId(DriveIdValue), ParentFolderId, LocalFilePath, RemotePath, ct: TestContext.Current.CancellationToken);
+
+        logger.Entries.ShouldNotContain(e => e.EventId.Id == 2802);
+    }
+
+    private static WireMock.ResponseMessage Created201Response()
+    {
+        var msg = new WireMock.ResponseMessage
+        {
+            StatusCode = 201,
+            Headers = new Dictionary<string, WireMockList<string>> { { "Content-Type", new WireMockList<string>("application/json") } },
+            BodyData = new BodyData { DetectedBodyType = WireMockBodyType.String, BodyAsString = ItemIdJson() }
+        };
+
+        return msg;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/CategoryNodeViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/CategoryNodeViewModel.cs
@@ -58,12 +58,15 @@ public sealed partial class CategoryNodeViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanAddKeyword))]
     private async Task AddKeywordAsync()
     {
-        var keywordResult = FileClassificationKeywordFactory.Create(NewKeyword.Trim(), NewKeywordIsSpecial ? Option.Some(true) : Option.None<bool>());
-        if (keywordResult is not Result<FileClassificationKeyword, string>.Ok okKeyword)
-            return;
+        await FileClassificationKeywordFactory.Create(NewKeyword.Trim(), NewKeywordIsSpecial ? Option.Some(true) : Option.None<bool>())
+            .Match(AddValidatedKeywordAsync, _ => Task.CompletedTask)
+            .ConfigureAwait(false);
+    }
 
-        await repository.AddKeywordAsync(CategoryId, okKeyword.Value, CancellationToken.None)
-            .TapAsync(keywordId => Keywords.Add(new KeywordRowViewModel(keywordId, okKeyword.Value, repository, self => Keywords.Remove(self))))
+    private async Task AddValidatedKeywordAsync(FileClassificationKeyword keyword)
+    {
+        await repository.AddKeywordAsync(CategoryId, keyword, CancellationToken.None)
+            .TapAsync(keywordId => Keywords.Add(new KeywordRowViewModel(keywordId, keyword, repository, self => Keywords.Remove(self))))
             .ConfigureAwait(false);
 
         NewKeyword = string.Empty;
@@ -79,13 +82,16 @@ public sealed partial class CategoryNodeViewModel : ObservableObject
         var placeholder = new FileClassificationCategoryId(0);
         string trimmedName = NewChildCategoryName.Trim();
 
-        var categoryResult = FileClassificationCategoryFactory.Create(placeholder, trimmedName, childLevel, Option.Some(CategoryId));
-        if (categoryResult is not Result<FileClassificationCategory, string>.Ok okCategory)
-            return;
+        await FileClassificationCategoryFactory.Create(placeholder, trimmedName, childLevel, Option.Some(CategoryId))
+            .Match(category => AddValidatedChildCategoryAsync(category, trimmedName, childLevel), _ => Task.CompletedTask)
+            .ConfigureAwait(false);
+    }
 
+    private async Task AddValidatedChildCategoryAsync(FileClassificationCategory category, string trimmedName, int childLevel)
+    {
         CategoryNodeViewModel? newChild = null;
 
-        await repository.AddCategoryAsync(okCategory.Value, CancellationToken.None)
+        await repository.AddCategoryAsync(category, CancellationToken.None)
             .TapAsync(newId =>
             {
                 newChild = new CategoryNodeViewModel(newId, trimmedName, childLevel, repository, self => Children.Remove(self));
@@ -96,17 +102,20 @@ public sealed partial class CategoryNodeViewModel : ObservableObject
                 if (newChild is null)
                     return;
 
-                var keywordResult = FileClassificationKeywordFactory.Create(trimmedName, Option.None<bool>());
-                if (keywordResult is not Result<FileClassificationKeyword, string>.Ok okKeyword)
-                    return;
-
-                await repository.AddKeywordAsync(newChild.CategoryId, okKeyword.Value, CancellationToken.None)
-                    .TapAsync(keywordId => newChild.Keywords.Add(new KeywordRowViewModel(keywordId, okKeyword.Value, repository, self => newChild.Keywords.Remove(self))))
+                await FileClassificationKeywordFactory.Create(trimmedName, Option.None<bool>())
+                    .Match(keyword => AddKeywordToChildAsync(newChild, keyword), _ => Task.CompletedTask)
                     .ConfigureAwait(false);
             })
             .ConfigureAwait(false);
 
         NewChildCategoryName = string.Empty;
+    }
+
+    private async Task AddKeywordToChildAsync(CategoryNodeViewModel child, FileClassificationKeyword keyword)
+    {
+        await repository.AddKeywordAsync(child.CategoryId, keyword, CancellationToken.None)
+            .TapAsync(keywordId => child.Keywords.Add(new KeywordRowViewModel(keywordId, keyword, repository, self => child.Keywords.Remove(self))))
+            .ConfigureAwait(false);
     }
 
     [RelayCommand]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
@@ -67,21 +67,20 @@ public sealed class FileClassificationExportImportService(IFileClassificationRep
     private async Task InsertNodeAsync(ClassificationCategoryNode node, int level, Option<FileClassificationCategoryId> parentId, CancellationToken cancellationToken)
     {
         var placeholder = new FileClassificationCategoryId(0);
-        var categoryResult = FileClassificationCategoryFactory.Create(placeholder, node.Name, level, parentId);
-        if (categoryResult is not Result<FileClassificationCategory, string>.Ok okCategory)
-            return;
 
-        var addResult = await repository.AddCategoryAsync(okCategory.Value, cancellationToken).ConfigureAwait(false);
-        if (addResult is not Result<FileClassificationCategoryId, string>.Ok okId)
-            return;
+        await FileClassificationCategoryFactory.Create(placeholder, node.Name, level, parentId)
+            .BindAsync(category => repository.AddCategoryAsync(category, cancellationToken))
+            .MatchAsync(
+                async newId =>
+                {
+                    foreach (var child in node.Children)
+                        await InsertNodeAsync(child, level + 1, Option.Some(newId), cancellationToken).ConfigureAwait(false);
 
-        FileClassificationCategoryId newId = okId.Value;
-
-        foreach (var child in node.Children)
-            await InsertNodeAsync(child, level + 1, Option.Some(newId), cancellationToken).ConfigureAwait(false);
-
-        foreach (var keyword in node.Keywords)
-            await repository.AddKeywordAsync(newId, new FileClassificationKeyword(keyword.Value, keyword.IsSpecialOverride.HasValue ? Option.Some(keyword.IsSpecialOverride.Value) : Option.None<bool>()), cancellationToken).ConfigureAwait(false);
+                    foreach (var keyword in node.Keywords)
+                        await repository.AddKeywordAsync(newId, new FileClassificationKeyword(keyword.Value, keyword.IsSpecialOverride.HasValue ? Option.Some(keyword.IsSpecialOverride.Value) : Option.None<bool>()), cancellationToken).ConfigureAwait(false);
+                },
+                _ => Task.CompletedTask)
+            .ConfigureAwait(false);
     }
 }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -138,14 +138,17 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
     {
         var placeholder = new FileClassificationCategoryId(0);
         string trimmedName = NewCategoryName.Trim();
-        var categoryResult = FileClassificationCategoryFactory.Create(placeholder, trimmedName, 1, Option.None<FileClassificationCategoryId>());
 
-        if (categoryResult is not Result<FileClassificationCategory, string>.Ok okCategory)
-            return;
+        await FileClassificationCategoryFactory.Create(placeholder, trimmedName, 1, Option.None<FileClassificationCategoryId>())
+            .Match(category => AddValidatedCategoryAsync(category, trimmedName), _ => Task.CompletedTask)
+            .ConfigureAwait(false);
+    }
 
+    private async Task AddValidatedCategoryAsync(FileClassificationCategory category, string trimmedName)
+    {
         CategoryNodeViewModel? newNode = null;
 
-        await repository.AddCategoryAsync(okCategory.Value, CancellationToken.None)
+        await repository.AddCategoryAsync(category, CancellationToken.None)
             .TapAsync(newId =>
             {
                 newNode = new CategoryNodeViewModel(newId, trimmedName, 1, repository, self => Categories.Remove(self));
@@ -156,17 +159,20 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
                 if (newNode is null)
                     return;
 
-                var keywordResult = FileClassificationKeywordFactory.Create(trimmedName, Option.None<bool>());
-                if (keywordResult is not Result<FileClassificationKeyword, string>.Ok okKeyword)
-                    return;
-
-                await repository.AddKeywordAsync(newNode.CategoryId, okKeyword.Value, CancellationToken.None)
-                    .TapAsync(keywordId => newNode.Keywords.Add(new KeywordRowViewModel(keywordId, okKeyword.Value, repository, self => newNode.Keywords.Remove(self))))
+                await FileClassificationKeywordFactory.Create(trimmedName, Option.None<bool>())
+                    .Match(keyword => AddKeywordToNewNodeAsync(newNode, keyword), _ => Task.CompletedTask)
                     .ConfigureAwait(false);
             })
             .ConfigureAwait(false);
 
         NewCategoryName = string.Empty;
+    }
+
+    private async Task AddKeywordToNewNodeAsync(CategoryNodeViewModel node, FileClassificationKeyword keyword)
+    {
+        await repository.AddKeywordAsync(node.CategoryId, keyword, CancellationToken.None)
+            .TapAsync(keywordId => node.Keywords.Add(new KeywordRowViewModel(keywordId, keyword, repository, self => node.Keywords.Remove(self))))
+            .ConfigureAwait(false);
     }
 
     private void RemoveFromParent(CategoryNodeViewModel node, Dictionary<FileClassificationCategoryId, CategoryNodeViewModel> nodeDict)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/KeywordRowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/KeywordRowViewModel.cs
@@ -46,12 +46,14 @@ public sealed partial class KeywordRowViewModel : ObservableObject
     [RelayCommand]
     private async Task SaveAsync()
     {
-        var keywordResult = FileClassificationKeywordFactory.Create(Value, IsSpecialOverride ? Option.Some(true) : Option.None<bool>());
-        if (keywordResult is not Result<FileClassificationKeyword, string>.Ok okResult)
-            return;
+        await FileClassificationKeywordFactory.Create(Value, IsSpecialOverride ? Option.Some(true) : Option.None<bool>())
+            .Match(PersistKeywordAsync, _ => Task.CompletedTask)
+            .ConfigureAwait(false);
+    }
 
-        await repository.UpdateKeywordAsync(KeywordId, okResult.Value, CancellationToken.None).ConfigureAwait(false);
-
+    private async Task PersistKeywordAsync(FileClassificationKeyword keyword)
+    {
+        await repository.UpdateKeywordAsync(KeywordId, keyword, CancellationToken.None).ConfigureAwait(false);
         originalValue = Value;
         originalIsSpecialOverride = IsSpecialOverride;
         IsEditing = false;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -64,16 +64,10 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 await using var stream = await response.Content.ReadAsStreamAsync(ct);
                 await WriteToFileAsync(stream, tempPath, progress, ct);
 
-                var moveResult = await MoveWithRetryAsync(tempPath, localPath, ct);
-                if (moveResult is Result<Unit, string>.Error)
-                {
-                    TryDeleteTemp(tempPath);
-                    return moveResult;
-                }
-
-                PreserveRemoteTimestamp(localPath, remoteModified);
-
-                return new Result<Unit, string>.Ok(Unit.Default);
+                return await MoveWithRetryAsync(tempPath, localPath, ct)
+                    .MatchAsync<Unit, string, Result<Unit, string>>(
+                        _ => { PreserveRemoteTimestamp(localPath, remoteModified); return new Result<Unit, string>.Ok(Unit.Default); },
+                        error => { TryDeleteTemp(tempPath); return new Result<Unit, string>.Error(error); });
             }
             catch (IOException) when (attempt <= MaxRetries)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
@@ -48,10 +48,8 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             async sessionUrl =>
             {
                 var result = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
-                if (result is Result<string, string>.Ok)
-                    OneDriveSyncClientMessages.UploadServiceCompleted(logger, remotePath);
 
-                return result;
+                return result.Tap(_ => OneDriveSyncClientMessages.UploadServiceCompleted(logger, remotePath));
             },
             error => new Result<string, string>.Error(error));
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.3",
+    "ApplicationVersion": "0.7.4",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Removes all forbidden `is Result<T,E>.Ok` / `is not Result<T,E>.Ok` / `is Result<T,E>.Error` pattern matching from the OneDrive Sync Client, replacing each site with `Match` / `MatchAsync` / `Tap` / `BindAsync` combinators from `AStar.Dev.Functional.Extensions`, per `.claude/rules/c-sharp-code-style.md`. Pure refactor — behaviour pinned by tests committed before the refactor. `grep -rn "is Result<|is not Result<"` over the app now returns zero matches.

Sites refactored:
- `Classifications/KeywordRowViewModel.cs` — save flow via `Match`
- `Classifications/CategoryNodeViewModel.cs` — add-keyword / add-child-category flows via `Match`
- `Classifications/FileClassificationRulesViewModel.cs` — add-category flow via `Match`
- `Classifications/FileClassificationExportImportService.cs` — import insert via `BindAsync` + `MatchAsync`
- `Infrastructure/Sync/Jobs/UploadService.cs` — completion logging via `Tap`
- `Infrastructure/Sync/Jobs/HttpDownloader.cs` — move-result handling via `MatchAsync` (explicit type args; error branch deletes temp file inside the error lambda)

`ApplicationVersion` bumped 0.7.3 → 0.7.4 per app CLAUDE.md bug-fix rule.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #491

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

Pinning tests committed first (commit 8fd2abb) covering the UploadService logging branch and HttpDownloader move-error branch, then the refactor (commit 6ddb6d9).

`dotnet build`: 0 Warning(s), 0 Error(s).
`dotnet test` Unit: Passed: 1440, Failed: 0, Skipped: 0. Integration: Passed: 31, Failed: 0, Skipped: 0.
(One transient failure of `GivenAParallelSyncPipeline.when_three_download_jobs_are_processed_then_on_job_completed_is_called_three_times` was observed under full-suite load, reproduced as flaky: passes in isolation 3/3 and on full-suite rerun, including with the refactor stashed. Unrelated to this change.)

## Impacted areas

apps/desktop/AStar.Dev.OneDrive.Sync.Client, apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Ensure CI passed for all OS runners where configured.
- `CategoryNodeViewModel` / `FileClassificationRulesViewModel` guard-clause sites were restructured into small private async helpers so success logic sits in the ok lambda; error lambda is a no-op (matching the previous silent early-return behaviour).
- This branch will conflict trivially with #517/#518 on the `appsettings.json` version bump — resolve to a single 0.7.4 (or sequence bumps) at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)