### PR TITLE
fix(onedrive-sync-client): extract ISyncRuleService from AccountFilesViewModel (#498)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelFolderCountChanged.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelFolderCountChanged.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -76,7 +77,7 @@ public sealed class GivenAnAccountFilesViewModelFolderCountChanged
         graphService.GetRootFoldersAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<List<DriveFolder>, string>.Ok([new DriveFolder(FolderId, FolderName, Option.None<string>())]));
 
-        return new AccountFilesViewModel(BuildAccount(), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new AccountFilesViewModel(BuildAccount(), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 
     private static OneDriveAccount BuildAccount()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManager.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
@@ -76,6 +77,6 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManager
             Profile = AccountProfileFactory.Create("Test User", "test@test.com")
         };
 
-        return new AccountFilesViewModel(account, authService, graphService, repository, syncRuleRepo, fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new AccountFilesViewModel(account, authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraversal.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -102,6 +103,6 @@ public sealed class GivenAnAccountFilesViewModelOpeningFileManagerWithPathTraver
             Profile = AccountProfileFactory.Create("Test User", "test@test.com")
         };
 
-        return new AccountFilesViewModel(account, authService, graphService, repository, syncRuleRepo, fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new AccountFilesViewModel(account, authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), fileSystem, fileManagerService, Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAConfiguredSyncPath.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -44,7 +45,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.LastWriteWins), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.LastWriteWins), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         sut.RootFolders[0].ToggleIncludeCommand.Execute(null);
@@ -64,7 +65,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -87,7 +88,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -110,7 +111,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -133,7 +134,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -155,7 +156,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = $"/{FolderName}", RuleType = RuleType.Include }]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -177,7 +178,7 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(LocalSyncPathString, ConflictPolicy.Ignore), authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
         await sut.RootFolders[0].ToggleExpandCommand.ExecuteAsync(null);
@@ -239,6 +240,6 @@ public sealed class GivenAnAccountFilesViewModelWithAConfiguredSyncPath
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        return new(account, authService, graphService, repository, syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new(account, authService, graphService, repository, new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithAuthFailure.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -27,7 +28,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
     {
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
 
-        return new AccountFilesViewModel(BuildAccount(), authService, Substitute.For<IGraphService>(), Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new AccountFilesViewModel(BuildAccount(), authService, Substitute.For<IGraphService>(), Substitute.For<IAccountRepository>(), new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 
     [Fact]
@@ -120,7 +121,7 @@ public sealed class GivenAnAccountFilesViewModelWithAuthFailure
         var syncRuleRepo = Substitute.For<ISyncRuleRepository>();
         syncRuleRepo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns([]);
 
-        var sut = new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        var sut = new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
 
         await sut.LoadCommand.ExecuteAsync(null);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/GivenAnAccountFilesViewModelWithDriveIdFetchFailure.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -70,7 +71,7 @@ public sealed class GivenAnAccountFilesViewModelWithDriveIdFetchFailure
         graphService.GetDriveIdAsync(AccountIdString, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
             .Returns(new Result<DriveId, string>.Error(DriveIdErrorMessage));
 
-        return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), syncRuleRepo, Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
+        return new AccountFilesViewModel(BuildAccount(), authService, graphService, Substitute.For<IAccountRepository>(), new SyncRuleService(syncRuleRepo, Substitute.For<ILogger<SyncRuleService>>()), Substitute.For<IFileSystem>(), Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), Substitute.For<ILocalizationService>());
     }
 
     private static OneDriveAccount BuildAccount() => new()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
@@ -44,7 +45,7 @@ public sealed class GivenAMainWindowViewModel
     }
 
     private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
-    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
+    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleService>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService, new InlineUiDispatcher());
     private FileClassificationRulesViewModel CreateClassificationRulesViewModel()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Rules/GivenASyncRuleService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Rules/GivenASyncRuleService.cs
@@ -1,0 +1,159 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
+using Microsoft.Extensions.Logging;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Rules;
+
+public sealed class GivenASyncRuleService
+{
+    private const string AccountIdString = "account-1";
+    private const string ParentPath = "/Photos";
+    private const string ChildPath = "/Photos/Holidays";
+    private const string ParentItemId = "item-parent";
+    private const string ChildItemId = "item-child";
+
+    [Fact]
+    public async Task when_applying_include_rule_then_child_rules_are_deleted_first()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Include, [(ParentPath, ParentItemId)], CancellationToken.None);
+
+        await repo.Received(1).DeleteChildRulesAsync(accountId, ParentPath, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_applying_include_rule_then_all_provided_nodes_are_upserted()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+        (string RemotePath, string Id)[] nodes = [(ParentPath, ParentItemId), (ChildPath, ChildItemId)];
+
+        await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Include, nodes, CancellationToken.None);
+
+        await repo.Received(1).UpsertAsync(accountId, ParentPath, RuleType.Include, ParentItemId, Arg.Any<CancellationToken>());
+        await repo.Received(1).UpsertAsync(accountId, ChildPath, RuleType.Include, ChildItemId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_applying_exclude_rule_then_only_the_single_node_is_upserted()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Exclude, [(ParentPath, ParentItemId)], CancellationToken.None);
+
+        await repo.Received(1).UpsertAsync(accountId, ParentPath, RuleType.Exclude, ParentItemId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_applying_include_rule_then_returns_count_of_include_rules()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ParentPath, RuleType = RuleType.Include },
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ChildPath, RuleType = RuleType.Include }
+            ]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        int result = await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Include, [(ParentPath, ParentItemId)], CancellationToken.None);
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_applying_exclude_rule_then_returns_count_of_remaining_include_rules()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ChildPath, RuleType = RuleType.Include }
+            ]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        int result = await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Exclude, [(ParentPath, ParentItemId)], CancellationToken.None);
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task when_applying_include_rule_then_delete_is_called_before_upsert()
+    {
+        var callOrder = new List<string>();
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        repo.DeleteChildRulesAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { callOrder.Add("delete"); return Task.CompletedTask; });
+
+        repo.UpsertAsync(Arg.Any<AccountId>(), Arg.Any<string>(), Arg.Any<RuleType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { callOrder.Add("upsert"); return Task.CompletedTask; });
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        await sut.ApplyRuleAsync(accountId, ParentPath, RuleType.Include, [(ParentPath, ParentItemId)], CancellationToken.None);
+
+        callOrder[0].ShouldBe("delete");
+        callOrder[1].ShouldBe("upsert");
+    }
+
+    [Fact]
+    public async Task when_getting_included_rules_then_returns_rules_for_account()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ParentPath, RuleType = RuleType.Include }
+            ]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        var result = await sut.GetIncludedPathsAsync(accountId, CancellationToken.None);
+
+        result.ShouldContain(ParentPath);
+    }
+
+    [Fact]
+    public async Task when_getting_included_rules_then_exclude_rules_are_not_returned()
+    {
+        var repo = Substitute.For<ISyncRuleRepository>();
+        repo.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ParentPath, RuleType = RuleType.Include },
+                new SyncRuleEntity { AccountId = new AccountId(AccountIdString), RemotePath = ChildPath, RuleType = RuleType.Exclude }
+            ]);
+
+        var sut = BuildSut(repo);
+        var accountId = new AccountId(AccountIdString);
+
+        var result = await sut.GetIncludedPathsAsync(accountId, CancellationToken.None);
+
+        result.ShouldNotContain(ChildPath);
+    }
+
+    private static SyncRuleService BuildSut(ISyncRuleRepository repo)
+        => new(repo, Substitute.For<ILogger<SyncRuleService>>());
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -8,6 +8,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
@@ -35,7 +36,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
     private readonly IAuthService authService = Substitute.For<IAuthService>();
     private readonly IGraphService graphService = Substitute.For<IGraphService>();
     private readonly IAccountRepository accountRepository = Substitute.For<IAccountRepository>();
-    private readonly ISyncRuleRepository syncRuleRepository = Substitute.For<ISyncRuleRepository>();
+    private readonly ISyncRuleService syncRuleService = Substitute.For<ISyncRuleService>();
     private readonly ISyncEventAggregator syncEventAggregator = Substitute.For<ISyncEventAggregator>();
     private readonly ISyncService syncService = Substitute.For<ISyncService>();
     private readonly ISyncRepository syncRepository = Substitute.For<ISyncRepository>();
@@ -72,7 +73,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
     private MainWindowViewModel CreateMainWindowViewModel()
     {
         var accounts = new AccountsViewModel(authService, graphService, accountRepository, Substitute.For<IAccountOnboardingService>(), Substitute.For<IQuotaRefreshService>(), syncEventAggregator, localizationService, Substitute.For<ILogger<AccountsViewModel>>());
-        var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleRepository, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), localizationService);
+        var files = new FilesViewModel(authService, graphService, accountRepository, syncRuleService, fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), localizationService);
         var dashboard = new DashboardViewModel(schedulerForViewModel, localizationService, accountRepository, syncEventAggregator);
         var activity = new ActivityViewModel(syncService, syncRepository, syncEventAggregator, localizationService, new InlineUiDispatcher());
         var classificationRepo = Substitute.For<IFileClassificationRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
@@ -50,7 +51,7 @@ public sealed class GivenAnApplicationInitializer
         => Task.FromResult<Result<List<OneDriveAccount>, string>>(new Result<List<OneDriveAccount>, string>.Error(message));
 
     private AccountsViewModel CreateAccountsViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<IAccountOnboardingService>(), _quotaRefreshService, _syncEventAggregator, _localizationService, Substitute.For<ILogger<AccountsViewModel>>());
-    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleRepository>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
+    private FilesViewModel CreateFilesViewModel() => new(_authService, _graphService, _accountRepository, Substitute.For<ISyncRuleService>(), _fileSystem, Substitute.For<IFileManagerService>(), Substitute.For<ILogger<AccountFilesViewModel>>(), Substitute.For<ILogger<FolderTreeNodeViewModel>>(), _localizationService);
     private DashboardViewModel CreateDashboardViewModel() => new(_scheduler, _localizationService, _accountRepository, _syncEventAggregator);
     private ActivityViewModel CreateActivityViewModel() => new(_syncService, _syncRepository, _syncEventAggregator, _localizationService, new InlineUiDispatcher());
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Accounts/AccountFilesViewModel.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
@@ -19,13 +20,13 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Accounts;
 
-public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> logger, ILogger<FolderTreeNodeViewModel> folderTreeLogger, ILocalizationService localizationService) : ObservableObject
+public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleService syncRuleService, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> logger, ILogger<FolderTreeNodeViewModel> folderTreeLogger, ILocalizationService localizationService) : ObservableObject
 {
     private readonly OneDriveAccount _account = account;
     private readonly IAuthService _authService = authService;
     private readonly IGraphService _graphService = graphService;
     private readonly IAccountRepository _repository = repository;
-    private readonly ISyncRuleRepository _syncRuleRepository = syncRuleRepository;
+    private readonly ISyncRuleService _syncRuleService = syncRuleService;
     private readonly IFileManagerService _fileManagerService = fileManagerService;
     private readonly ILogger<AccountFilesViewModel> _logger = logger;
     private readonly ILogger<FolderTreeNodeViewModel> _folderTreeLogger = folderTreeLogger;
@@ -106,7 +107,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
 
             _driveId = new Option<DriveId>.Some(driveId.Value);
 
-            var includedPaths = await LoadRulesAsync();
+            var includedPaths = await _syncRuleService.GetIncludedPathsAsync(_account.Id, CancellationToken.None);
             await BuildRootFoldersAsync(includedPaths);
         }
         catch (Exception ex)
@@ -120,17 +121,7 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         }
     }
 
-    private async Task<HashSet<string>> LoadRulesAsync()
-    {
-        var existingRules = await _syncRuleRepository.GetByAccountIdAsync(_account.Id, CancellationToken.None);
-
-        return existingRules
-            .Where(r => r.RuleType == RuleType.Include)
-            .Select(r => r.RemotePath)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-    }
-
-    private async Task BuildRootFoldersAsync(HashSet<string> includedPaths)
+    private async Task BuildRootFoldersAsync(IReadOnlySet<string> includedPaths)
     {
         var folders = await _graphService.GetRootFoldersAsync(_account.Id.Id, _ => Task.FromResult(_accessToken ?? string.Empty))
             .MatchAsync<List<DriveFolder>, string, List<DriveFolder>?>(
@@ -182,21 +173,13 @@ public sealed partial class AccountFilesViewModel(OneDriveAccount account, IAuth
         try
         {
             var ruleType = node.IsIncluded ? RuleType.Include : RuleType.Exclude;
-            string ruleTypeName = ruleType.ToString();
-
-            OneDriveSyncClientMessages.RulePersisting(_logger, ruleTypeName, node.RemotePath, _account.Id.Id);
-
-            await _syncRuleRepository.DeleteChildRulesAsync(_account.Id, node.RemotePath, CancellationToken.None);
 
             var affected = ruleType == RuleType.Include
                 ? CollectAllVisible([node])
                 : [node];
 
-            foreach (var item in affected)
-                await _syncRuleRepository.UpsertAsync(_account.Id, item.RemotePath, ruleType, item.Id, CancellationToken.None);
-
-            var updatedRules = await _syncRuleRepository.GetByAccountIdAsync(_account.Id, CancellationToken.None);
-            int includedCount = updatedRules.Count(r => r.RuleType == RuleType.Include);
+            var ruleNodes = affected.Select(item => (item.RemotePath, item.Id)).ToList();
+            int includedCount = await _syncRuleService.ApplyRuleAsync(_account.Id, node.RemotePath, ruleType, ruleNodes, CancellationToken.None);
 
             FolderCountChanged?.Invoke(this, includedCount);
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FilesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/FilesViewModel.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -12,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
-public sealed partial class FilesViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleRepository syncRuleRepository, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> accountFilesLogger, ILogger<FolderTreeNodeViewModel> folderTreeLogger, ILocalizationService localizationService) : ObservableObject
+public sealed partial class FilesViewModel(IAuthService authService, IGraphService graphService, IAccountRepository repository, ISyncRuleService syncRuleService, IFileSystem fileSystem, IFileManagerService fileManagerService, ILogger<AccountFilesViewModel> accountFilesLogger, ILogger<FolderTreeNodeViewModel> folderTreeLogger, ILocalizationService localizationService) : ObservableObject
 {
     public ObservableCollection<AccountFilesViewModel> Tabs { get; } = [];
 
@@ -39,7 +40,7 @@ public sealed partial class FilesViewModel(IAuthService authService, IGraphServi
             return;
 
         var tab = new AccountFilesViewModel(
-            account, authService, graphService, repository, syncRuleRepository, fileSystem, fileManagerService, accountFilesLogger, folderTreeLogger, localizationService);
+            account, authService, graphService, repository, syncRuleService, fileSystem, fileManagerService, accountFilesLogger, folderTreeLogger, localizationService);
 
         tab.ViewActivityRequested += (_, node) =>
             ViewActivityRequested?.Invoke(this,

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/ISyncRuleService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/ISyncRuleService.cs
@@ -1,0 +1,16 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
+
+/// <summary>
+/// Encapsulates sync-rule persistence logic so view models never access <see cref="Data.Repositories.ISyncRuleRepository" /> directly.
+/// </summary>
+public interface ISyncRuleService
+{
+    /// <summary>Removes all rules beneath <paramref name="parentRemotePath" />, upserts the supplied nodes with <paramref name="ruleType" />, and returns the resulting count of include rules for the account.</summary>
+    Task<int> ApplyRuleAsync(AccountId accountId, string parentRemotePath, RuleType ruleType, IReadOnlyList<(string RemotePath, string Id)> nodes, CancellationToken cancellationToken);
+
+    /// <summary>Returns the remote paths of all include rules for the account, compared case-insensitively.</summary>
+    Task<IReadOnlySet<string>> GetIncludedPathsAsync(AccountId accountId, CancellationToken cancellationToken);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/SyncRuleService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/SyncRuleService.cs
@@ -1,0 +1,37 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using Microsoft.Extensions.Logging;
+using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
+
+/// <summary>
+/// Default <see cref="ISyncRuleService" /> implementation backed by <see cref="ISyncRuleRepository" />.
+/// </summary>
+public sealed class SyncRuleService(ISyncRuleRepository syncRuleRepository, ILogger<SyncRuleService> logger) : ISyncRuleService
+{
+    /// <inheritdoc />
+    public async Task<int> ApplyRuleAsync(AccountId accountId, string parentRemotePath, RuleType ruleType, IReadOnlyList<(string RemotePath, string Id)> nodes, CancellationToken cancellationToken)
+    {
+        string ruleTypeName = ruleType.ToString();
+        OneDriveSyncClientMessages.RulePersisting(logger, ruleTypeName, parentRemotePath, accountId.Id);
+
+        await syncRuleRepository.DeleteChildRulesAsync(accountId, parentRemotePath, cancellationToken);
+
+        foreach (var (remotePath, remoteItemId) in nodes)
+            await syncRuleRepository.UpsertAsync(accountId, remotePath, ruleType, remoteItemId, cancellationToken);
+
+        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken);
+
+        return rules.Count(rule => rule.RuleType == RuleType.Include);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlySet<string>> GetIncludedPathsAsync(AccountId accountId, CancellationToken cancellationToken)
+    {
+        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken);
+
+        return rules.Where(rule => rule.RuleType == RuleType.Include).Select(rule => rule.RemotePath).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.OneDrive;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Onboarding;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Rules;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Detection;
@@ -38,6 +39,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IGraphService, GraphService>();
         _ = services.AddSingleton<IQuotaRefreshService, QuotaRefreshService>();
         _ = services.AddSingleton<IStartupService, StartupService>();
+        _ = services.AddSingleton<ISyncRuleService, SyncRuleService>();
         _ = services.AddSingleton<IHttpDownloader, HttpDownloader>();
         _ = services.AddSingleton<IUploadService, UploadService>();
         _ = services.AddSingleton<IConflictApplier, ConflictApplier>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.6",
+    "ApplicationVersion": "0.7.7",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

`AccountFilesViewModel` called `ISyncRuleRepository.GetByAccountIdAsync`, `DeleteChildRulesAsync`, and `UpsertAsync` directly, holding eight injected dependencies and embedding rule-persistence business logic in the UI layer. This PR extracts a new `ISyncRuleService` (`Infrastructure/Rules`) that encapsulates the cascade-delete + upsert + include-count logic and the include-path query. The view model (and the pass-through in `FilesViewModel`) now depends on the service instead of the repository.

TDD: failing `GivenASyncRuleService` tests committed first (de5690c), then the implementation.

## Type of change

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #498

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

8 new `GivenASyncRuleService` tests cover cascade delete-before-upsert ordering, multi-node include upsert, single-node exclude upsert, include-count return value, and include-path filtering. Existing `GivenAnAccountFilesViewModel*` tests now exercise the real `SyncRuleService` over a substituted repository, so end-to-end rule behaviour through the view model is still asserted.

Results: `dotnet build` 0 warnings, 0 errors. Unit: **1483/1483 passed** (+8 over the 1475 baseline). Integration: **31/31 passed**.

## Impacted areas

apps/desktop/AStar.Dev.OneDrive.Sync.Client (Accounts, Home, Infrastructure/Rules, Startup), AStar.Dev.OneDrive.Sync.Client.Tests.Unit

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- `ApplicationVersion` bumped 0.7.6 → 0.7.7. PR #527 also bumps to 0.7.7 — whichever merges second will be rebased and re-bumped.
- `StartupService` still uses `ISyncRuleRepository` directly; issue #498 scoped the extraction to `AccountFilesViewModel` only.
- Ensure CI passed for all OS runners where configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)