### PR TITLE
fix(onedrive-sync-client): validate file manager paths stay under OneDrive base directory (#494)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
@@ -1,0 +1,108 @@
+using System.IO.Abstractions;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
+using Microsoft.Extensions.Logging;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
+
+public sealed class GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal
+{
+    private const string AccountIdString = "account-1";
+    private const string AccessToken = "token-abc";
+    private const string DriveIdValue = "drive-1";
+    private const string FolderId = "folder-1";
+
+    [Theory]
+    [InlineData("../../etc")]
+    [InlineData("../secret")]
+    [InlineData("..\\..\\Windows\\System32")]
+    public async Task when_folder_name_contains_parent_traversal_then_file_manager_is_not_launched(string maliciousFolderName)
+    {
+        var fileManagerService = Substitute.For<IFileManagerService>();
+        var fileSystem = Substitute.For<IFileSystem>();
+        fileSystem.Directory.Exists(Arg.Any<string>()).Returns(true);
+
+        var sut = BuildSut(fileManagerService, fileSystem, maliciousFolderName);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.RootFolders[0].OpenInFileManagerCommand.Execute(null);
+
+        fileManagerService.DidNotReceive().OpenFolder(Arg.Any<string>());
+    }
+
+    [Theory]
+    [InlineData("/etc/passwd")]
+    [InlineData("/root/.ssh")]
+    [InlineData("C:\\Windows\\System32")]
+    public async Task when_folder_name_is_absolute_path_escape_then_file_manager_is_not_launched(string absoluteEscapePath)
+    {
+        var fileManagerService = Substitute.For<IFileManagerService>();
+        var fileSystem = Substitute.For<IFileSystem>();
+        fileSystem.Directory.Exists(Arg.Any<string>()).Returns(true);
+
+        var sut = BuildSut(fileManagerService, fileSystem, absoluteEscapePath);
+
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.RootFolders[0].OpenInFileManagerCommand.Execute(null);
+
+        fileManagerService.DidNotReceive().OpenFolder(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task when_folder_name_is_legitimate_then_resolved_path_is_under_onedrive_base()
+    {
+        string capturedPath = string.Empty;
+        var fileManagerService = Substitute.For<IFileManagerService>();
+        fileManagerService.When(s => s.OpenFolder(Arg.Any<string>()))
+            .Do(call => capturedPath = call.Arg<string>());
+
+        var fileSystem = Substitute.For<IFileSystem>();
+        fileSystem.Directory.Exists(Arg.Any<string>()).Returns(true);
+
+        string oneDriveBase = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "OneDrive");
+
+        var sut = BuildSut(fileManagerService, fileSystem, "Photos");
+
+        await sut.LoadCommand.ExecuteAsync(null);
+        sut.RootFolders[0].OpenInFileManagerCommand.Execute(null);
+
+        fileManagerService.Received(1).OpenFolder(Arg.Any<string>());
+        capturedPath.ShouldStartWith(oneDriveBase, Case.Sensitive);
+    }
+
+    private static AccountFilesViewModel BuildSut(IFileManagerService fileManagerService, IFileSystem fileSystem, string folderName)
+    {
+        var authService = Substitute.For<IAuthService>();
+        var graphService = Substitute.For<IGraphService>();
+        var repository = Substitute.For<IAccountRepository>();
+        var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
+
+        authService.AcquireTokenSilentAsync(AccountIdString, Arg.Any<CancellationToken>())
+            .Returns(AuthResultFactory.Success(AccessToken, AccountIdString, AccountProfileFactory.Create("Test User", "test@test.com")));
+
+        graphService.GetDriveIdAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<DriveId, string>.Ok(new DriveId(DriveIdValue)));
+
+        graphService.GetRootFoldersAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId, folderName, Option.None<string>())]));
+
+        syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var account = new OneDriveAccount
+        {
+            Id = new AccountId(AccountIdString),
+            Profile = AccountProfileFactory.Create("Test User", "test@test.com")
+        };
+
+        return new AccountFilesViewModel(account, authService, graphService, repository, syncRuleRepo, fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
@@ -23,7 +23,7 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraver
     [Theory]
     [InlineData("../../etc")]
     [InlineData("../secret")]
-    [InlineData("..\\..\\Windows\\System32")]
+    [InlineData("subdir/../../secret")]
     public async Task when_folder_name_contains_parent_traversal_then_file_manager_is_not_launched(string maliciousFolderName)
     {
         var fileManagerService = Substitute.For<IFileManagerService>();
@@ -41,7 +41,6 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraver
     [Theory]
     [InlineData("/etc/passwd")]
     [InlineData("/root/.ssh")]
-    [InlineData("C:\\Windows\\System32")]
     public async Task when_folder_name_is_absolute_path_escape_then_file_manager_is_not_launched(string absoluteEscapePath)
     {
         var fileManagerService = Substitute.For<IFileManagerService>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -211,12 +211,29 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
     private void OnOpenInFileManager(object? sender, FolderTreeNodeViewModel node)
     {
-        string path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).CombinePath("OneDrive", node.Name);
+        string oneDriveBase = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile).CombinePath("OneDrive"));
 
-        if (!fileSystem.Directory.Exists(path))
+        string candidatePath;
+        try
+        {
+            candidatePath = Path.GetFullPath(oneDriveBase.CombinePath(node.Name));
+        }
+        catch (ArgumentException)
+        {
+            OneDriveSyncClientMessages.FileManagerPathEscapesBase(_logger, node.Name);
+            return;
+        }
+
+        if (!candidatePath.StartsWith(oneDriveBase + Path.DirectorySeparatorChar, StringComparison.Ordinal) && candidatePath != oneDriveBase)
+        {
+            OneDriveSyncClientMessages.FileManagerPathEscapesBase(_logger, candidatePath);
+            return;
+        }
+
+        if (!fileSystem.Directory.Exists(candidatePath))
             return;
 
-        _fileManagerService.OpenFolder(path);
+        _fileManagerService.OpenFolder(candidatePath);
     }
 
     private static IEnumerable<FolderTreeNodeViewModel> CollectAllVisible(IEnumerable<FolderTreeNodeViewModel> nodes)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Logging/OneDriveSyncClientMessages.cs
@@ -251,6 +251,10 @@ public static partial class OneDriveSyncClientMessages
     [LoggerMessage(EventId = 2905, Level = LogLevel.Warning, Message = "[FolderTreeNodeViewModel] Failed to load children for {Path}: {Error}")]
     public static partial void FolderChildrenLoadFailed(ILogger logger, string path, string error);
 
+    /// <summary>Logs refusal to open a path that escapes the OneDrive base directory.</summary>
+    [LoggerMessage(EventId = 2906, Level = LogLevel.Warning, Message = "[AccountFilesViewModel] Refused to open folder — path escapes OneDrive base: {CandidatePath}")]
+    public static partial void FileManagerPathEscapesBase(ILogger logger, string candidatePath);
+
     // Conflict Resolution (2950-2999)
 
     /// <summary>Logs conflict resolution failure to get download URL.</summary>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -6,7 +6,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.4",
+    "ApplicationVersion": "0.7.5",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

A folder name originating from the Graph API was interpolated directly into a filesystem path passed to `Process.Start` with no containment check. A crafted remote folder name such as `../../etc` or `/etc/passwd` could escape the expected `<UserProfile>/OneDrive/` base directory.

The fix adds path containment validation in `AccountFilesViewModel.OnOpenInFileManager`:
- `CombinePath` already throws `ArgumentException` for rooted segments (e.g. `/etc/passwd`) — the fix catches that and refuses gracefully.
- `Path.GetFullPath` is used to canonicalise the combined path; if the result does not start with the resolved OneDrive base, the request is refused with a structured warning log.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #494

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

New test class `GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal` with 6 tests covering:
- `../` and multi-hop `../../` traversal — file manager not launched
- `subdir/../../` traversal — file manager not launched
- Rooted absolute paths (`/etc/passwd`, `/root/.ssh`) — file manager not launched
- Legitimate folder name (`Photos`) — file manager launched with path confirmed under OneDrive base

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally — `Build succeeded. 0 Warning(s) 0 Error(s)`
- [x] Tests pass (`dotnet test`) — Unit: 1456 passed, 0 failed; Integration: 31 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed — no public API changes; `IFileManagerService` signature unchanged
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/
```

---

## Notes for reviewers

- `appsettings.json` `ApplicationVersion` bumped `0.7.4` → `0.7.5` per the app's bug-fix rule. This will conflict with any sibling P2 PRs that also bump the version — the last one to merge should set the correct final value.
- The containment check uses `StringComparison.Ordinal` to match `Path.GetFullPath` output exactly.
- The `..\..\Windows\System32` (Windows backslash) case is intentionally absent from tests: on Linux, backslash is a valid filename character and not a path separator, so this input stays under the OneDrive base and is not a traversal attack on Linux. On Windows the fix covers it because `Path.GetFullPath` resolves `\\` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)