### PR TITLE
fix(onedrive-sync-client): log account id instead of email to Application Insights (#492)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenAPiiScrubber.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenAPiiScrubber.cs
@@ -1,0 +1,54 @@
+using AStar.Dev.OneDrive.Sync.Client.LogViewer;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.LogViewer;
+
+public sealed class GivenAPiiScrubber
+{
+    [Fact]
+    public void when_message_contains_no_email_then_message_is_returned_unchanged()
+    {
+        string message = "SyncAccountAsync for account-123";
+
+        string result = PiiScrubber.Scrub(message);
+
+        result.ShouldBe("SyncAccountAsync for account-123");
+    }
+
+    [Fact]
+    public void when_message_contains_one_email_then_email_is_replaced_with_placeholder()
+    {
+        string message = "[SyncService] SyncAccountAsync for user@outlook.com";
+
+        string result = PiiScrubber.Scrub(message);
+
+        result.ShouldBe("[SyncService] SyncAccountAsync for [email redacted]");
+    }
+
+    [Fact]
+    public void when_message_contains_multiple_emails_then_all_are_replaced()
+    {
+        string message = "Syncing alice@outlook.com and bob@example.com";
+
+        string result = PiiScrubber.Scrub(message);
+
+        result.ShouldBe("Syncing [email redacted] and [email redacted]");
+    }
+
+    [Fact]
+    public void when_message_is_empty_then_empty_string_is_returned()
+    {
+        string result = PiiScrubber.Scrub(string.Empty);
+
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void when_message_contains_email_with_subdomain_then_email_is_redacted()
+    {
+        string message = "Authenticated as user@mail.subdomain.example.co.uk";
+
+        string result = PiiScrubber.Scrub(message);
+
+        result.ShouldBe("Authenticated as [email redacted]");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -44,20 +44,20 @@ public static partial class OneDriveSyncClientMessages
     // Sync Service (2100-2199)
 
     /// <summary>Logs start of account sync.</summary>
-    [LoggerMessage(EventId = 2100, Level = LogLevel.Information, Message = "[SyncService] SyncAccountAsync for {Email}")]
-    public static partial void SyncServiceStarting(ILogger logger, string email);
+    [LoggerMessage(EventId = 2100, Level = LogLevel.Information, Message = "[SyncService] SyncAccountAsync for {AccountId}")]
+    public static partial void SyncServiceStarting(ILogger logger, string accountId);
 
     /// <summary>Logs completion of account sync.</summary>
-    [LoggerMessage(EventId = 2101, Level = LogLevel.Information, Message = "[SyncService] Sync complete for {Email}")]
-    public static partial void SyncServiceComplete(ILogger logger, string email);
+    [LoggerMessage(EventId = 2101, Level = LogLevel.Information, Message = "[SyncService] Sync complete for {AccountId}")]
+    public static partial void SyncServiceComplete(ILogger logger, string accountId);
 
     /// <summary>Logs unhandled error during sync.</summary>
-    [LoggerMessage(EventId = 2102, Level = LogLevel.Error, Message = "[SyncService] Unhandled error syncing {Email}: {Error}")]
-    public static partial void SyncServiceError(ILogger logger, string email, string error, Exception ex);
+    [LoggerMessage(EventId = 2102, Level = LogLevel.Error, Message = "[SyncService] Unhandled error syncing {AccountId}: {Error}")]
+    public static partial void SyncServiceError(ILogger logger, string accountId, string error, Exception ex);
 
     /// <summary>Logs when re-authentication is required during sync.</summary>
-    [LoggerMessage(EventId = 2103, Level = LogLevel.Warning, Message = "[SyncService] Re-authentication required for {Email}")]
-    public static partial void SyncServiceReAuthRequired(ILogger logger, string email);
+    [LoggerMessage(EventId = 2103, Level = LogLevel.Warning, Message = "[SyncService] Re-authentication required for {AccountId}")]
+    public static partial void SyncServiceReAuthRequired(ILogger logger, string accountId);
 
     // Sync Scheduler (2200-2299)
 
@@ -134,16 +134,16 @@ public static partial class OneDriveSyncClientMessages
     // Remote Folder Enumeration (2600-2699)
 
     /// <summary>Logs enumeration of remote folder.</summary>
-    [LoggerMessage(EventId = 2600, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] Enumerating {Path} for {Email}")]
-    public static partial void RemoteFolderEnumeratorEnumerating(ILogger logger, string path, string email);
+    [LoggerMessage(EventId = 2600, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] Enumerating {Path} for {AccountId}")]
+    public static partial void RemoteFolderEnumeratorEnumerating(ILogger logger, string path, string accountId);
 
     /// <summary>Logs enumeration completed with item count.</summary>
     [LoggerMessage(EventId = 2601, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] Enumerated {Count} items under {Path}")]
     public static partial void RemoteFolderEnumeratorEnumerated(ILogger logger, int count, string path);
 
     /// <summary>Logs no sync rules configured for account.</summary>
-    [LoggerMessage(EventId = 2602, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] No sync rules configured for {Email} — nothing to sync")]
-    public static partial void RemoteFolderEnumeratorNoRules(ILogger logger, string email);
+    [LoggerMessage(EventId = 2602, Level = LogLevel.Information, Message = "[RemoteFolderEnumerator] No sync rules configured for {AccountId} — nothing to sync")]
+    public static partial void RemoteFolderEnumeratorNoRules(ILogger logger, string accountId);
 
     /// <summary>Logs backfill of RemoteItemId for rule.</summary>
     [LoggerMessage(EventId = 2603, Level = LogLevel.Debug, Message = "[RemoteFolderEnumerator] Back-filling RemoteItemId for rule {Path}")]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
@@ -21,7 +21,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
 
         if (rules.Count == 0)
         {
-            OneDriveSyncClientMessages.RemoteFolderEnumeratorNoRules(logger, account.Profile.Email);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorNoRules(logger, account.Id.Id);
 
             return new RemoteEnumerationResult([], new HashSet<string>(StringComparer.OrdinalIgnoreCase), [], [], HadNoRules: true);
         }
@@ -60,7 +60,7 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
                 continue;
             }
 
-            OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Profile.Email);
+            OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Id.Id);
             var items = await graphService.EnumerateFolderAsync(tokenFactory, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
                 .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
                     deltaItems => deltaItems,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -30,7 +30,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
     /// <inheritdoc />
     public async Task SyncAccountAsync(OneDriveAccount account, CancellationToken ct = default)
     {
-        OneDriveSyncClientMessages.SyncServiceStarting(logger, account.Profile.Email);
+        OneDriveSyncClientMessages.SyncServiceStarting(logger, account.Id.Id);
         RaiseProgress(account.Id.Id, 0, 0, "Authenticating...", SyncState.Syncing);
 
         var initialAuth = await authService.AcquireTokenSilentAsync(account.Id.Id, ct).ConfigureAwait(false);
@@ -74,7 +74,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                 RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.NoFoldersSelected"), SyncState.Idle);
             else
             {
-                OneDriveSyncClientMessages.SyncServiceComplete(logger, account.Profile.Email);
+                OneDriveSyncClientMessages.SyncServiceComplete(logger, account.Id.Id);
                 RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.Complete"), SyncState.Idle);
             }
         }
@@ -84,12 +84,12 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
         }
         catch (SyncReAuthRequiredException)
         {
-            OneDriveSyncClientMessages.SyncServiceReAuthRequired(logger, account.Profile.Email);
+            OneDriveSyncClientMessages.SyncServiceReAuthRequired(logger, account.Id.Id);
             RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.ReAuthRequired"), SyncState.ReAuthRequired);
         }
         catch (Exception ex)
         {
-            OneDriveSyncClientMessages.SyncServiceError(logger, account.Profile.Email, ex.Message, ex);
+            OneDriveSyncClientMessages.SyncServiceError(logger, account.Id.Id, ex.Message, ex);
             RaiseProgress(account.Id.Id, 0, 0, ex.Message, SyncState.Error);
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.4",
+    "ApplicationVersion": "0.7.5",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Replaces user email (`account.Profile.Email`) with the stable account ID (`account.Id.Id`) in all six log templates that previously emitted email addresses as structured log properties to Azure Application Insights, eliminating a PII/security leak.

Also adds unit tests for `PiiScrubber`, which previously had zero test coverage.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #492

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
```

---

## Notes for reviewers

- Six log templates updated: EventIds 2100 (`SyncServiceStarting`), 2101 (`SyncServiceComplete`), 2102 (`SyncServiceError`), 2103 (`SyncServiceReAuthRequired`), 2600 (`RemoteFolderEnumeratorEnumerating`), 2602 (`RemoteFolderEnumeratorNoRules`). All changed from `string email` / `{Email}` to `string accountId` / `{AccountId}`, matching the established pattern used by EventIds 2203/2205/3200.
- Call sites in `SyncService.cs` and `RemoteFolderEnumerator.cs` updated to pass `account.Id.Id`.
- No other `Profile.Email` → logger paths found in the app or test projects beyond the six addressed here.
- `PiiScrubber` regex was validated against all five test cases and required no production fix — the existing `[GeneratedRegex]` correctly handles plain addresses, multiple addresses, empty strings, and subdomain addresses.
- `ApplicationVersion` bumped from `0.7.4` to `0.7.5` per app bug-fix convention.
- The `appsettings.json` version bump (`0.7.4` → `0.7.5`) will conflict with sibling P2 PRs (#493/#494/#495 branches) and should be resolved at merge time by taking `0.7.5` from whichever lands last.
- Build: 0 errors, 0 warnings. Unit: 1455 passed (1440 baseline + 5 new PiiScrubber tests + 10 pre-existing additions since baseline was measured). Integration: 31 passed (exact baseline match). Zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)