### PR TITLE
fix(onedrive-sync-client): unwrap SyncConfig once at sync boundary instead of throw-on-None (#499)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -81,4 +81,36 @@ public sealed class GivenASyncedItemEntityFactory
 
         (entity.Tags.ETag is Option<string>.None).ShouldBeTrue();
     }
+
+    [Fact]
+    public void when_creating_from_upload_job_with_uploaded_id_then_remote_item_id_matches()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile("/local/file.txt").Which(m => m.HasStringContent("content"));
+
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("original-id"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "file.txt");
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
+        var job = SyncJobFactory.CreateUpload(remote, target, metadata);
+
+        var entity = SyncedItemEntityFactory.CreateFromUploadJob(new AccountId("acc-1"), job, "uploaded-remote-id", "/file.txt", mockFileSystem);
+
+        entity.RemoteItemId.Id.ShouldBe("uploaded-remote-id");
+    }
+
+    [Fact]
+    public void when_creating_from_upload_job_then_local_path_matches_job_target()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile("/local/file.txt").Which(m => m.HasStringContent("content"));
+
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("original-id"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "file.txt");
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
+        var job = SyncJobFactory.CreateUpload(remote, target, metadata);
+
+        var entity = SyncedItemEntityFactory.CreateFromUploadJob(new AccountId("acc-1"), job, "uploaded-remote-id", "/file.txt", mockFileSystem);
+
+        entity.LocalPath.ShouldBe("/local/file.txt");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -37,7 +37,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -58,7 +58,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -73,6 +73,7 @@ public sealed class GivenASyncService
 
         await _syncPassOrchestrator.Received(1).OrchestrateAsync(
             Arg.Is(account),
+            Arg.Any<AccountSyncConfig>(),
             Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
@@ -141,7 +142,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new SyncReAuthRequiredException()));
 
         var service = BuildSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
@@ -91,7 +91,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(false);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -107,7 +107,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -123,7 +123,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -181,7 +181,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         var sut = CreateSut();
@@ -196,7 +196,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var sut = CreateSut();
@@ -211,7 +211,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         var sut = CreateSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -38,7 +38,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private void SetupOrchestratorReturns(bool didRun) =>
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(didRun);
 
     [Fact]
@@ -132,7 +132,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_operation_cancelled_then_progress_is_sync_cancelled_localisation_key_with_idle_state()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         string? capturedMessage = null;
@@ -157,7 +157,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new InvalidOperationException("unexpected")));
 
         SyncState? capturedState = null;
@@ -247,6 +247,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
         Func<CancellationToken, Task<string>>? capturedFactory = null;
         _syncPassOrchestrator.OrchestrateAsync(
             Arg.Any<OneDriveAccount>(),
+            Arg.Any<AccountSyncConfig>(),
             Arg.Do<Func<CancellationToken, Task<string>>>(f => capturedFactory = f),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
@@ -271,6 +272,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
         Func<CancellationToken, Task<string>>? capturedFactory = null;
         _syncPassOrchestrator.OrchestrateAsync(
             Arg.Any<OneDriveAccount>(),
+            Arg.Any<AccountSyncConfig>(),
             Arg.Do<Func<CancellationToken, Task<string>>>(f => capturedFactory = f),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenADownloadJobBuilder.cs
@@ -25,6 +25,9 @@ public sealed class GivenADownloadJobBuilder
         SelectedFolderIds = []
     };
 
+    private static AccountSyncConfig CreateSyncConfig(ConflictPolicy policy = ConflictPolicy.Ignore)
+        => AccountSyncConfigFactory.Create(policy, LocalSyncPath.Restore(BasePath));
+
     private static SyncRuleEntity IncludeRule(string remotePath)
         => new() { RemotePath = remotePath, RuleType = RuleType.Include };
 
@@ -41,7 +44,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Other/a.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -53,7 +56,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FolderItem("subfolder-1", "/Documents/Sub") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRegistrar.Received(1).RegisterFolderAsync(Arg.Any<AccountId>(), Arg.Is<FolderDeltaItem>(i => i.Id.Id == "subfolder-1"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
     }
@@ -65,7 +68,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FolderItem("subfolder-1", "/Documents/Sub") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -77,7 +80,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].ShouldBeOfType<DownloadSyncJob>();
@@ -106,7 +109,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", etag: "etag-123") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -135,7 +138,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, conflict =>
+        await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, syncedItems, conflict =>
         {
             conflictsDetected.Add(conflict);
             return Task.CompletedTask;
@@ -156,7 +159,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-phantom", "/Documents/phantom.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRegistrar.Received(1).RegisterPhantomAsync(Arg.Any<AccountId>(), Arg.Is<FileDeltaItem>(i => i.Id.Id == "item-phantom"), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<CancellationToken>());
     }
@@ -172,7 +175,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-phantom", "/Documents/phantom.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -201,7 +204,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -231,7 +234,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: newRemoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].ShouldBeOfType<DownloadSyncJob>();
@@ -244,7 +247,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/2024/report.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].Target.LocalPath.ShouldStartWith(BasePath);
@@ -257,7 +260,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/2024/report.txt") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].Target.LocalPath.ShouldNotBe(BasePath);
@@ -286,7 +289,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.RemoteWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.RemoteWins), CreateSyncConfig(ConflictPolicy.RemoteWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].ShouldBeOfType<DownloadSyncJob>();
@@ -315,7 +318,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.LocalWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.LocalWins), CreateSyncConfig(ConflictPolicy.LocalWins), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].ShouldBeOfType<UploadSyncJob>();
@@ -344,7 +347,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", lastModified: remoteModified) };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.Ignore), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(ConflictPolicy.Ignore), CreateSyncConfig(ConflictPolicy.Ignore), items, rules, syncedItems, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -356,7 +359,7 @@ public sealed class GivenADownloadJobBuilder
         var items = new List<DeltaItem> { FileItem("item-a", "/Documents/a.txt", etag: "etag-from-delta") };
         var rules = new List<SyncRuleEntity> { IncludeRule("/Documents") };
 
-        var result = await sut.BuildAsync(CreateAccount(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
+        var result = await sut.BuildAsync(CreateAccount(), CreateSyncConfig(), items, rules, [], _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         result.ShouldHaveSingleItem();
         result[0].Metadata.VersionInfo.TryGetValue(out var vi).ShouldBeTrue();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -48,6 +48,9 @@ public sealed class GivenASyncPassOrchestrator
         SelectedFolderIds = []
     };
 
+    private static AccountSyncConfig CreateSyncConfig(string localSyncPath = "/path/to/sync")
+        => AccountSyncConfigFactory.Create(ConflictPolicy.Ignore, LocalSyncPath.Restore(localSyncPath));
+
     private static RemoteEnumerationResult EmptyEnumerationResult() => new([], new HashSet<string>(), [], []);
 
     private static bool IsEnumerationProgressEvent(SyncProgressEventArgs args)
@@ -59,7 +62,7 @@ public sealed class GivenASyncPassOrchestrator
             .Returns(Option.None<DriveStateEntity>());
         _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
             .Returns(EmptyEnumerationResult());
-        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SyncJob>)[]);
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
             .Returns([]);
@@ -79,7 +82,7 @@ public sealed class GivenASyncPassOrchestrator
                     onItemDiscovered?.Invoke(i);
                 return Task.FromResult(EmptyEnumerationResult());
             });
-        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SyncJob>)[]);
         _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
             .Returns([]);
@@ -96,7 +99,7 @@ public sealed class GivenASyncPassOrchestrator
         var account = CreateAccount();
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
 
-        await sut.OrchestrateAsync(account, tokenFactory, _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), tokenFactory, _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteFolderEnumerator.Received(1).EnumerateAsync(
             Arg.Is(account),
@@ -116,7 +119,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        bool result = await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        bool result = await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         result.ShouldBeFalse();
     }
@@ -132,7 +135,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteDeletionDetector.DidNotReceive().DetectAndApplyAsync(
             Arg.Any<AccountId>(),
@@ -150,7 +153,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        bool result = await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        bool result = await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         result.ShouldBeTrue();
     }
@@ -163,7 +166,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _remoteDeletionDetector.Received(1).DetectAndApplyAsync(
             Arg.Any<AccountId>(),
@@ -181,7 +184,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _localDeletionDetector.Received(1).DetectAndApplyAsync(
             Arg.Any<AccountId>(),
@@ -198,7 +201,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _syncJobExecutor.DidNotReceive().ExecuteAsync(
             Arg.Any<OneDriveAccount>(),
@@ -219,7 +222,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut              = CreateSut();
         var account          = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
         progressMessages.ShouldContain("No changes");
     }
@@ -233,7 +236,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut              = CreateSut();
         var account          = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, onProgress: args => progressMessages.Add(args.CurrentFile), ct: TestContext.Current.CancellationToken);
 
         progressMessages.ShouldContain("Detecting remote deletions...");
         progressMessages.ShouldContain("Detecting local changes...");
@@ -250,7 +253,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _accountRepository.Received(1).UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
     }
@@ -263,7 +266,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
 
         await _accountRepository.DidNotReceive().UpsertAsync(Arg.Any<AccountEntity>(), Arg.Any<CancellationToken>());
     }
@@ -280,10 +283,10 @@ public sealed class GivenASyncPassOrchestrator
         };
         bool callbackInvoked = false;
 
-        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
+        _downloadJobBuilder.BuildAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<IReadOnlyList<DeltaItem>>(), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<Dictionary<string, SyncedItemEntity>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<CancellationToken>())
             .Returns(async args =>
             {
-                var callback = args.ArgAt<Func<SyncConflict, Task>>(4);
+                var callback = args.ArgAt<Func<SyncConflict, Task>>(5);
                 await callback(conflict);
 
                 return (IReadOnlyList<SyncJob>)[];
@@ -292,7 +295,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), async detectedConflict =>
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), async detectedConflict =>
         {
             if(detectedConflict.Id == conflict.Id)
                 callbackInvoked = true;
@@ -300,6 +303,24 @@ public sealed class GivenASyncPassOrchestrator
         }, ct: TestContext.Current.CancellationToken);
 
         callbackInvoked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_sync_config_local_path_is_passed_then_local_change_detector_receives_that_path()
+    {
+        SetupDeepSyncPrerequisites();
+
+        string? capturedPath = null;
+        _localChangeDetector.DetectNewAndModifiedFiles(Arg.Any<string>(), Arg.Do<string>(p => capturedPath = p), Arg.Any<IReadOnlyList<SyncRuleEntity>>(), Arg.Any<IReadOnlyDictionary<string, SyncedItemEntity>>())
+            .Returns([]);
+
+        var sut        = CreateSut();
+        var account    = CreateAccount("/my/local/path");
+        var syncConfig = CreateSyncConfig("/my/local/path");
+
+        await sut.OrchestrateAsync(account, syncConfig, _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: TestContext.Current.CancellationToken);
+
+        capturedPath.ShouldBe("/my/local/path");
     }
 
     // --- enumeration progress throttle ---
@@ -313,7 +334,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask,
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask,
             onProgress: args =>
             {
                 if (IsEnumerationProgressEvent(args))
@@ -333,7 +354,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask,
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask,
             onProgress: args =>
             {
                 if (IsEnumerationProgressEvent(args))
@@ -353,7 +374,7 @@ public sealed class GivenASyncPassOrchestrator
         var sut     = CreateSut();
         var account = CreateAccount();
 
-        await sut.OrchestrateAsync(account, _ => Task.FromResult("token"), _ => Task.CompletedTask,
+        await sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask,
             onProgress: args =>
             {
                 if (IsEnumerationProgressEvent(args))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -73,17 +73,20 @@ public static class SyncedItemEntityFactory
 
     /// <summary>
     /// Creates a tracking entity for a successfully completed upload job.
+    /// <paramref name="uploadedRemoteItemId"/> must be the unwrapped remote item ID assigned by OneDrive after upload;
+    /// callers are responsible for verifying the value is present before invoking this method.
     /// </summary>
     /// <param name="accountId">The ID of the account to which the item belongs.</param>
     /// <param name="job">The upload job that was completed.</param>
+    /// <param name="uploadedRemoteItemId">The remote item ID returned by OneDrive for the uploaded file.</param>
     /// <param name="remotePath">The remote path of the item in OneDrive.</param>
     /// <param name="fileSystem">The file system abstraction.</param>
     /// <returns>A new instance of <see cref="SyncedItemEntity"/>.</returns>
-    public static SyncedItemEntity CreateFromUploadJob(AccountId accountId, UploadSyncJob job, string remotePath, IFileSystem fileSystem)
+    public static SyncedItemEntity CreateFromUploadJob(AccountId accountId, UploadSyncJob job, string uploadedRemoteItemId, string remotePath, IFileSystem fileSystem)
         => new()
         {
             AccountId = accountId,
-            RemoteItemId = new OneDriveItemId(job.UploadedRemoteItemId.Match(v => v, () => throw new InvalidOperationException("UploadedRemoteItemId is None"))),
+            RemoteItemId = new OneDriveItemId(uploadedRemoteItemId),
             RemoteParentId = string.Empty,
             RemotePath = remotePath,
             LocalPath = job.Target.LocalPath,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/DownloadJobBuilder.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar, IFileSystem fileSystem, ILogger<DownloadJobBuilder> logger) : IDownloadJobBuilder
 {
     /// <inheritdoc />
-    public async Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    public async Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, AccountSyncConfig syncConfig, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
     {
         List<SyncJob> jobs = [];
 
@@ -26,7 +26,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
 
             if (item is FolderDeltaItem folderItem)
             {
-                string folderLocalPath = BuildLocalPath(account.SyncConfig.Match(v => v, () => throw new InvalidOperationException("SyncConfig is None")).LocalSyncPath.Value, folderItem.Path.EffectivePath.TrimStart('/'));
+                string folderLocalPath = BuildLocalPath(syncConfig.LocalSyncPath.Value, folderItem.Path.EffectivePath.TrimStart('/'));
                 await syncedItemRegistrar.RegisterFolderAsync(account.Id, folderItem, folderItem.Path.EffectivePath, folderLocalPath, syncedItems, ct).ConfigureAwait(false);
                 continue;
             }
@@ -34,7 +34,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
             if (item is not FileDeltaItem fileItem)
                 continue;
 
-            var job = await ProcessFileItemAsync(account, fileItem, syncedItems, onConflict, ct).ConfigureAwait(false);
+            var job = await ProcessFileItemAsync(account, syncConfig, fileItem, syncedItems, onConflict, ct).ConfigureAwait(false);
             if (job is not null)
                 jobs.Add(job);
         }
@@ -42,9 +42,9 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return jobs;
     }
 
-    private async Task<SyncJob?> ProcessFileItemAsync(OneDriveAccount account, FileDeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
+    private async Task<SyncJob?> ProcessFileItemAsync(OneDriveAccount account, AccountSyncConfig syncConfig, FileDeltaItem item, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct)
     {
-        string localPath = BuildLocalPath(account.SyncConfig.Match(v => v, () => throw new InvalidOperationException("SyncConfig is None")).LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
+        string localPath = BuildLocalPath(syncConfig.LocalSyncPath.Value, item.Path.EffectivePath.TrimStart('/'));
         syncedItems.TryGetValue(item.Id.Id, out var knownItem);
 
         if (knownItem?.Tags.ETag is Option<string>.Some && knownItem.Tags.ETag == item.VersionInfo.ETag && fileSystem.File.Exists(localPath))
@@ -59,7 +59,7 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
             bool isConflict = localModified > knownItem.RemoteModifiedAt.AddSeconds(5);
 
             if (isConflict)
-                return await BuildConflictJobAsync(account, item, localPath, localModified, onConflict).ConfigureAwait(false);
+                return await BuildConflictJobAsync(account, syncConfig, item, localPath, localModified, onConflict).ConfigureAwait(false);
 
             bool remoteUnchanged = item.LastModified.Match(lm => lm <= knownItem.RemoteModifiedAt.AddSeconds(5), () => true);
             if (remoteUnchanged)
@@ -74,12 +74,12 @@ public sealed class DownloadJobBuilder(ISyncedItemRegistrar syncedItemRegistrar,
         return BuildDownloadJob(account.Id, item, localPath);
     }
 
-    private async Task<SyncJob?> BuildConflictJobAsync(OneDriveAccount account, FileDeltaItem item, string localPath, DateTimeOffset localModified, Func<SyncConflict, Task> onConflict)
+    private async Task<SyncJob?> BuildConflictJobAsync(OneDriveAccount account, AccountSyncConfig syncConfig, FileDeltaItem item, string localPath, DateTimeOffset localModified, Func<SyncConflict, Task> onConflict)
     {
         var conflict = BuildConflict(account, item, localPath, localModified);
         await onConflict(conflict).ConfigureAwait(false);
 
-        var outcome = ConflictResolver.Resolve(account.SyncConfig.Match(v => v, () => throw new InvalidOperationException("SyncConfig is None")).ConflictPolicy, localModified, item.LastModified.MapOrDefault(v => v, DateTimeOffset.MinValue));
+        var outcome = ConflictResolver.Resolve(syncConfig.ConflictPolicy, localModified, item.LastModified.MapOrDefault(v => v, DateTimeOffset.MinValue));
 
         return outcome switch
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IDownloadJobBuilder.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/IDownloadJobBuilder.cs
@@ -14,5 +14,5 @@ public interface IDownloadJobBuilder
     /// Processes <paramref name="items"/>, applies sync rule filtering, registers folders and phantom
     /// files via <see cref="ISyncedItemRegistrar"/>, detects conflicts, and returns the resulting jobs.
     /// </summary>
-    Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct);
+    Task<IReadOnlyList<SyncJob>> BuildAsync(OneDriveAccount account, AccountSyncConfig syncConfig, IReadOnlyList<DeltaItem> items, IReadOnlyList<SyncRuleEntity> rules, Dictionary<string, SyncedItemEntity> syncedItems, Func<SyncConflict, Task> onConflict, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
@@ -1,4 +1,5 @@
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 
@@ -11,7 +12,8 @@ public interface ISyncPassOrchestrator
 {
     /// <summary>
     /// Runs the full sync pass pipeline for <paramref name="account"/> using <paramref name="tokenFactory"/> for Graph API calls.
+    /// <paramref name="syncConfig"/> is the unwrapped sync configuration, resolved by the caller before invoking this method.
     /// Returns <see langword="true"/> when at least one sync rule was active; <see langword="false"/> when no folders were selected.
     /// </summary>
-    Task<bool> OrchestrateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
+    Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -57,7 +57,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             }
             else if(job is UploadSyncJob uploadJob && uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId)
             {
-                var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, uploadJob, remotePath, fileSystem);
+                var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, uploadJob, uploadedId.Value, remotePath, fileSystem);
                 int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
                 syncedItems[uploadedId.Value] = entity;
                 await ClassifyAsync(syncedItemId, remotePath, mappings, ct).ConfigureAwait(false);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -11,7 +11,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, SyncServiceDependencies dependencies, IOptions<SyncSettings> syncSettings) : ISyncPassOrchestrator
 {
-    public async Task<bool> OrchestrateAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
+    public async Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
     {
         var driveState = (await driveStateRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false))
             .Match(v => v, () => new DriveStateEntity { AccountId = account.Id });
@@ -40,10 +40,10 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         RaiseProgress(account.Id.Id, 0, 0, "Detecting local changes...", onProgress);
         await dependencies.LocalDeletionDetector.DetectAndApplyAsync(account.Id, tokenFactory, syncedItemsDict, ct).ConfigureAwait(false);
 
-        var downloadJobs = await dependencies.DownloadJobBuilder.BuildAsync(account, enumerationResult.DeltaItems, enumerationResult.Rules, syncedItemsDict, conflictCallback, ct).ConfigureAwait(false);
+        var downloadJobs = await dependencies.DownloadJobBuilder.BuildAsync(account, syncConfig, enumerationResult.DeltaItems, enumerationResult.Rules, syncedItemsDict, conflictCallback, ct).ConfigureAwait(false);
 
         var syncedItemsByLocalPath = syncedItemsDict.Values.ToDictionary(i => i.LocalPath, StringComparer.OrdinalIgnoreCase);
-        var uploadJobs = dependencies.LocalChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, account.SyncConfig.Match(v => v, () => throw new InvalidOperationException("SyncConfig is None")).LocalSyncPath.Value, enumerationResult.Rules, syncedItemsByLocalPath);
+        var uploadJobs = dependencies.LocalChangeDetector.DetectNewAndModifiedFiles(account.Id.Id, syncConfig.LocalSyncPath.Value, enumerationResult.Rules, syncedItemsByLocalPath);
 
         var allJobs = new List<SyncJob>(downloadJobs.Count + uploadJobs.Count);
         allJobs.AddRange(downloadJobs);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -46,13 +46,14 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             return;
         }
 
-        if (account.SyncConfig is Option<AccountSyncConfig>.None)
+        if (account.SyncConfig is not Option<AccountSyncConfig>.Some syncConfigSome)
         {
             RaiseProgress(account.Id.Id, 0, 0, localizationService.GetLocal("Sync.NoSyncPath"), SyncState.Error);
 
             return;
         }
 
+        var syncConfig = syncConfigSome.Value;
         var (initialToken, initialExpiry) = initialAuth.Match<(string, DateTimeOffset)>(ok => (ok.AccessToken, ok.ExpiresOn), _ => (string.Empty, DateTimeOffset.MinValue));
         using var tokenFactory = new CachedTokenFactory(account.Id.Id, authService, initialToken, initialExpiry);
 
@@ -60,6 +61,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
         {
             bool didRun = await syncPassOrchestrator.OrchestrateAsync(
                 account,
+                syncConfig,
                 tokenFactory.GetTokenAsync,
                 async conflict =>
                 {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.5",
+    "ApplicationVersion": "0.7.6",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Removes all four `Option<T>.Match(v => v, () => throw new InvalidOperationException(...))` unwrap sites deep in the call chain, replacing them with a single upfront unwrap at the sync boundary (`SyncService.SyncAccountAsync`) and type-safe propagation of the resolved value.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #499

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

Unit tests updated across all five affected test classes. Three new tests added:
- `GivenASyncPassOrchestrator.when_sync_config_local_path_is_passed_then_local_change_detector_receives_that_path` — pins that `syncConfig` flows through the orchestrator to `LocalChangeDetector`
- `GivenASyncedItemEntityFactory.when_creating_from_upload_job_with_uploaded_id_then_remote_item_id_matches` — covers new `CreateFromUploadJob` signature
- `GivenASyncedItemEntityFactory.when_creating_from_upload_job_then_local_path_matches_job_target` — same

Baseline: Unit 1472/0, Integration 31/0. Final: Unit 1475/0, Integration 31/0.

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client` — production sync pipeline
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit` — test updates

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/AStar.Dev.OneDrive.Sync.Client.Tests.Integration.csproj
```

---

## Notes for reviewers

**Signature changes made:**

- `ISyncPassOrchestrator.OrchestrateAsync` / `SyncPassOrchestrator.OrchestrateAsync`: added `AccountSyncConfig syncConfig` as second parameter (after `account`). `SyncService` unwraps `account.SyncConfig` via `is Option<AccountSyncConfig>.Some` pattern match — the existing `None` guard — and passes the resolved value down. All four throw-on-None sites in the orchestrator and builder are deleted.

- `IDownloadJobBuilder.BuildAsync` / `DownloadJobBuilder.BuildAsync`: added `AccountSyncConfig syncConfig` as second parameter. The orchestrator, which already has the resolved config, passes it through. The three `account.SyncConfig.Match(v => v, () => throw...)` calls in `BuildAsync` and `BuildConflictJobAsync` are replaced with direct property access on `syncConfig`.

- `SyncedItemEntityFactory.CreateFromUploadJob`: signature changed from `(AccountId, UploadSyncJob, string remotePath, IFileSystem)` to `(AccountId, UploadSyncJob, string uploadedRemoteItemId, string remotePath, IFileSystem)`. The caller (`SyncJobExecutor`) already guards `uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId` before calling the factory, so it holds the unwrapped value and passes `uploadedId.Value` directly. This removes the throw-on-None inside the factory without losing the invariant check.

**Why this approach for `SyncedItemEntityFactory`:** making the factory accept the raw `string` is the smallest change that removes the internal throw while preserving the caller's existing guard. Changing the factory return type to `Result<T>` would be a larger API change with more callers to update; the current caller-side guard is already the correct boundary.

**Conflict note:** this PR touches `SyncPassOrchestrator.OrchestrateAsync`, which the sibling PR #496 (localisation injection) also modifies. Recommend merging one then rebasing the other to resolve. The `appsettings.json` version bump (0.7.5 → 0.7.6) will also conflict with any other in-flight fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)