### PR TITLE
fix(build): move PackageVersion entries from csproj files to Directory.Packages.props (#500)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,6 +112,7 @@
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
   </ItemGroup>
   <ItemGroup Label="Data access">
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
@@ -11,10 +11,6 @@
     <EmbeddedResource Include="Assets\Localization\*.json" />
   </ItemGroup>
 
-    <ItemGroup Label="Application Insights">
-        <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.ReactiveUI" />


### PR DESCRIPTION
# Summary

`Microsoft.ApplicationInsights.WorkerService` version `2.23.0` was declared inside `apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj` as a `<PackageVersion>` entry, violating the Central Package Management (CPM) rule that all version declarations must live exclusively in the root `Directory.Packages.props`. The version has been moved to the `Logging` group in `Directory.Packages.props` (alphabetically after `Microsoft.ApplicationInsights.AspNetCore`), and the local `ItemGroup Label="Application Insights"` block has been removed from the csproj. No `PackageReference` or application behaviour was changed — this is a build-plumbing-only fix and no `ApplicationVersion` bump is warranted.

A full `grep -rn "PackageVersion" --include='*.csproj'` scan was run across the repo; `AStar.Dev.OneDrive.Sync.Client.csproj` was the sole offender.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #500

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Manual validation
- [x] Not applicable

The build is the test for this change. `dotnet build` output (zero errors, zero warnings):

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:00:08.66
```

Test run results:

- Unit tests: **Passed — Failed: 0, Passed: 1472, Skipped: 0, Total: 1472**
- Integration tests: **Passed — Failed: 0, Passed: 31, Skipped: 0, Total: 31**

## Impacted areas

- `Directory.Packages.props` (root)
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet build apps/desktop/AStar.Dev.OneDrive.Sync.Client/AStar.Dev.OneDrive.Sync.Client.csproj
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
```

---

## Notes for reviewers

- Only one csproj in the repo had this violation (`AStar.Dev.OneDrive.Sync.Client.csproj`), confirmed by `grep -rn "PackageVersion" --include='*.csproj' .`
- The `PackageVersion` entry in the csproj had no corresponding `PackageReference` in the same file — it was a transitive-pinning declaration, now correctly centralised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)