### PR TITLE
fix(onedrive-sync-client): resolve all P4 issues #503–#510

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationExportImportService.cs
@@ -36,7 +36,7 @@ public sealed class GivenAFileClassificationExportImportService
     [Fact]
     public async Task when_exporting_empty_taxonomy_then_json_has_empty_categories_array()
     {
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -54,7 +54,7 @@ public sealed class GivenAFileClassificationExportImportService
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
 
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -77,7 +77,7 @@ public sealed class GivenAFileClassificationExportImportService
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
 
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -105,7 +105,7 @@ public sealed class GivenAFileClassificationExportImportService
         repository.GetKeywordsForCategoryAsync(new FileClassificationCategoryId(1), Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(keywords));
 
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -135,7 +135,7 @@ public sealed class GivenAFileClassificationExportImportService
         repository.GetKeywordsForCategoryAsync(new FileClassificationCategoryId(1), Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(keywords));
 
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -165,7 +165,7 @@ public sealed class GivenAFileClassificationExportImportService
         repository.GetKeywordsForCategoryAsync(new FileClassificationCategoryId(1), Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(keywords));
 
-        await sut.ExportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ExportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         var written = fileSystem.File.ReadAllText(ExportFilePath);
         using var doc = JsonDocument.Parse(written);
@@ -190,7 +190,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         callOrder[0].ShouldBe("delete");
     }
@@ -201,7 +201,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         await repository.Received(1).AddCategoryAsync(Arg.Is<FileClassificationCategory>(c => c.Name == "Photos"), Arg.Any<CancellationToken>());
     }
@@ -216,7 +216,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[{"name":"Holidays","children":[],"keywords":[]}],"keywords":[]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         await repository.Received(1).AddCategoryAsync(
             Arg.Is<FileClassificationCategory>(c => c.Name == "Holidays" && c.ParentId == Option.Some(parentId)),
@@ -235,7 +235,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[{"value":"holiday","isSpecialOverride":null},{"value":"vacation","isSpecialOverride":null}]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "holiday"), Arg.Any<CancellationToken>());
         await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "vacation"), Arg.Any<CancellationToken>());
@@ -253,7 +253,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[{"value":"holiday","isSpecialOverride":true}]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "holiday" && k.IsSpecialOverride == Option.Some(true)), Arg.Any<CancellationToken>());
     }
@@ -270,7 +270,7 @@ public sealed class GivenAFileClassificationExportImportService
         var importJson = """{"version":1,"categories":[{"name":"Photos","children":[],"keywords":[{"value":"holiday","isSpecialOverride":null}]}]}""";
         fileSystem.File.WriteAllText(ExportFilePath, importJson);
 
-        await sut.ImportAsync(ExportFilePath, CancellationToken.None);
+        await sut.ImportAsync(fileSystem.FileInfo.New(ExportFilePath), CancellationToken.None);
 
         await repository.Received(1).AddKeywordAsync(leafCategoryId, Arg.Is<FileClassificationKeyword>(k => k.Value == "holiday" && k.IsSpecialOverride == Option.None<bool>()), Arg.Any<CancellationToken>());
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenAFileClassificationRulesViewModel.cs
@@ -5,6 +5,8 @@ using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using Avalonia.Platform.Storage;
+using System.IO.Abstractions;
+using Testably.Abstractions.Testing;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Classifications;
 
@@ -15,6 +17,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     private readonly IFilePickerService filePickerService;
     private readonly IConfirmationDialogService confirmationDialogService;
     private readonly ILocalizationService localizationService;
+    private readonly IFileSystem fileSystem;
 
     public GivenAFileClassificationRulesViewModel()
     {
@@ -23,6 +26,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         filePickerService = Substitute.For<IFilePickerService>();
         confirmationDialogService = Substitute.For<IConfirmationDialogService>();
         localizationService = Substitute.For<ILocalizationService>();
+        fileSystem = new MockFileSystem();
 
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult<IReadOnlyList<FileClassificationCategory>>([]));
@@ -44,7 +48,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -61,7 +65,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -84,7 +88,7 @@ public sealed class GivenAFileClassificationRulesViewModel
                   .Returns(Task.FromResult(categories));
         repository.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(keywords));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -94,7 +98,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_category_persisted_and_added()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem)
         {
             NewCategoryName = "Media"
         };
@@ -108,7 +112,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_new_category_name_cleared()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem)
         {
             NewCategoryName = "Media"
         };
@@ -121,7 +125,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_new_category_name_empty_then_add_category_command_disabled()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem)
         {
             NewCategoryName = string.Empty
         };
@@ -132,7 +136,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_no_categories_loaded_then_has_no_categories_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -148,7 +152,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -161,7 +165,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
         filePickerService.PickOpenFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                          .Returns(Task.FromResult<string?>(null));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.ImportAsync(storageProvider, CancellationToken.None);
 
@@ -176,7 +180,7 @@ public sealed class GivenAFileClassificationRulesViewModel
                          .Returns(Task.FromResult<string?>("/some/file.json"));
         confirmationDialogService.ConfirmAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                                  .Returns(Task.FromResult(false));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.ImportAsync(storageProvider, CancellationToken.None);
 
@@ -192,13 +196,13 @@ public sealed class GivenAFileClassificationRulesViewModel
                          .Returns(Task.FromResult<string?>(importFilePath));
         confirmationDialogService.ConfirmAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                                  .Returns(Task.FromResult(true));
-        exportImportService.ImportAsync(importFilePath, Arg.Any<CancellationToken>())
+        exportImportService.ImportAsync(Arg.Any<IFileInfo>(), Arg.Any<CancellationToken>())
                            .Returns(Task.CompletedTask);
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.ImportAsync(storageProvider, CancellationToken.None);
 
-        await exportImportService.Received(1).ImportAsync(importFilePath, Arg.Any<CancellationToken>());
+        await exportImportService.Received(1).ImportAsync(Arg.Any<IFileInfo>(), Arg.Any<CancellationToken>());
         await repository.Received(1).GetAllCategoriesAsync(Arg.Any<CancellationToken>());
     }
 
@@ -208,11 +212,11 @@ public sealed class GivenAFileClassificationRulesViewModel
         IStorageProvider storageProvider = Substitute.For<IStorageProvider>();
         filePickerService.PickSaveFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                          .Returns(Task.FromResult<string?>(null));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.ExportAsync(storageProvider, CancellationToken.None);
 
-        await exportImportService.DidNotReceive().ExportAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await exportImportService.DidNotReceive().ExportAsync(Arg.Any<IFileInfo>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -222,17 +226,17 @@ public sealed class GivenAFileClassificationRulesViewModel
         const string exportFilePath = "/some/export.json";
         filePickerService.PickSaveFileAsync(storageProvider, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
                          .Returns(Task.FromResult<string?>(exportFilePath));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.ExportAsync(storageProvider, CancellationToken.None);
 
-        await exportImportService.Received(1).ExportAsync(exportFilePath, Arg.Any<CancellationToken>());
+        await exportImportService.Received(1).ExportAsync(Arg.Any<IFileInfo>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public void when_view_model_constructed_then_is_loading_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.IsLoading.ShouldBeTrue();
     }
@@ -240,7 +244,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_view_model_constructed_then_is_loaded_is_false()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.IsLoaded.ShouldBeFalse();
     }
@@ -248,7 +252,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_load_async_completes_then_is_loaded_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -261,7 +265,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         using var cts = new CancellationTokenSource();
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(callInfo => Task.FromCanceled<IReadOnlyList<FileClassificationCategory>>(callInfo.Arg<CancellationToken>()));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
         cts.Cancel();
 
         await Should.ThrowAsync<OperationCanceledException>(() => sut.LoadAsync(cts.Token));
@@ -272,7 +276,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_load_async_completes_then_is_loading_is_false()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -282,7 +286,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_is_loading_is_true_then_has_no_categories_is_false()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.IsLoading.ShouldBeTrue();
         sut.HasNoCategories.ShouldBeFalse();
@@ -291,7 +295,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_load_async_completes_with_no_categories_then_has_no_categories_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -307,7 +311,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -317,7 +321,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_prepare_for_load_called_then_is_loading_is_true()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.PrepareForLoad();
 
@@ -327,7 +331,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public void when_prepare_for_load_called_then_is_loaded_is_false()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.PrepareForLoad();
 
@@ -343,7 +347,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
         await sut.LoadAsync(CancellationToken.None);
 
         sut.PrepareForLoad();
@@ -356,7 +360,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     {
         const string expectedText = "Loading...";
         localizationService.GetLocal("Common.Loading").Returns(expectedText);
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         sut.LoadingText.ShouldBe(expectedText);
     }
@@ -364,7 +368,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_keyword_also_persisted()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem)
         {
             NewCategoryName = "Media"
         };
@@ -377,7 +381,7 @@ public sealed class GivenAFileClassificationRulesViewModel
     [Fact]
     public async Task when_add_category_command_executed_then_new_category_has_one_keyword()
     {
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService)
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem)
         {
             NewCategoryName = "Media"
         };
@@ -398,7 +402,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 
@@ -419,7 +423,7 @@ public sealed class GivenAFileClassificationRulesViewModel
         ];
         repository.GetAllCategoriesAsync(Arg.Any<CancellationToken>())
                   .Returns(Task.FromResult(categories));
-        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService);
+        FileClassificationRulesViewModel sut = new(repository, exportImportService, filePickerService, confirmationDialogService, localizationService, fileSystem);
 
         await sut.LoadAsync(CancellationToken.None);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncRepository.cs
@@ -33,7 +33,7 @@ public sealed class GivenASyncRepository
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
 
-        await repository.EnqueueJobsAsync(new List<SyncJob>());
+        await repository.EnqueueJobsAsync(new List<SyncJob>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public sealed class GivenASyncRepository
             MinimalJob(folderId: "folder-2")
         };
 
-        await repository.EnqueueJobsAsync(jobs);
+        await repository.EnqueueJobsAsync(jobs, TestContext.Current.CancellationToken);
 
         db.SyncJobs.Count().ShouldBe(2);
     }
@@ -58,7 +58,7 @@ public sealed class GivenASyncRepository
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
 
-        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"));
+        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result.ShouldBeEmpty();
     }
@@ -74,9 +74,9 @@ public sealed class GivenASyncRepository
             MinimalJob(folderId: "folder-2", state: SyncJobState.Completed),
             MinimalJob(folderId: "folder-3", state: SyncJobState.Failed)
         };
-        await repository.EnqueueJobsAsync(jobs);
+        await repository.EnqueueJobsAsync(jobs, TestContext.Current.CancellationToken);
 
-        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"));
+        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
         result[0].State.ShouldBe(SyncJobState.Queued);
@@ -97,9 +97,9 @@ public sealed class GivenASyncRepository
             SyncJobFactory.CreateDownload(remote, target, metadata) with { Status = SyncJobStatusFactory.Create() with { QueuedAt = now.AddSeconds(1) } },
             SyncJobFactory.CreateDownload(remote, target, metadata) with { Status = SyncJobStatusFactory.Create() with { QueuedAt = now.AddSeconds(2) } }
         };
-        await repository.EnqueueJobsAsync(jobs);
+        await repository.EnqueueJobsAsync(jobs, TestContext.Current.CancellationToken);
 
-        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"));
+        var result = await repository.GetPendingJobsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(3);
         result[0].QueuedAt.ShouldBeLessThan(result[1].QueuedAt);
@@ -114,11 +114,11 @@ public sealed class GivenASyncRepository
         var jobId = Guid.NewGuid();
         var baseJob = MinimalJob();
         var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
-        await repository.EnqueueJobsAsync(new[] { job });
+        await repository.EnqueueJobsAsync(new[] { job }, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.UpdateJobStateAsync(jobId, SyncJobState.InProgress, Option.None<string>());
+            await repository.UpdateJobStateAsync(jobId, SyncJobState.InProgress, Option.None<string>(), TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -133,11 +133,11 @@ public sealed class GivenASyncRepository
         var jobId = Guid.NewGuid();
         var baseJob = MinimalJob();
         var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
-        await repository.EnqueueJobsAsync(new[] { job });
+        await repository.EnqueueJobsAsync(new[] { job }, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.UpdateJobStateAsync(jobId, SyncJobState.Completed, Option.None<string>());
+            await repository.UpdateJobStateAsync(jobId, SyncJobState.Completed, Option.None<string>(), TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -152,11 +152,11 @@ public sealed class GivenASyncRepository
         var jobId = Guid.NewGuid();
         var baseJob = MinimalJob();
         var job = baseJob with { Status = baseJob.Status with { Id = jobId } };
-        await repository.EnqueueJobsAsync(new[] { job });
+        await repository.EnqueueJobsAsync(new[] { job }, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.UpdateJobStateAsync(jobId, SyncJobState.Failed, "Upload failed");
+            await repository.UpdateJobStateAsync(jobId, SyncJobState.Failed, "Upload failed", TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -174,11 +174,11 @@ public sealed class GivenASyncRepository
             MinimalJob(state: SyncJobState.Queued),
             MinimalJob(state: SyncJobState.Completed)
         };
-        await repository.EnqueueJobsAsync(jobs);
+        await repository.EnqueueJobsAsync(jobs, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.ClearCompletedJobsAsync(new AccountId("user-1"));
+            await repository.ClearCompletedJobsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -192,7 +192,7 @@ public sealed class GivenASyncRepository
         var repository = new SyncRepository(factory);
         var conflict = MinimalConflict(folderId: "folder-1");
 
-        await repository.AddConflictAsync(conflict);
+        await repository.AddConflictAsync(conflict, TestContext.Current.CancellationToken);
 
         var inserted = await db.SyncConflicts.FindAsync([conflict.Id], cancellationToken: TestContext.Current.CancellationToken);
         _ = inserted.ShouldNotBeNull();
@@ -207,10 +207,10 @@ public sealed class GivenASyncRepository
         var conflict1 = MinimalConflict();
         var conflict2 = MinimalConflict(state: ConflictState.Resolved);
 
-        await repository.AddConflictAsync(conflict1);
-        await repository.AddConflictAsync(conflict2);
+        await repository.AddConflictAsync(conflict1, TestContext.Current.CancellationToken);
+        await repository.AddConflictAsync(conflict2, TestContext.Current.CancellationToken);
 
-        var result = await repository.GetPendingConflictsAsync(new AccountId("user-1"));
+        var result = await repository.GetPendingConflictsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
         result[0].State.ShouldBe(ConflictState.Pending);
@@ -225,10 +225,10 @@ public sealed class GivenASyncRepository
         var conflict1 = MinimalConflict(detectedAt: now.AddSeconds(2));
         var conflict2 = MinimalConflict(detectedAt: now.AddSeconds(1));
 
-        await repository.AddConflictAsync(conflict1);
-        await repository.AddConflictAsync(conflict2);
+        await repository.AddConflictAsync(conflict1, TestContext.Current.CancellationToken);
+        await repository.AddConflictAsync(conflict2, TestContext.Current.CancellationToken);
 
-        var result = await repository.GetPendingConflictsAsync(new AccountId("user-1"));
+        var result = await repository.GetPendingConflictsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         result[0].DetectedAt.ShouldBeLessThan(result[1].DetectedAt);
     }
@@ -239,11 +239,11 @@ public sealed class GivenASyncRepository
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var conflict = MinimalConflict();
-        await repository.AddConflictAsync(conflict);
+        await repository.AddConflictAsync(conflict, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.ResolveConflictAsync(conflict.Id, ConflictPolicy.Ignore);
+            await repository.ResolveConflictAsync(conflict.Id, ConflictPolicy.Ignore, TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -256,11 +256,11 @@ public sealed class GivenASyncRepository
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
         var conflict = MinimalConflict();
-        await repository.AddConflictAsync(conflict);
+        await repository.AddConflictAsync(conflict, TestContext.Current.CancellationToken);
 
         try
         {
-            await repository.ResolveConflictAsync(conflict.Id, ConflictPolicy.LocalWins);
+            await repository.ResolveConflictAsync(conflict.Id, ConflictPolicy.LocalWins, TestContext.Current.CancellationToken);
         }
         catch(InvalidOperationException)
         {
@@ -273,7 +273,7 @@ public sealed class GivenASyncRepository
         var (_, factory) = CreateInMemoryFactory();
         var repository = new SyncRepository(factory);
 
-        int count = await repository.GetPendingConflictCountAsync(new AccountId("user-1"));
+        int count = await repository.GetPendingConflictCountAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         count.ShouldBe(0);
     }
@@ -287,11 +287,11 @@ public sealed class GivenASyncRepository
         var conflict2 = MinimalConflict();
         var conflict3 = MinimalConflict(state: ConflictState.Resolved);
 
-        await repository.AddConflictAsync(conflict1);
-        await repository.AddConflictAsync(conflict2);
-        await repository.AddConflictAsync(conflict3);
+        await repository.AddConflictAsync(conflict1, TestContext.Current.CancellationToken);
+        await repository.AddConflictAsync(conflict2, TestContext.Current.CancellationToken);
+        await repository.AddConflictAsync(conflict3, TestContext.Current.CancellationToken);
 
-        int count = await repository.GetPendingConflictCountAsync(new AccountId("user-1"));
+        int count = await repository.GetPendingConflictCountAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
 
         count.ShouldBe(2);
     }
@@ -306,15 +306,39 @@ public sealed class GivenASyncRepository
             MinimalJob(accountId: "user-1"),
             MinimalJob(accountId: "user-2")
         };
-        await repository.EnqueueJobsAsync(jobs);
+        await repository.EnqueueJobsAsync(jobs, TestContext.Current.CancellationToken);
 
-        var user1Jobs = await repository.GetPendingJobsAsync(new AccountId("user-1"));
-        var user2Jobs = await repository.GetPendingJobsAsync(new AccountId("user-2"));
+        var user1Jobs = await repository.GetPendingJobsAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+        var user2Jobs = await repository.GetPendingJobsAsync(new AccountId("user-2"), TestContext.Current.CancellationToken);
 
         user1Jobs.Count.ShouldBe(1);
         user1Jobs[0].AccountId.Id.ShouldBe("user-1");
         user2Jobs.Count.ShouldBe(1);
         user2Jobs[0].AccountId.Id.ShouldBe("user-2");
+    }
+
+    [Fact]
+    public async Task when_enqueue_jobs_is_called_with_a_token_then_the_token_is_forwarded_to_the_context_factory()
+    {
+        var (_, factory) = CreateInMemoryFactory();
+        var repository = new SyncRepository(factory);
+        using var cts = new CancellationTokenSource();
+
+        await repository.EnqueueJobsAsync([MinimalJob()], cts.Token);
+
+        _ = await factory.Received(1).CreateDbContextAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task when_add_conflict_is_called_with_a_token_then_the_token_is_forwarded_to_the_context_factory()
+    {
+        var (_, factory) = CreateInMemoryFactory();
+        var repository = new SyncRepository(factory);
+        using var cts = new CancellationTokenSource();
+
+        await repository.AddConflictAsync(MinimalConflict(), cts.Token);
+
+        _ = await factory.Received(1).CreateDbContextAsync(cts.Token);
     }
 
     private static (AppDbContext seedingContext, IDbContextFactory<AppDbContext> factory) CreateInMemoryFactory()

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -58,7 +58,7 @@ public sealed class GivenAMainWindowViewModel
         repo.GetKeywordsForCategoryAsync(Arg.Any<FileClassificationCategoryId>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<FileClassificationKeywordEntry>>([]));
 
-        return new FileClassificationRulesViewModel(repo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), _localizationService);
+        return new FileClassificationRulesViewModel(repo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), _localizationService, _fileSystem);
     }
 
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenADriveContextCache.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenADriveContextCache.cs
@@ -1,0 +1,135 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Graph;
+
+public sealed class GivenADriveContextCache : IDisposable
+{
+    private const string AnyAccountId = "account-001";
+    private const string AnyAccessToken = "any-access-token";
+    private const string AnyDriveId = "drive-001";
+    private const string AnyRootId = "root-001";
+
+    private readonly WireMockServer server = WireMockServer.Start();
+
+    public void Dispose() => server.Stop();
+
+    private DriveContextCache CreateSut() => new(new WireMockGraphClientFactory(server));
+
+    private void SetupDriveContext(string driveId, string rootId)
+    {
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = driveId }));
+        server.Given(Request.Create().WithPath($"/drives/{driveId}/root").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = rootId }));
+    }
+
+    [Fact]
+    public void when_constructed_then_instance_is_not_null()
+    {
+        var sut = CreateSut();
+
+        _ = sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task when_resolved_successfully_then_result_is_ok_with_correct_drive_id()
+    {
+        SetupDriveContext(AnyDriveId, AnyRootId);
+
+        var result = await CreateSut().ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        var ok = result.ShouldBeAssignableTo<Result<(Microsoft.Graph.GraphServiceClient Client, DriveContext Ctx), string>.Ok>()!;
+        ok.Value.Ctx.DriveId.Value.ShouldBe(AnyDriveId);
+        ok.Value.Ctx.RootId.ShouldBe(AnyRootId);
+    }
+
+    [Fact]
+    public async Task when_resolved_twice_for_same_account_then_me_drive_endpoint_is_only_called_once()
+    {
+        SetupDriveContext(AnyDriveId, AnyRootId);
+        var ct = TestContext.Current.CancellationToken;
+        var sut = CreateSut();
+
+        _ = await sut.ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
+        _ = await sut.ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
+
+        (server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task when_evict_is_called_then_subsequent_resolve_hits_me_drive_endpoint_again()
+    {
+        SetupDriveContext(AnyDriveId, AnyRootId);
+        var ct = TestContext.Current.CancellationToken;
+        var sut = CreateSut();
+
+        _ = await sut.ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
+        sut.Evict(AnyAccountId);
+        _ = await sut.ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
+
+        (server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
+    }
+
+    [Fact]
+    public void when_evict_is_called_for_unknown_account_then_no_exception_is_thrown()
+    {
+        var sut = CreateSut();
+
+        var exception = Record.Exception(() => sut.Evict("unknown-account"));
+
+        exception.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task when_graph_returns_null_drive_id_then_result_is_error()
+    {
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = (string?)null }));
+
+        var result = await CreateSut().ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<(Microsoft.Graph.GraphServiceClient Client, DriveContext Ctx), string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_graph_returns_null_root_item_id_then_result_is_error()
+    {
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = AnyDriveId }));
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/root").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new { id = (string?)null }));
+
+        var result = await CreateSut().ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), TestContext.Current.CancellationToken);
+
+        result.ShouldBeAssignableTo<Result<(Microsoft.Graph.GraphServiceClient Client, DriveContext Ctx), string>.Error>();
+    }
+
+    [Fact]
+    public async Task when_resolve_is_called_with_a_pre_cancelled_token_then_operation_is_cancelled()
+    {
+        var sut = CreateSut();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.ResolveAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), cts.Token));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -19,12 +19,16 @@ public sealed class GivenAGraphService : IDisposable
     private const string AnyRemotePath = "/Documents";
     private const string AnyLocalPath = "/home/user/file.txt";
 
-    private readonly WireMockServer _server = WireMockServer.Start();
+    private readonly WireMockServer server = WireMockServer.Start();
 
-    public void Dispose() => _server.Stop();
+    public void Dispose() => server.Stop();
 
-    private GraphService CreateSut() =>
-        new(Substitute.For<IUploadService>(), new WireMockGraphClientFactory(_server));
+    private GraphService CreateSut()
+    {
+        var factory = new WireMockGraphClientFactory(server);
+
+        return new GraphService(Substitute.For<IUploadService>(), factory, new DriveContextCache(factory), new GraphFolderEnumerator(factory));
+    }
 
     [Fact]
     public void when_constructed_then_instance_is_not_null()
@@ -136,7 +140,7 @@ public sealed class GivenAGraphService : IDisposable
     public async Task when_get_root_folders_returns_mixed_items_then_only_folders_are_returned_ordered_by_name()
     {
         SetupDriveContext(AnyDriveId, "root-001");
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/root-001/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/root-001/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -161,7 +165,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_folder_id_by_path_receives_a_404_then_null_is_returned()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(404)
                 .WithHeader("Content-Type", "application/json")
@@ -176,7 +180,7 @@ public sealed class GivenAGraphService : IDisposable
     public async Task when_get_quota_response_has_null_total_then_zero_is_returned_for_both_values()
     {
         SetupDriveContext(AnyDriveId, "root-001");
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -193,7 +197,7 @@ public sealed class GivenAGraphService : IDisposable
     public async Task when_get_download_url_item_has_no_additional_data_then_null_is_returned()
     {
         SetupDriveContext(AnyDriveId, "root-001");
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -207,7 +211,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_enumerate_folder_contains_subfolders_then_recursive_enumeration_visits_each_child()
     {
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -219,7 +223,7 @@ public sealed class GivenAGraphService : IDisposable
                         new { id = "subfolder-001", name = "SubFolder", folder = new { }, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } }
                     }
                 }));
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-001/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-001/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -243,7 +247,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_enumerate_folder_encounters_a_cycle_via_parentId_then_each_folder_is_visited_exactly_once()
     {
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -254,7 +258,7 @@ public sealed class GivenAGraphService : IDisposable
                         new { id = "subfolder-A", name = "SubFolderA", folder = new { }, parentReference = new { id = AnyFolderId, driveId = AnyDriveId } }
                     }
                 }));
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-A/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/subfolder-A/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -284,13 +288,13 @@ public sealed class GivenAGraphService : IDisposable
         _ = await sut.GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
         _ = await sut.GetDriveIdAsync(AnyAccountId, _ => Task.FromResult(AnyAccessToken), ct);
 
-        (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
+        (server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
     }
 
     [Fact]
     public async Task when_get_drive_id_is_called_and_graph_returns_null_drive_id_then_result_is_error()
     {
-        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -304,12 +308,12 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_drive_id_is_called_and_graph_returns_null_root_item_id_then_result_is_error()
     {
-        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = "drive-001" }));
-        _server.Given(Request.Create().WithPath("/drives/drive-001/root").UsingGet())
+        server.Given(Request.Create().WithPath("/drives/drive-001/root").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -331,7 +335,7 @@ public sealed class GivenAGraphService : IDisposable
         _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult(AnyAccessToken), ct);
         _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult("refreshed-token"), ct);
 
-        (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
+        (server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(1);
     }
 
     [Fact]
@@ -346,15 +350,15 @@ public sealed class GivenAGraphService : IDisposable
         sut.EvictCachedDriveContext(accountId);
         _ = await sut.GetDriveIdAsync(accountId, _ => Task.FromResult(AnyAccessToken), ct);
 
-        (_server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
+        (server.LogEntries?.Count(entry => entry.RequestMessage?.Url?.Contains("/me/drive", StringComparison.OrdinalIgnoreCase) == true) ?? 0).ShouldBe(2);
     }
 
     [Fact]
     public async Task when_enumerate_folder_next_link_does_not_pass_guard_then_only_the_first_page_is_returned()
     {
-        var nonGraphNextLinkUrl = $"{_server.Url}/drives/{AnyDriveId}/items/{AnyFolderId}/children?$skiptoken=page2";
+        var nonGraphNextLinkUrl = $"{server.Url}/drives/{AnyDriveId}/items/{AnyFolderId}/children?$skiptoken=page2";
 
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyFolderId}/children").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
@@ -377,7 +381,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_drive_id_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -391,7 +395,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_root_folders_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -405,7 +409,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_quota_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -419,7 +423,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_folder_id_by_path_returns_server_error_then_null_is_returned()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -433,7 +437,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_download_url_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -447,7 +451,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_upload_file_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -471,7 +475,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_get_child_folders_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -485,7 +489,7 @@ public sealed class GivenAGraphService : IDisposable
     [Fact]
     public async Task when_enumerate_folder_returns_server_error_then_result_is_error()
     {
-        _server.Given(Request.Create().UsingAnyMethod())
+        server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -500,7 +504,7 @@ public sealed class GivenAGraphService : IDisposable
     public async Task when_delete_item_returns_server_error_then_result_is_error()
     {
         SetupDriveContext(AnyDriveId, "root-001");
-        _server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingDelete())
+        server.Given(Request.Create().WithPath($"/drives/{AnyDriveId}/items/{AnyItemId}").UsingDelete())
             .RespondWith(Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
@@ -513,12 +517,12 @@ public sealed class GivenAGraphService : IDisposable
 
     private void SetupDriveContext(string driveId, string rootId)
     {
-        _server.Given(Request.Create().WithPath("/me/drive").UsingGet())
+        server.Given(Request.Create().WithPath("/me/drive").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { id = driveId }));
-        _server.Given(Request.Create().WithPath($"/drives/{driveId}/root").UsingGet())
+        server.Given(Request.Create().WithPath($"/drives/{driveId}/root").UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Http/GivenAnHttpRetryPolicy.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Http/GivenAnHttpRetryPolicy.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Headers;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Http;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Http;
+
+public sealed class GivenAnHttpRetryPolicy
+{
+    [Fact]
+    public void when_attempt_is_1_then_backoff_delay_is_near_base_delay()
+    {
+        var result = HttpRetryPolicy.GetBackoffDelay(1);
+
+        result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(HttpRetryPolicy.BaseDelaySeconds);
+        result.TotalSeconds.ShouldBeLessThan(HttpRetryPolicy.BaseDelaySeconds * 1.2 + 0.001);
+    }
+
+    [Fact]
+    public void when_attempt_grows_then_backoff_delay_grows()
+    {
+        var delay1 = HttpRetryPolicy.GetBackoffDelay(1);
+        var delay2 = HttpRetryPolicy.GetBackoffDelay(2);
+        var delay3 = HttpRetryPolicy.GetBackoffDelay(3);
+
+        delay1.TotalSeconds.ShouldBeLessThan(delay2.TotalSeconds);
+        delay2.TotalSeconds.ShouldBeLessThan(delay3.TotalSeconds);
+    }
+
+    [Fact]
+    public void when_attempt_is_very_large_then_delay_is_capped_at_max_plus_jitter()
+    {
+        var result = HttpRetryPolicy.GetBackoffDelay(100);
+
+        result.TotalSeconds.ShouldBeLessThanOrEqualTo(HttpRetryPolicy.MaxDelaySeconds * 1.2 + 0.001);
+    }
+
+    [Theory]
+    [InlineData(1, 2.0, 2.4)]
+    [InlineData(2, 4.0, 4.8)]
+    [InlineData(3, 8.0, 9.6)]
+    [InlineData(4, 16.0, 19.2)]
+    [InlineData(5, 32.0, 38.4)]
+    public void when_attempt_is_specified_then_delay_is_within_jitter_band(int attempt, double minSeconds, double maxSeconds)
+    {
+        var result = HttpRetryPolicy.GetBackoffDelay(attempt);
+
+        result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(minSeconds);
+        result.TotalSeconds.ShouldBeLessThanOrEqualTo(maxSeconds);
+    }
+
+    [Fact]
+    public void when_retry_after_delta_header_is_present_then_retry_delay_uses_delta_plus_one_second()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+
+        var result = HttpRetryPolicy.GetRetryDelay(response, 1);
+
+        result.TotalSeconds.ShouldBe(31.0, tolerance: 0.01);
+    }
+
+    [Fact]
+    public void when_retry_after_date_header_is_in_the_future_then_retry_delay_uses_remaining_time_plus_one_second()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+        var retryAt = DateTimeOffset.UtcNow.AddSeconds(20);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(retryAt);
+
+        var result = HttpRetryPolicy.GetRetryDelay(response, 1);
+
+        result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(19.0);
+        result.TotalSeconds.ShouldBeLessThanOrEqualTo(22.0);
+    }
+
+    [Fact]
+    public void when_retry_after_date_header_is_in_the_past_then_retry_delay_falls_back_to_backoff()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddSeconds(-5));
+
+        var result = HttpRetryPolicy.GetRetryDelay(response, 1);
+
+        result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(HttpRetryPolicy.BaseDelaySeconds);
+        result.TotalSeconds.ShouldBeLessThanOrEqualTo(HttpRetryPolicy.BaseDelaySeconds * 1.2 + 0.001);
+    }
+
+    [Fact]
+    public void when_retry_after_header_is_absent_then_retry_delay_falls_back_to_backoff()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+
+        var result = HttpRetryPolicy.GetRetryDelay(response, 1);
+
+        result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(HttpRetryPolicy.BaseDelaySeconds);
+        result.TotalSeconds.ShouldBeLessThanOrEqualTo(HttpRetryPolicy.BaseDelaySeconds * 1.2 + 0.001);
+    }
+
+    [Fact]
+    public void when_retry_after_delta_is_zero_then_retry_delay_is_one_second()
+    {
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+
+        var result = HttpRetryPolicy.GetRetryDelay(response, 1);
+
+        result.TotalSeconds.ShouldBe(1.0, tolerance: 0.01);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAFeatureAvailabilityService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAFeatureAvailabilityService.cs
@@ -1,0 +1,61 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using ReactiveUnit = System.Reactive.Unit;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Shell;
+
+public sealed class GivenAFeatureAvailabilityService
+{
+    [Fact]
+    public void when_registering_before_freeze_then_result_is_ok()
+    {
+        var sut = new FeatureAvailabilityService();
+
+        var result = sut.Register(NavSection.Dashboard);
+
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Ok>();
+    }
+
+    [Fact]
+    public void when_registering_after_freeze_then_result_is_error()
+    {
+        var sut = new FeatureAvailabilityService();
+        sut.Freeze();
+
+        var result = sut.Register(NavSection.Dashboard);
+
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Error>();
+    }
+
+    [Fact]
+    public void when_registering_after_freeze_then_error_message_is_descriptive()
+    {
+        var sut = new FeatureAvailabilityService();
+        sut.Freeze();
+
+        var result = sut.Register(NavSection.Dashboard);
+
+        var error = result.ShouldBeOfType<Result<ReactiveUnit, string>.Error>();
+        error.Reason.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void when_registering_before_freeze_then_section_is_available()
+    {
+        var sut = new FeatureAvailabilityService();
+
+        sut.Register(NavSection.Accounts);
+        sut.Freeze();
+
+        sut.IsAvailable(NavSection.Accounts).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_section_not_registered_then_is_available_returns_false()
+    {
+        var sut = new FeatureAvailabilityService();
+        sut.Freeze();
+
+        sut.IsAvailable(NavSection.Help).ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -26,6 +26,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
+using ReactiveUnit = System.Reactive.Unit;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Shell;
 
@@ -58,6 +59,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
         localizationService.AvailableCultures.Returns([]);
         startupService.RestoreAccountsAsync().Returns(Task.FromResult<Result<List<OneDriveAccount>, string>>(new Result<List<OneDriveAccount>, string>.Ok([])));
         syncRepository.GetPendingConflictsAsync(Arg.Any<AccountId>()).Returns([]);
+        syncScheduler.StartSync(Arg.Any<TimeSpan?>()).Returns(new Result<ReactiveUnit, string>.Ok(ReactiveUnit.Default));
 
         sqliteConnection = new SqliteConnection("Data Source=:memory:");
         sqliteConnection.Open();
@@ -86,7 +88,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
         var settings = new SettingsViewModel(settingsServiceForViewModel, themeServiceForViewModel, schedulerForViewModel, accountRepository, localizationService, Substitute.For<IFolderPickerService>());
         var statusBar = new StatusBarViewModel(accounts, localizationService);
 
-        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localizationService), statusBar, localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
+        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localizationService, fileSystem), statusBar, localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     private AppBootstrapper CreateSut() => new(dbContextFactory, settingsService, themeService, localizationService, syncScheduler, CreateMainWindowViewModel(), Substitute.For<ILogger<AppBootstrapper>>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -157,7 +157,7 @@ public sealed class GivenAnApplicationInitializer
 
         await sut.InitializeAsync(TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).GetPendingConflictsAsync(new AccountId("acc-active"));
+        await _syncRepository.Received(1).GetPendingConflictsAsync(new AccountId("acc-active"), CancellationToken.None);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -538,6 +538,36 @@ public sealed class GivenASyncScheduler
         await manualSync;
     }
 
+    [Fact]
+    public async Task when_trigger_now_called_concurrently_then_second_full_pass_is_skipped()
+    {
+        var firstPassStarted = new TaskCompletionSource();
+        var firstPassRelease = new TaskCompletionSource();
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                firstPassStarted.TrySetResult();
+                await firstPassRelease.Task;
+            });
+
+        var mockRepository = Substitute.For<IAccountRepository>();
+        mockRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([new AccountEntity { Id = new AccountId("pass-account"), Profile = AccountProfileFactory.Create("Test", "test@test.com") }]);
+
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+
+        var firstPass = scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
+        await firstPassStarted.Task;
+
+        await scheduler.TriggerNowAsync(TestContext.Current.CancellationToken);
+
+        await mockRepository.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+
+        firstPassRelease.SetResult();
+        await firstPass;
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using Microsoft.Extensions.Logging;
+using ReactiveUnit = System.Reactive.Unit;
 using AccountId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.AccountId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync;
@@ -29,48 +30,40 @@ public sealed class GivenASyncScheduler
         => SyncScheduler.DefaultInterval.ShouldBe(TimeSpan.FromMinutes(60));
 
     [Fact]
-    public void when_started_then_scheduler_is_not_null()
+    public void when_started_then_result_is_ok()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
 
-        scheduler.StartSync();
+        var result = scheduler.StartSync();
 
-        _ = scheduler.ShouldNotBeNull();
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Ok>();
     }
 
     [Fact]
-    public void when_started_with_default_interval_then_scheduler_is_not_null()
+    public void when_started_with_default_interval_then_result_is_ok()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
 
-        scheduler.StartSync();
+        var result = scheduler.StartSync();
 
-        _ = scheduler.ShouldNotBeNull();
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Ok>();
     }
 
     [Fact]
-    public void when_started_with_custom_interval_then_scheduler_is_not_null()
+    public void when_started_with_custom_interval_then_result_is_ok()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
         var customInterval = TimeSpan.FromMinutes(30);
 
-        scheduler.StartSync(customInterval);
+        var result = scheduler.StartSync(customInterval);
 
-        _ = scheduler.ShouldNotBeNull();
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Ok>();
     }
 
     [Fact]
     public void when_stopped_after_start_then_scheduler_is_not_null()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
         scheduler.StartSync();
 
         scheduler.StopSync();
@@ -81,9 +74,7 @@ public sealed class GivenASyncScheduler
     [Fact]
     public void when_interval_set_after_start_then_scheduler_is_not_null()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
         scheduler.StartSync();
         var newInterval = TimeSpan.FromMinutes(30);
 
@@ -200,9 +191,7 @@ public sealed class GivenASyncScheduler
     [Fact]
     public void when_scheduler_created_then_it_is_async_disposable()
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
 
         _ = scheduler.ShouldBeAssignableTo<IAsyncDisposable>();
     }
@@ -212,16 +201,14 @@ public sealed class GivenASyncScheduler
     [InlineData(30)]
     [InlineData(60)]
     [InlineData(120)]
-    public void when_started_with_various_intervals_then_scheduler_is_not_null(int minutes)
+    public void when_started_with_various_intervals_then_result_is_ok(int minutes)
     {
-        var mockSyncService = Substitute.For<ISyncService>();
-        var mockRepository = Substitute.For<IAccountRepository>();
-        var scheduler = CreateScheduler(mockSyncService, mockRepository, Substitute.For<ISyncRuleRepository>());
+        var scheduler = CreateScheduler(Substitute.For<ISyncService>(), Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
         var interval = TimeSpan.FromMinutes(minutes);
 
-        scheduler.StartSync(interval);
+        var result = scheduler.StartSync(interval);
 
-        _ = scheduler.ShouldNotBeNull();
+        result.ShouldBeOfType<Result<ReactiveUnit, string>.Ok>();
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -208,7 +208,7 @@ public sealed class GivenASyncService
 
         await service.ResolveConflictAsync(conflict, ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -222,7 +222,7 @@ public sealed class GivenASyncService
 
         await service.ResolveConflictAsync(conflict, ConflictPolicy.Ignore, TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Theory]
@@ -242,6 +242,6 @@ public sealed class GivenASyncService
 
         await service.ResolveConflictAsync(conflict, policy, TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Is(policy));
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Is(policy), TestContext.Current.CancellationToken);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceApplyingUseRemoteConflictOutcome.cs
@@ -60,7 +60,7 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
 
         await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -71,6 +71,6 @@ public sealed class GivenASyncServiceApplyingUseRemoteConflictOutcome
 
         await CreateSut().ResolveConflictAsync(CreateConflict(), ConflictPolicy.RemoteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceResolvingConflicts.cs
@@ -41,7 +41,7 @@ public sealed class GivenASyncServiceResolvingConflicts
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.Received(1).ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public sealed class GivenASyncServiceResolvingConflicts
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public sealed class GivenASyncServiceResolvingConflicts
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public sealed class GivenASyncServiceResolvingConflicts
 
         await sut.ResolveConflictAsync(CreateConflict(), ConflictPolicy.LastWriteWins, TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>());
+        await _syncRepository.DidNotReceive().ResolveConflictAsync(Arg.Any<Guid>(), Arg.Any<ConflictPolicy>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderBackoff.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderBackoff.cs
@@ -1,5 +1,4 @@
-using System.Reflection;
-using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Http;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Jobs;
 
@@ -8,10 +7,8 @@ public sealed class GivenAnHttpDownloaderBackoff
     [Fact]
     public void when_attempt_is_1_then_backoff_delay_is_between_2_and_2_point_4_seconds()
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
+        var result = HttpRetryPolicy.GetBackoffDelay(1);
 
-        var result = (TimeSpan)method!.Invoke(null, [1])!;
         result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(2.0);
         result.TotalSeconds.ShouldBeLessThanOrEqualTo(2.4);
     }
@@ -19,11 +16,8 @@ public sealed class GivenAnHttpDownloaderBackoff
     [Fact]
     public void when_attempt_is_2_then_backoff_delay_is_between_4_and_4_point_8_seconds()
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
+        var result2 = HttpRetryPolicy.GetBackoffDelay(2);
 
-        _ = (TimeSpan)method!.Invoke(null, [1])!;
-        var result2 = (TimeSpan)method!.Invoke(null, [2])!;
         result2.TotalSeconds.ShouldBeGreaterThanOrEqualTo(4.0);
         result2.TotalSeconds.ShouldBeLessThanOrEqualTo(4.8);
     }
@@ -31,15 +25,11 @@ public sealed class GivenAnHttpDownloaderBackoff
     [Fact]
     public void when_attempts_increase_then_delays_increase_exponentially()
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
-
         var delays = new List<TimeSpan>();
 
-        for(int i = 1; i <= 5; i++)
+        for (int i = 1; i <= 5; i++)
         {
-            var delay = (TimeSpan)method!.Invoke(null, [i])!;
-            delays.Add(delay);
+            delays.Add(HttpRetryPolicy.GetBackoffDelay(i));
         }
 
         delays[0].TotalSeconds.ShouldBeLessThan(delays[1].TotalSeconds);
@@ -51,22 +41,18 @@ public sealed class GivenAnHttpDownloaderBackoff
     [Fact]
     public void when_attempt_is_10_then_delay_is_capped_at_144_seconds()
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
-        var result = (TimeSpan)method!.Invoke(null, [10])!;
+        var result = HttpRetryPolicy.GetBackoffDelay(10);
+
         result.TotalSeconds.ShouldBeLessThanOrEqualTo(144);
     }
 
     [Fact]
     public void when_called_multiple_times_then_delays_have_variability()
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
         var delays = new List<TimeSpan>();
-        for(int i = 0; i < 10; i++)
+        for (int i = 0; i < 10; i++)
         {
-            var delay = (TimeSpan)method!.Invoke(null, [1])!;
-            delays.Add(delay);
+            delays.Add(HttpRetryPolicy.GetBackoffDelay(1));
         }
 
         int uniqueValues = delays.DistinctBy(d => d.TotalMilliseconds).Count();
@@ -74,17 +60,14 @@ public sealed class GivenAnHttpDownloaderBackoff
     }
 
     [Theory]
-    [InlineData(1, 2.0, 2.4)]      // 2s base, 20% = 0.4s jitter
-    [InlineData(2, 4.0, 4.8)]      // 4s base, 20% = 0.8s jitter
-    [InlineData(3, 8.0, 9.6)]      // 8s base, 20% = 1.6s jitter
-    [InlineData(4, 16.0, 19.2)]    // 16s base, 20% = 3.2s jitter
-    [InlineData(5, 32.0, 38.4)]    // 32s base, 20% = 6.4s jitter
+    [InlineData(1, 2.0, 2.4)]
+    [InlineData(2, 4.0, 4.8)]
+    [InlineData(3, 8.0, 9.6)]
+    [InlineData(4, 16.0, 19.2)]
+    [InlineData(5, 32.0, 38.4)]
     public void when_attempt_is_specified_then_delay_respects_ceiling_and_jitter(int attempt, double minSeconds, double maxSeconds)
     {
-        var method = typeof(HttpDownloader).GetMethod("GetBackoffDelay", BindingFlags.NonPublic | BindingFlags.Static);
-        _ = method.ShouldNotBeNull();
-
-        var result = (TimeSpan)method!.Invoke(null, [attempt])!;
+        var result = HttpRetryPolicy.GetBackoffDelay(attempt);
 
         result.TotalSeconds.ShouldBeGreaterThanOrEqualTo(minSeconds);
         result.TotalSeconds.ShouldBeLessThanOrEqualTo(maxSeconds);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
@@ -70,7 +70,7 @@ public sealed class GivenAParallelSyncPipeline
 
         await sut.RunAsync([], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
-        await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>());
+        await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public sealed class GivenAParallelSyncPipeline
 
         await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ClearCompletedJobsAsync(Arg.Any<AccountId>());
+        await _syncRepository.Received(1).ClearCompletedJobsAsync(Arg.Any<AccountId>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public sealed class GivenAParallelSyncPipeline
 
         await sut.RunAsync([MakeDownloadJob()], TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountIdValue));
+        await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountIdValue), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -195,7 +195,7 @@ public sealed class GivenAParallelSyncPipeline
         }
         catch(OperationCanceledException) { }
 
-        await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>());
+        await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -79,7 +79,7 @@ public sealed class GivenASyncJobExecutor
 
         await sut.ExecuteAsync(_account, tokenFactory, jobs, [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).EnqueueJobsAsync(Arg.Is<IEnumerable<SyncJob>>(j => j.Count() == 1));
+        await _syncRepository.Received(1).EnqueueJobsAsync(Arg.Is<IEnumerable<SyncJob>>(j => j.Count() == 1), TestContext.Current.CancellationToken);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
@@ -84,7 +84,7 @@ public sealed class GivenASyncWorker
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed, Option.None<string>());
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed, Option.None<string>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public sealed class GivenASyncWorker
 
         await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
 
-        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, Arg.Any<Option<string>>());
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, Arg.Any<Option<string>>(), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public sealed class GivenASyncWorker
         }
         catch(OperationCanceledException) { }
 
-        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>());
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>(), CancellationToken.None);
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenAccountsViewDisplay.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenAccountsViewDisplay.cs
@@ -20,6 +20,7 @@ using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using Microsoft.Extensions.Logging;
+using System.IO.Abstractions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Views;
 
@@ -49,7 +50,7 @@ public sealed class GivenAccountsViewDisplay
         var dashboard = new DashboardViewModel(localization, Substitute.For<ISyncEventAggregator>(), Substitute.For<IDashboardAccountViewModelFactory>(), Substitute.For<IActivityItemViewModelFactory>());
         var activity = new ActivityViewModel(Substitute.For<ISyncRepository>(), Substitute.For<ISyncEventAggregator>(), Substitute.For<IConflictItemViewModelFactory>(), Substitute.For<IActivityItemViewModelFactory>(), Substitute.For<IUiDispatcher>(), localization);
         var settings = new SettingsViewModel(settingsService, Substitute.For<IThemeService>(), Substitute.For<ISyncScheduler>(), Substitute.For<IAccountRepository>(), localization, Substitute.For<IFolderPickerService>());
-        var classificationRules = new FileClassificationRulesViewModel(Substitute.For<IFileClassificationRepository>(), Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localization);
+        var classificationRules = new FileClassificationRulesViewModel(Substitute.For<IFileClassificationRepository>(), Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localization, Substitute.For<IFileSystem>());
         var statusBar = new StatusBarViewModel(accounts, localization);
 
         return new MainWindowViewModel(Substitute.For<IApplicationInitializer>(), Substitute.For<ISyncScheduler>(), accounts, files, dashboard, activity, settings, classificationRules, statusBar, localization, Substitute.For<ILogger<MainWindowViewModel>>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenFileClassificationsViewDisplay.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenFileClassificationsViewDisplay.cs
@@ -5,6 +5,7 @@ using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
+using System.IO.Abstractions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Views;
 
@@ -16,7 +17,7 @@ public sealed class GivenFileClassificationsViewDisplay
         localization.GetLocal(Arg.Any<string>()).Returns(call => call.Arg<string>());
         localization.GetLocal(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
 
-        return new FileClassificationRulesViewModel(Substitute.For<IFileClassificationRepository>(), Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localization);
+        return new FileClassificationRulesViewModel(Substitute.For<IFileClassificationRepository>(), Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localization, Substitute.For<IFileSystem>());
     }
 
     private static FileClassificationsView CreateViewWithViewModel(FileClassificationRulesViewModel viewModel)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Activity/ActivityViewModel.cs
@@ -116,7 +116,7 @@ public sealed partial class ActivityViewModel(ISyncRepository syncRepository, IS
 
     private async Task LoadPersistedConflictsAsync(string accountId)
     {
-        var persistedConflicts = await syncRepository.GetPendingConflictsAsync(new AccountId(accountId));
+        var persistedConflicts = await syncRepository.GetPendingConflictsAsync(new AccountId(accountId), CancellationToken.None);
 
         foreach (var entity in persistedConflicts)
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -20,8 +20,7 @@ namespace AStar.Dev.OneDrive.Sync.Client;
 
 public class App : Application, IDisposable
 {
-    private readonly ServiceProvider services = BuildServiceProvider();
-    private readonly CancellationTokenSource appLifetimeCts = new();
+    private ServiceProvider? services;
     private bool disposed;
 
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
@@ -29,6 +28,8 @@ public class App : Application, IDisposable
     public override void OnFrameworkInitializationCompleted()
     {
         base.OnFrameworkInitializationCompleted();
+
+        services = BuildServiceProvider();
 
         if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
             return;
@@ -122,8 +123,7 @@ public class App : Application, IDisposable
             return;
 
         disposed = true;
-        appLifetimeCts.Dispose();
-        services.Dispose();
+        services?.Dispose();
 
         GC.SuppressFinalize(this);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationExportImportService.cs
@@ -12,7 +12,7 @@ public sealed class FileClassificationExportImportService(IFileClassificationRep
     private static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
 
     /// <inheritdoc />
-    public async Task ExportAsync(string filePath, CancellationToken cancellationToken = default)
+    public async Task ExportAsync(IFileInfo fileInfo, CancellationToken cancellationToken = default)
     {
         var allCategories = await repository.GetAllCategoriesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -47,13 +47,13 @@ public sealed class FileClassificationExportImportService(IFileClassificationRep
 
         var exportRoot = new ClassificationExportRoot { Version = 1, Categories = rootNodes };
         string json = JsonSerializer.Serialize(exportRoot, SerializerOptions);
-        fileSystem.File.WriteAllText(filePath, json);
+        fileSystem.File.WriteAllText(fileInfo.FullName, json);
     }
 
     /// <inheritdoc />
-    public async Task ImportAsync(string filePath, CancellationToken cancellationToken = default)
+    public async Task ImportAsync(IFileInfo fileInfo, CancellationToken cancellationToken = default)
     {
-        string json = fileSystem.File.ReadAllText(filePath);
+        string json = fileSystem.File.ReadAllText(fileInfo.FullName);
         var exportRoot = JsonSerializer.Deserialize<ClassificationExportRoot>(json, SerializerOptions);
         if (exportRoot is null)
             return;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileClassificationRulesViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.IO.Abstractions;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -18,14 +19,16 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
     private readonly IFilePickerService filePickerService;
     private readonly IConfirmationDialogService confirmationDialogService;
     private readonly ILocalizationService localizationService;
+    private readonly IFileSystem fileSystem;
 
-    public FileClassificationRulesViewModel(IFileClassificationRepository repository, IFileClassificationExportImportService exportImportService, IFilePickerService filePickerService, IConfirmationDialogService confirmationDialogService, ILocalizationService localizationService)
+    public FileClassificationRulesViewModel(IFileClassificationRepository repository, IFileClassificationExportImportService exportImportService, IFilePickerService filePickerService, IConfirmationDialogService confirmationDialogService, ILocalizationService localizationService, IFileSystem fileSystem)
     {
         this.repository = repository;
         this.exportImportService = exportImportService;
         this.filePickerService = filePickerService;
         this.confirmationDialogService = confirmationDialogService;
         this.localizationService = localizationService;
+        this.fileSystem = fileSystem;
         Categories.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasNoCategories));
     }
 
@@ -113,7 +116,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         if (path is null)
             return;
 
-        await exportImportService.ExportAsync(path, ct).ConfigureAwait(false);
+        await exportImportService.ExportAsync(fileSystem.FileInfo.New(path), ct).ConfigureAwait(false);
     }
 
     /// <summary>Imports a taxonomy from a user-selected JSON file, replacing all existing data after confirmation.</summary>
@@ -127,7 +130,7 @@ public sealed partial class FileClassificationRulesViewModel : ObservableObject
         if (!confirmed)
             return;
 
-        await exportImportService.ImportAsync(path, ct).ConfigureAwait(false);
+        await exportImportService.ImportAsync(fileSystem.FileInfo.New(path), ct).ConfigureAwait(false);
         await LoadAsync(ct).ConfigureAwait(false);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileClassificationExportImportService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileClassificationExportImportService.cs
@@ -1,11 +1,13 @@
+using System.IO.Abstractions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
 
 /// <summary>Exports and imports the file classification taxonomy to/from a JSON file.</summary>
 public interface IFileClassificationExportImportService
 {
-    /// <summary>Serializes the current taxonomy to a JSON file at <paramref name="filePath"/>.</summary>
-    Task ExportAsync(string filePath, CancellationToken cancellationToken = default);
+    /// <summary>Serializes the current taxonomy to a JSON file described by <paramref name="fileInfo"/>.</summary>
+    Task ExportAsync(IFileInfo fileInfo, CancellationToken cancellationToken = default);
 
-    /// <summary>Reads a JSON taxonomy file and replaces ALL existing categories and keywords.</summary>
-    Task ImportAsync(string filePath, CancellationToken cancellationToken = default);
+    /// <summary>Reads a JSON taxonomy file described by <paramref name="fileInfo"/> and replaces ALL existing categories and keywords.</summary>
+    Task ImportAsync(IFileInfo fileInfo, CancellationToken cancellationToken = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Conflicts/ConflictResolver.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Conflicts/ConflictResolver.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.Utilities;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Conflicts;
 
@@ -30,6 +31,6 @@ public static class ConflictResolver
         string ext       = fileSystem.Path.GetExtension(localPath);
         string timestamp = localModified.LocalDateTime.ToString("yyyy-MM-dd HH-mm", CultureInfo.CurrentCulture);
 
-        return fileSystem.Path.Combine(dir, $"{stem} (local {timestamp}){ext}");
+        return dir.CombinePath($"{stem} (local {timestamp}){ext}");
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/AccountRepository.cs
@@ -18,7 +18,7 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
 
         return await db.Accounts
           .OrderBy(a => a.Profile.Email)
-          .ToListAsync(cancellationToken);
+          .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -26,7 +26,7 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-        var entity = await db.Accounts.FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
+        var entity = await db.Accounts.FirstOrDefaultAsync(a => a.Id == id, cancellationToken).ConfigureAwait(false);
 
         return entity is not null ? Option.Some(entity) : Option.None<AccountEntity>();
     }
@@ -37,7 +37,7 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         var existing = await db.Accounts
-            .FirstOrDefaultAsync(a => a.Id == account.Id, cancellationToken);
+            .FirstOrDefaultAsync(a => a.Id == account.Id, cancellationToken).ConfigureAwait(false);
 
         if(existing is null)
         {
@@ -48,7 +48,7 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
             db.Entry(existing).CurrentValues.SetValues(account);
         }
 
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -56,19 +56,19 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-        var entity = await db.Accounts.FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
+        var entity = await db.Accounts.FirstOrDefaultAsync(a => a.Id == id, cancellationToken).ConfigureAwait(false);
         if(entity is null)
             return;
 
         entity.Quota = quota;
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task DeleteAsync(AccountId id, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
-        _ = await db.Accounts.Where(a => a.Id == id).ExecuteDeleteAsync(cancellationToken);
+        _ = await db.Accounts.Where(a => a.Id == id).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -77,11 +77,11 @@ public sealed class AccountRepository(IDbContextFactory<AppDbContext> dbFactory)
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         _ = await db.Accounts.ExecuteUpdateAsync(s =>
-            s.SetProperty(a => a.IsActive, false), cancellationToken: cancellationToken);
+            s.SetProperty(a => a.IsActive, false), cancellationToken: cancellationToken).ConfigureAwait(false);
 
         _ = await db.Accounts
             .Where(a => a.Id == id)
             .ExecuteUpdateAsync(s =>
-                s.SetProperty(a => a.IsActive, true), cancellationToken: cancellationToken);
+                s.SetProperty(a => a.IsActive, true), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/DriveStateRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/DriveStateRepository.cs
@@ -10,7 +10,7 @@ public sealed class DriveStateRepository(IDbContextFactory<AppDbContext> dbFacto
     public async Task<Option<DriveStateEntity>> GetByAccountIdAsync(AccountId accountId, CancellationToken cancellationToken)
     {
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
-        var entity = await db.DriveStates.FirstOrDefaultAsync(d => d.AccountId == accountId, cancellationToken);
+        var entity = await db.DriveStates.FirstOrDefaultAsync(d => d.AccountId == accountId, cancellationToken).ConfigureAwait(false);
 
         return entity is null ? Option.None<DriveStateEntity>() : new Option<DriveStateEntity>.Some(entity);
     }
@@ -20,7 +20,7 @@ public sealed class DriveStateRepository(IDbContextFactory<AppDbContext> dbFacto
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         var existing = await db.DriveStates
-            .FirstOrDefaultAsync(d => d.AccountId == driveState.AccountId, cancellationToken);
+            .FirstOrDefaultAsync(d => d.AccountId == driveState.AccountId, cancellationToken).ConfigureAwait(false);
 
         if(existing is null)
         {
@@ -32,7 +32,7 @@ public sealed class DriveStateRepository(IDbContextFactory<AppDbContext> dbFacto
             existing.LastSyncStartedAt = driveState.LastSyncStartedAt;
         }
 
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task ClearDeltaLinkAsync(AccountId accountId, CancellationToken cancellationToken)
@@ -41,6 +41,6 @@ public sealed class DriveStateRepository(IDbContextFactory<AppDbContext> dbFacto
 
         _ = await db.DriveStates
             .Where(d => d.AccountId == accountId)
-            .ExecuteUpdateAsync(s => s.SetProperty(d => d.DeltaLink, Option.None<string>()), cancellationToken);
+            .ExecuteUpdateAsync(s => s.SetProperty(d => d.DeltaLink, Option.None<string>()), cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncRepository.cs
@@ -10,36 +10,44 @@ public interface ISyncRepository
 {
     /// <summary>Enqueues new sync jobs to be processed by the SyncService.</summary>
     /// <param name="jobs">A list of sync jobs to enqueue.</param>
-    Task EnqueueJobsAsync(IEnumerable<SyncJob> jobs);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task EnqueueJobsAsync(IEnumerable<SyncJob> jobs, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves pending sync jobs for the specified account.</summary>
     /// <param name="accountId">The ID of the account for which to retrieve pending jobs.</param>
-    Task<List<SyncJobEntity>> GetPendingJobsAsync(AccountId accountId);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task<List<SyncJobEntity>> GetPendingJobsAsync(AccountId accountId, CancellationToken cancellationToken = default);
 
     /// <summary>Updates the state of a sync job.</summary>
     /// <param name="jobId">The ID of the job to update.</param>
     /// <param name="state">The new state of the job.</param>
     /// <param name="stateError">An optional error message.</param>
-    Task UpdateJobStateAsync(Guid jobId, SyncJobState state, Option<string> stateError);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task UpdateJobStateAsync(Guid jobId, SyncJobState state, Option<string> stateError, CancellationToken cancellationToken = default);
 
     /// <summary>Clears completed jobs for the specified account.</summary>
     /// <param name="accountId">The ID of the account for which to clear completed jobs.</param>
-    Task ClearCompletedJobsAsync(AccountId accountId);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task ClearCompletedJobsAsync(AccountId accountId, CancellationToken cancellationToken = default);
 
     /// <summary>Adds a new sync conflict to the repository.</summary>
     /// <param name="conflict">The conflict to add.</param>
-    Task AddConflictAsync(SyncConflict conflict);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task AddConflictAsync(SyncConflict conflict, CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves pending conflicts for the specified account.</summary>
     /// <param name="accountId">The ID of the account for which to retrieve pending conflicts.</param>
-    Task<List<SyncConflictEntity>> GetPendingConflictsAsync(AccountId accountId);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task<List<SyncConflictEntity>> GetPendingConflictsAsync(AccountId accountId, CancellationToken cancellationToken = default);
 
     /// <summary>Resolves a sync conflict with the specified resolution policy.</summary>
     /// <param name="conflictId">The ID of the conflict to resolve.</param>
     /// <param name="resolution">The resolution policy to apply.</param>
-    Task ResolveConflictAsync(Guid conflictId, ConflictPolicy resolution);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task ResolveConflictAsync(Guid conflictId, ConflictPolicy resolution, CancellationToken cancellationToken = default);
 
     /// <summary>Gets the count of pending conflicts for the specified account.</summary>
     /// <param name="accountId">The ID of the account for which to get pending conflict count.</param>
-    Task<int> GetPendingConflictCountAsync(AccountId accountId);
+    /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+    Task<int> GetPendingConflictCountAsync(AccountId accountId, CancellationToken cancellationToken = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRepository.cs
@@ -14,9 +14,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : ISyncRepository
 {
     /// <inheritdoc/>
-    public async Task EnqueueJobsAsync(IEnumerable<SyncJob> jobs)
+    public async Task EnqueueJobsAsync(IEnumerable<SyncJob> jobs, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         var entities = jobs.Select(j => new SyncJobEntity
         {
@@ -41,25 +41,26 @@ public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : 
         });
 
         db.SyncJobs.AddRange(entities);
-        _ = await db.SaveChangesAsync();
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<List<SyncJobEntity>> GetPendingJobsAsync(AccountId accountId)
+    public async Task<List<SyncJobEntity>> GetPendingJobsAsync(AccountId accountId, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         return await db.SyncJobs
           .Where(j => j.AccountId == accountId &&
                       j.State == SyncJobState.Queued)
           .OrderBy(j => j.QueuedAt)
-          .ToListAsync();
+          .ToListAsync(cancellationToken)
+          .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task UpdateJobStateAsync(Guid jobId, SyncJobState state, Option<string> stateError)
+    public async Task UpdateJobStateAsync(Guid jobId, SyncJobState state, Option<string> stateError, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         _ = await db.SyncJobs
             .Where(j => j.Id == jobId)
@@ -69,23 +70,25 @@ public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : 
                 .SetProperty(j => j.CompletedAt,
                     state is SyncJobState.Completed or SyncJobState.Failed or SyncJobState.Skipped
                         ? Option.Some(DateTimeOffset.UtcNow)
-                        : Option.None<DateTimeOffset>()));
+                        : Option.None<DateTimeOffset>()), cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task ClearCompletedJobsAsync(AccountId accountId)
+    public async Task ClearCompletedJobsAsync(AccountId accountId, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         _ = await db.SyncJobs
           .Where(job => job.AccountId == accountId && job.State == SyncJobState.Completed)
-          .ExecuteDeleteAsync();
+          .ExecuteDeleteAsync(cancellationToken)
+          .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task AddConflictAsync(SyncConflict conflict)
+    public async Task AddConflictAsync(SyncConflict conflict, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         _ = db.SyncConflicts.Add(new SyncConflictEntity
         {
@@ -103,41 +106,44 @@ public sealed class SyncRepository(IDbContextFactory<AppDbContext> dbFactory) : 
             DetectedAt     = conflict.DetectedAt
         });
 
-        _ = await db.SaveChangesAsync();
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<List<SyncConflictEntity>> GetPendingConflictsAsync(AccountId accountId)
+    public async Task<List<SyncConflictEntity>> GetPendingConflictsAsync(AccountId accountId, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         return await db.SyncConflicts
           .Where(c => c.AccountId == accountId &&
                       c.State == ConflictState.Pending)
           .OrderBy(c => c.DetectedAt)
-          .ToListAsync();
+          .ToListAsync(cancellationToken)
+          .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task ResolveConflictAsync(Guid conflictId, ConflictPolicy resolution)
+    public async Task ResolveConflictAsync(Guid conflictId, ConflictPolicy resolution, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         _ = await db.SyncConflicts
             .Where(c => c.Id == conflictId)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(c => c.State, ConflictState.Resolved)
                 .SetProperty(c => c.Resolution, Option.Some(resolution))
-                .SetProperty(c => c.ResolvedAt, Option.Some(DateTimeOffset.UtcNow)));
+                .SetProperty(c => c.ResolvedAt, Option.Some(DateTimeOffset.UtcNow)), cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<int> GetPendingConflictCountAsync(AccountId accountId)
+    public async Task<int> GetPendingConflictCountAsync(AccountId accountId, CancellationToken cancellationToken = default)
     {
-        await using var db = await dbFactory.CreateDbContextAsync();
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         return await db.SyncConflicts
           .CountAsync(c => c.AccountId == accountId &&
-                           c.State == ConflictState.Pending);
+                           c.State == ConflictState.Pending, cancellationToken)
+          .ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRuleRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncRuleRepository.cs
@@ -14,7 +14,7 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
 
         return await db.SyncRules
              .Where(r => r.AccountId == accountId)
-             .ToListAsync(cancellationToken);
+             .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpsertAsync(AccountId accountId, string remotePath, RuleType ruleType, string? remoteItemId, CancellationToken cancellationToken)
@@ -22,7 +22,7 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         var existing = await db.SyncRules
-            .FirstOrDefaultAsync(r => r.AccountId == accountId && r.RemotePath == remotePath, cancellationToken);
+            .FirstOrDefaultAsync(r => r.AccountId == accountId && r.RemotePath == remotePath, cancellationToken).ConfigureAwait(false);
 
         if (existing is null)
         {
@@ -42,7 +42,7 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
                 existing.RemoteItemId = Option.Some(remoteItemId);
         }
 
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(AccountId accountId, string remotePath, CancellationToken cancellationToken)
@@ -51,7 +51,7 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
 
         _ = await db.SyncRules
                    .Where(r => r.AccountId == accountId && r.RemotePath == remotePath)
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteAllAsync(AccountId accountId, CancellationToken cancellationToken)
@@ -60,7 +60,7 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
 
         _ = await db.SyncRules
                    .Where(r => r.AccountId == accountId)
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteChildRulesAsync(AccountId accountId, string parentPath, CancellationToken cancellationToken)
@@ -70,6 +70,6 @@ public sealed class SyncRuleRepository(IDbContextFactory<AppDbContext> dbFactory
         string prefix = parentPath + "/";
         _ = await db.SyncRules
                    .Where(r => r.AccountId == accountId && r.RemotePath.StartsWith(prefix))
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -15,7 +15,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
 
         var items = await db.SyncedItems
             .Where(i => i.AccountId == accountId)
-            .ToListAsync(cancellationToken);
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
 
         return items.ToDictionary(i => i.RemoteItemId.Id);
     }
@@ -25,12 +25,12 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
         await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         var existing = await db.SyncedItems
-            .FirstOrDefaultAsync(i => i.AccountId == item.AccountId && i.RemoteItemId == item.RemoteItemId, cancellationToken);
+            .FirstOrDefaultAsync(i => i.AccountId == item.AccountId && i.RemoteItemId == item.RemoteItemId, cancellationToken).ConfigureAwait(false);
 
         if(existing is null)
         {
             _ = db.SyncedItems.Add(item);
-            _ = await db.SaveChangesAsync(cancellationToken);
+            _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             return item.Id;
         }
@@ -41,7 +41,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
         existing.IsFolder         = item.IsFolder;
         existing.RemoteModifiedAt = item.RemoteModifiedAt;
         existing.Tags             = item.Tags;
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         return existing.Id;
     }
@@ -52,7 +52,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
 
         _ = await db.SyncedItemClassifications
                    .Where(c => c.SyncedItemId == syncedItemId)
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
 
         var entities = classifications.Select(c => new SyncedItemClassificationEntity
         {
@@ -65,7 +65,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
         });
 
         db.SyncedItemClassifications.AddRange(entities);
-        _ = await db.SaveChangesAsync(cancellationToken);
+        _ = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteByRemoteIdAsync(AccountId accountId, OneDriveItemId remoteItemId, CancellationToken cancellationToken)
@@ -74,7 +74,7 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
 
         _ = await db.SyncedItems
                    .Where(i => i.AccountId == accountId && i.RemoteItemId == remoteItemId)
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteAllAsync(AccountId accountId, CancellationToken cancellationToken)
@@ -83,6 +83,6 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
 
         _ = await db.SyncedItems
                    .Where(i => i.AccountId == accountId)
-                   .ExecuteDeleteAsync(cancellationToken);
+                   .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/AuthService.cs
@@ -28,7 +28,7 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
     /// <inheritdoc />
     public async Task<Result<AuthResult, AuthError>> SignInInteractiveAsync(CancellationToken ct = default)
     {
-        await EnsureCacheRegisteredAsync();
+        await EnsureCacheRegisteredAsync().ConfigureAwait(false);
 
         try
         {
@@ -36,7 +36,7 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
                     .AcquireTokenInteractive(entraIdOptions.Value.Scopes)
                     .WithPrompt(Prompt.SelectAccount)
                     .WithUseEmbeddedWebView(false)
-                    .ExecuteAsync(ct);
+                    .ExecuteAsync(ct).ConfigureAwait(false);
 
             return BuildSuccess(result);
         }
@@ -65,11 +65,11 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
     /// <inheritdoc />
     public async Task<Result<AuthResult, AuthError>> AcquireTokenSilentAsync(string accountId, CancellationToken ct = default)
     {
-        await EnsureCacheRegisteredAsync();
+        await EnsureCacheRegisteredAsync().ConfigureAwait(false);
 
         try
         {
-            var accounts = await app.GetAccountsAsync();
+            var accounts = await app.GetAccountsAsync().ConfigureAwait(false);
             var account = accounts.FirstOrDefault(a =>
                 string.Equals(a.HomeAccountId?.Identifier, accountId, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(a.Username, accountId, StringComparison.OrdinalIgnoreCase));
@@ -79,7 +79,7 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
 
             var result = await app
                 .AcquireTokenSilent(entraIdOptions.Value.Scopes, account)
-                .ExecuteAsync(ct);
+                .ExecuteAsync(ct).ConfigureAwait(false);
 
             return BuildSuccess(result);
         }
@@ -104,21 +104,21 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
     /// <inheritdoc />
     public async Task SignOutAsync(string accountId, CancellationToken ct = default)
     {
-        await EnsureCacheRegisteredAsync();
+        await EnsureCacheRegisteredAsync().ConfigureAwait(false);
 
-        var accounts = await app.GetAccountsAsync();
+        var accounts = await app.GetAccountsAsync().ConfigureAwait(false);
         var account = accounts.FirstOrDefault(a => a.HomeAccountId?.Identifier == accountId);
 
         if (account is not null)
-            await app.RemoveAsync(account);
+            await app.RemoveAsync(account).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<string>> GetCachedAccountIdsAsync()
     {
-        await EnsureCacheRegisteredAsync();
+        await EnsureCacheRegisteredAsync().ConfigureAwait(false);
 
-        var accounts = await app.GetAccountsAsync();
+        var accounts = await app.GetAccountsAsync().ConfigureAwait(false);
 
         return accounts
             .Select(account => account.HomeAccountId.Identifier)
@@ -130,7 +130,7 @@ public sealed class AuthService(IPublicClientApplication app, ITokenCacheService
         if (cacheRegistered)
             return;
 
-        await cacheService.RegisterAsync(app);
+        await cacheService.RegisterAsync(app).ConfigureAwait(false);
         cacheRegistered = true;
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using AStar.Dev.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
@@ -88,13 +89,13 @@ public sealed class TokenCacheService(IFileSystem fileSystem, ILogger<TokenCache
 
     private static string InitialiseCacheDirectory(IFileSystem fs)
     {
-        string directory = GetPlatformCacheDirectory(fs);
+        string directory = GetPlatformCacheDirectory();
         _ = fs.Directory.CreateDirectory(directory);
 
         return directory;
     }
 
-    private static string GetPlatformCacheDirectory(IFileSystem fs)
+    private static string GetPlatformCacheDirectory()
     {
         string appData = Environment.GetFolderPath(
             OperatingSystem.IsWindows()
@@ -102,9 +103,9 @@ public sealed class TokenCacheService(IFileSystem fileSystem, ILogger<TokenCache
                 : Environment.SpecialFolder.UserProfile);
 
         return OperatingSystem.IsWindows()
-            ? fs.Path.Combine(appData, ApplicationMetadata.ApplicationNameHyphenated)
+            ? appData.CombinePath(ApplicationMetadata.ApplicationNameHyphenated)
             : OperatingSystem.IsMacOS()
-                ? fs.Path.Combine(appData, "Library", "Application Support", ApplicationMetadata.ApplicationNameHyphenated)
-                : fs.Path.Combine(appData, ".config", ApplicationMetadata.ApplicationNameHyphenated);
+                ? appData.CombinePath("Library", "Application Support", ApplicationMetadata.ApplicationNameHyphenated)
+                : appData.CombinePath(".config", ApplicationMetadata.ApplicationNameHyphenated);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Authentication/TokenCacheService.cs
@@ -56,7 +56,7 @@ public sealed class TokenCacheService(IFileSystem fileSystem, ILogger<TokenCache
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(KeyringTimeoutSeconds));
                 var helper = await MsalCacheHelper
                     .CreateAsync(keyringProperties)
-                    .WaitAsync(cts.Token);
+                    .WaitAsync(cts.Token).ConfigureAwait(false);
                 helper.RegisterCache(app.UserTokenCache);
 
                 return;
@@ -83,7 +83,7 @@ public sealed class TokenCacheService(IFileSystem fileSystem, ILogger<TokenCache
                 .Build();
         }
 
-        var cacheHelper = await MsalCacheHelper.CreateAsync(storageProperties);
+        var cacheHelper = await MsalCacheHelper.CreateAsync(storageProperties).ConfigureAwait(false);
         cacheHelper.RegisterCache(app.UserTokenCache);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/DriveContext.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/DriveContext.cs
@@ -1,0 +1,6 @@
+using AStar.Dev.OneDrive.Sync.Client.Home;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+/// <summary>Holds the resolved drive ID and root item ID for a specific OneDrive account.</summary>
+internal sealed record DriveContext(DriveId DriveId, string RootId);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/DriveContextCache.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/DriveContextCache.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Graph;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+/// <summary>Resolves and caches the <see cref="DriveContext"/> (drive ID + root item ID) for each OneDrive account, so that the Graph API is called at most once per account per session.</summary>
+internal sealed class DriveContextCache(IGraphClientFactory graphClientFactory)
+{
+    private readonly ConcurrentDictionary<string, DriveContext> cache = [];
+
+    /// <summary>Returns the <see cref="GraphServiceClient"/> together with the resolved <see cref="DriveContext"/> for the given account. The drive context is fetched from the Graph API on the first call and cached for subsequent calls.</summary>
+    internal async Task<Result<(GraphServiceClient Client, DriveContext Ctx), string>> ResolveAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
+    {
+        var client = graphClientFactory.CreateClient(tokenFactory);
+
+        if(cache.TryGetValue(accountId, out var cached))
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, cached));
+
+        var drive = await client.Me.Drive.GetAsync(cancellationToken: ct).ConfigureAwait(false);
+
+        if(drive?.Id is null)
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve drive ID.");
+
+        var driveId = new DriveId(drive.Id);
+        var root = await client.Drives[driveId.Value].Root.GetAsync(cancellationToken: ct).ConfigureAwait(false);
+
+        if(root?.Id is null)
+            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve root item ID.");
+
+        var driveContext = new DriveContext(driveId, root.Id);
+        cache[accountId] = driveContext;
+
+        return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, driveContext));
+    }
+
+    /// <summary>Removes the cached drive context for the given account. Call after sign-out to prevent stale entries accumulating.</summary>
+    internal void Evict(string accountId) => cache.TryRemove(accountId, out _);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphFolderEnumerator.cs
@@ -1,0 +1,98 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
+
+/// <summary>Recursively enumerates all descendants (files and sub-folders) of a given OneDrive folder using the Microsoft Graph API.</summary>
+internal sealed class GraphFolderEnumerator(IGraphClientFactory graphClientFactory)
+{
+    private const string DownloadUrlKey = "@microsoft.graph.downloadUrl";
+
+    private static readonly string[] childrenSelect =
+    [
+        "id", "name", "folder", "file", "size", "lastModifiedDateTime", "parentReference",
+        "eTag", "cTag", DownloadUrlKey
+    ];
+
+    /// <summary>Enumerates all descendants of the specified folder, returning a flat list of <see cref="DeltaItem"/> instances. Cycles in the folder graph are detected and broken.</summary>
+    internal async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered, CancellationToken ct)
+    {
+        try
+        {
+            var client = graphClientFactory.CreateClient(tokenFactory);
+            List<DeltaItem> items = [];
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct).ConfigureAwait(false);
+
+            return new Result<List<DeltaItem>, string>.Ok(items);
+        }
+        catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
+        {
+            return new Result<List<DeltaItem>, string>.Error(ex.Message);
+        }
+    }
+
+    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, Action<int>? onItemDiscovered, CancellationToken ct)
+    {
+        if(!visited.Add(parentId))
+            return;
+
+        var page = await client.Drives[driveId.Value].Items[parentId].Children
+            .GetAsync(req => req.QueryParameters.Select = childrenSelect, ct).ConfigureAwait(false);
+
+        while(page?.Value is not null)
+        {
+            foreach(var item in page.Value)
+            {
+                string itemPath = BuildRelativePath(relativePath, item);
+
+                items.Add(MapToDeltaItem(item, itemPath));
+                onItemDiscovered?.Invoke(items.Count);
+
+                if(item.Folder is not null && item.Id is not null)
+                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct).ConfigureAwait(false);
+            }
+
+            if(!OdataNextLinkGuard.IsSafe(page.OdataNextLink))
+                break;
+
+            page = await client.Drives[driveId.Value].Items[parentId].Children
+                .WithUrl(page.OdataNextLink!)
+                .GetAsync(cancellationToken: ct).ConfigureAwait(false);
+        }
+    }
+
+    private static string BuildRelativePath(string relativePath, DriveItem item) => string.IsNullOrEmpty(relativePath)
+        ? item.Name ?? string.Empty
+        : $"{relativePath}/{item.Name}";
+
+    private static DeltaItem MapToDeltaItem(DriveItem item, string itemPath)
+    {
+        var id = new OneDriveItemId(item.Id!);
+        var driveId = new DriveId(item.ParentReference?.DriveId ?? string.Empty);
+        var parentId = item.ParentReference?.Id is string pid ? Option.Some(new OneDriveFolderId(pid)) : Option.None<OneDriveFolderId>();
+        var path = ItemPathFactory.Create(item.Name ?? string.Empty, itemPath);
+        var versionInfo = VersionInfoFactory.Create(ToOptionString(item.ETag), ToOptionString(item.CTag));
+
+        if(item.Folder is not null)
+            return DeltaItemFactory.CreateFolder(id, driveId, parentId, path, versionInfo);
+
+        return DeltaItemFactory.CreateFile(id, driveId, parentId, path, item.Size ?? 0L, item.LastModifiedDateTime.ToOption(), ExtractDownloadUrl(item), versionInfo);
+    }
+
+    private static Option<string> ExtractDownloadUrl(DriveItem item)
+    {
+        if(item.AdditionalData?.TryGetValue(DownloadUrlKey, out object? url) is not true || url is null)
+            return Option.None<string>();
+
+        return Option.Some(url.ToString()!);
+    }
+
+    private static Option<string> ToOptionString(string? value) => value is not null ? Option.Some(value) : Option.None<string>();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -49,7 +49,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
                 async ctx =>
                 {
                     var response = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
-                        .GetAsync(req => req.QueryParameters.Select = childrenSelect, ct);
+                        .GetAsync(req => req.QueryParameters.Select = childrenSelect, ct).ConfigureAwait(false);
 
                     List<DriveFolder> folders = [];
 
@@ -66,12 +66,12 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
 
                         page = await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[ctx.Ctx.RootId].Children
                             .WithUrl(page.OdataNextLink!)
-                            .GetAsync(cancellationToken: ct);
+                            .GetAsync(cancellationToken: ct).ConfigureAwait(false);
                     }
 
                     return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
                 },
-                error => new Result<List<DriveFolder>, string>.Error(error));
+                error => new Result<List<DriveFolder>, string>.Error(error)).ConfigureAwait(false);
         }
         catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
         {
@@ -91,7 +91,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
                 {
                     req.QueryParameters.Select = ["id", "name", "folder", "parentReference"];
                     req.QueryParameters.Top = 100;
-                }, ct);
+                }, ct).ConfigureAwait(false);
 
             List<DriveFolder> folders = [];
 
@@ -108,7 +108,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
 
                 page = await client.Drives[driveId.Value].Items[parentFolderId].Children
                     .WithUrl(page.OdataNextLink!)
-                    .GetAsync(cancellationToken: ct);
+                    .GetAsync(cancellationToken: ct).ConfigureAwait(false);
             }
 
             return new Result<List<DriveFolder>, string>.Ok([.. folders.OrderBy(f => f.Name)]);
@@ -130,7 +130,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
                 async ctx =>
                 {
                     var drive = await ctx.Client.Drives[ctx.Ctx.DriveId.Value]
-                        .GetAsync(req => req.QueryParameters.Select = ["quota"], ct);
+                        .GetAsync(req => req.QueryParameters.Select = ["quota"], ct).ConfigureAwait(false);
 
                     var quota = drive?.Quota is { Total: not null, Used: not null }
                         ? (drive.Quota.Total!.Value, drive.Quota.Used!.Value)
@@ -138,7 +138,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
 
                     return new Result<(long Total, long Used), string>.Ok(quota);
                 },
-                error => new Result<(long Total, long Used), string>.Error(error));
+                error => new Result<(long Total, long Used), string>.Error(error)).ConfigureAwait(false);
         }
         catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
         {
@@ -158,7 +158,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
         try
         {
             var item = await client.Drives[driveId.Value].Items[$"{RootPathMarker}:{remotePath}"]
-                .GetAsync(req => req.QueryParameters.Select = ["id"], ct);
+                .GetAsync(req => req.QueryParameters.Select = ["id"], ct).ConfigureAwait(false);
 
             return item?.Id;
         }
@@ -194,7 +194,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
 
                     return new Result<string, string>.Ok(url.ToString()!);
                 },
-                error => new Result<string, string>.Error(error));
+                error => new Result<string, string>.Error(error)).ConfigureAwait(false);
         }
         catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
         {
@@ -211,7 +211,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
 
             return await contextResult.MatchAsync(
                 async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
-                error => new Result<string, string>.Error(error));
+                error => new Result<string, string>.Error(error)).ConfigureAwait(false);
         }
         catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
         {
@@ -229,7 +229,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
             {
                 try
                 {
-                    await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct);
+                    await ctx.Client.Drives[ctx.Ctx.DriveId.Value].Items[itemId].DeleteAsync(cancellationToken: ct).ConfigureAwait(false);
 
                     return new Result<Unit, string>.Ok(Unit.Default);
                 }
@@ -238,7 +238,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
                     return new Result<Unit, string>.Error(ex.Message);
                 }
             },
-            error => new Result<Unit, string>.Error(error));
+            error => new Result<Unit, string>.Error(error)).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -1,19 +1,16 @@
-using System.Collections.Concurrent;
 using System.Reactive;
 using AStar.Dev.Functional.Extensions;
-using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
-using AStar.Dev.OneDrive.Sync.Client.Domain;
 using Microsoft.Graph;
-using Microsoft.Graph.Models;
 using Microsoft.Kiota.Abstractions;
-using OneDriveItemId = AStar.Dev.OneDrive.Sync.Client.Data.Entities.OneDriveItemId;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 
-public sealed class GraphService(IUploadService uploadService, IGraphClientFactory graphClientFactory) : IGraphService
+/// <summary>Implementation of <see cref="IGraphService"/> that delegates drive-context resolution to <see cref="DriveContextCache"/> and recursive folder enumeration to <see cref="GraphFolderEnumerator"/>.</summary>
+internal sealed class GraphService(IUploadService uploadService, IGraphClientFactory graphClientFactory, DriveContextCache driveContextCache, GraphFolderEnumerator graphFolderEnumerator) : IGraphService
 {
     private const string RootPathMarker = "root:";
     private const string DownloadUrlKey = "@microsoft.graph.downloadUrl";
@@ -24,14 +21,12 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
         "eTag", "cTag", DownloadUrlKey
     ];
 
-    private readonly ConcurrentDictionary<string, DriveContext> cache = [];
-
     /// <inheritdoc />
     public async Task<Result<DriveId, string>> GetDriveIdAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default)
     {
         try
         {
-            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+            var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
             return contextResult.Match<Result<DriveId, string>>(
                 ctx => new Result<DriveId, string>.Ok(ctx.Ctx.DriveId),
@@ -48,7 +43,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         try
         {
-            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+            var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
             return await contextResult.MatchAsync<Result<List<DriveFolder>, string>>(
                 async ctx =>
@@ -129,7 +124,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         try
         {
-            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+            var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
             return await contextResult.MatchAsync<Result<(long Total, long Used), string>>(
                 async ctx =>
@@ -152,22 +147,8 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     }
 
     /// <inheritdoc />
-    public async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
-    {
-        try
-        {
-            var client = graphClientFactory.CreateClient(tokenFactory);
-            List<DeltaItem> items = [];
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct);
-
-            return new Result<List<DeltaItem>, string>.Ok(items);
-        }
-        catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
-        {
-            return new Result<List<DeltaItem>, string>.Error(ex.Message);
-        }
-    }
+    public Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
+        => graphFolderEnumerator.EnumerateFolderAsync(tokenFactory, driveId, folderId, remotePath, onItemDiscovered, ct);
 
     /// <inheritdoc />
     public async Task<string?> GetFolderIdByPathAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string remotePath, CancellationToken ct = default)
@@ -196,7 +177,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         try
         {
-            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+            var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
             return await contextResult.MatchAsync<Result<string, string>>(
                 async ctx =>
@@ -226,7 +207,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     {
         try
         {
-            var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+            var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
             return await contextResult.MatchAsync(
                 async ctx => await uploadService.UploadAsync(ctx.Client, ctx.Ctx.DriveId, parentFolderId, localPath, remotePath, ct: ct).ConfigureAwait(false),
@@ -241,7 +222,7 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
     /// <inheritdoc />
     public async Task<Result<Unit, string>> DeleteItemAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, string itemId, CancellationToken ct = default)
     {
-        var contextResult = await ResolveClientWithDriveContextAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
+        var contextResult = await driveContextCache.ResolveAsync(accountId, tokenFactory, ct).ConfigureAwait(false);
 
         return await contextResult.MatchAsync<Result<Unit, string>>(
             async ctx =>
@@ -260,90 +241,8 @@ public sealed class GraphService(IUploadService uploadService, IGraphClientFacto
             error => new Result<Unit, string>.Error(error));
     }
 
-    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, Action<int>? onItemDiscovered, CancellationToken ct)
-    {
-        if(!visited.Add(parentId))
-            return;
-
-        var page = await client.Drives[driveId.Value].Items[parentId].Children
-            .GetAsync(req => req.QueryParameters.Select = childrenSelect, ct);
-
-        while(page?.Value is not null)
-        {
-            foreach(var item in page.Value)
-            {
-                string itemPath = BuildRelativePath(relativePath, item);
-
-                items.Add(MapToDeltaItem(item, itemPath));
-                onItemDiscovered?.Invoke(items.Count);
-
-                if(item.Folder is not null && item.Id is not null)
-                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct);
-            }
-
-            if(!OdataNextLinkGuard.IsSafe(page.OdataNextLink))
-                break;
-
-            page = await client.Drives[driveId.Value].Items[parentId].Children
-                .WithUrl(page.OdataNextLink!)
-                .GetAsync(cancellationToken: ct);
-        }
-    }
-
-    private static string BuildRelativePath(string relativePath, DriveItem item) => string.IsNullOrEmpty(relativePath)
-                        ? item.Name ?? string.Empty
-                        : $"{relativePath}/{item.Name}";
-
-    private static DeltaItem MapToDeltaItem(DriveItem item, string itemPath)
-    {
-        var id = new OneDriveItemId(item.Id!);
-        var driveId = new DriveId(item.ParentReference?.DriveId ?? string.Empty);
-        var parentId = item.ParentReference?.Id is string pid ? Option.Some(new OneDriveFolderId(pid)) : Option.None<OneDriveFolderId>();
-        var path = ItemPathFactory.Create(item.Name ?? string.Empty, itemPath);
-        var versionInfo = VersionInfoFactory.Create(ToOptionString(item.ETag), ToOptionString(item.CTag));
-
-        if (item.Folder is not null)
-            return DeltaItemFactory.CreateFolder(id, driveId, parentId, path, versionInfo);
-
-        return DeltaItemFactory.CreateFile(id, driveId, parentId, path, item.Size ?? 0L, item.LastModifiedDateTime.ToOption(), ExtractDownloadUrl(item), versionInfo);
-    }
-
-    private static Option<string> ExtractDownloadUrl(DriveItem item)
-    {
-        if(item.AdditionalData?.TryGetValue(DownloadUrlKey, out object? url) is not true || url is null)
-            return Option.None<string>();
-
-        return Option.Some(url.ToString()!);
-    }
+    /// <inheritdoc />
+    public void EvictCachedDriveContext(string accountId) => driveContextCache.Evict(accountId);
 
     private static Option<string> ToOptionString(string? value) => value is not null ? Option.Some(value) : Option.None<string>();
-
-    /// <inheritdoc />
-    public void EvictCachedDriveContext(string accountId) => cache.TryRemove(accountId, out _);
-
-    private async Task<Result<(GraphServiceClient Client, DriveContext Ctx), string>> ResolveClientWithDriveContextAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct)
-    {
-        var client = graphClientFactory.CreateClient(tokenFactory);
-
-        if(cache.TryGetValue(accountId, out var cached))
-            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, cached));
-
-        var drive = await client.Me.Drive.GetAsync(cancellationToken: ct);
-
-        if(drive?.Id is null)
-            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve drive ID.");
-
-        var driveId = new DriveId(drive.Id);
-        var root = await client.Drives[driveId.Value].Root.GetAsync(cancellationToken: ct);
-
-        if(root?.Id is null)
-            return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Error("Could not retrieve root item ID.");
-
-        var driveContext = new DriveContext(driveId, root.Id);
-        cache[accountId] = driveContext;
-
-        return new Result<(GraphServiceClient Client, DriveContext Ctx), string>.Ok((client, driveContext));
-    }
-
-    private sealed record DriveContext(DriveId DriveId, string RootId);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Http/HttpRetryPolicy.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Http/HttpRetryPolicy.cs
@@ -1,0 +1,54 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Http;
+
+/// <summary>
+/// Shared HTTP retry constants and helpers for exponential backoff with jitter
+/// and Retry-After header parsing. Used by both download and upload pipelines.
+/// </summary>
+public static class HttpRetryPolicy
+{
+    /// <summary>Maximum number of retry attempts before the operation is considered failed.</summary>
+    public const int MaxRetries = 5;
+
+    /// <summary>Base delay in seconds for the first exponential backoff step.</summary>
+    public const double BaseDelaySeconds = 2.0;
+
+    /// <summary>Upper bound in seconds for any single backoff delay before jitter is applied.</summary>
+    public const double MaxDelaySeconds = 120.0;
+
+    /// <summary>
+    /// Computes the delay to wait before a retry attempt, honouring the
+    /// <c>Retry-After</c> response header when present. Falls back to
+    /// <see cref="GetBackoffDelay"/> when no header is available.
+    /// </summary>
+    /// <param name="response">The HTTP response that triggered the retry (typically 429).</param>
+    /// <param name="attempt">The 1-based attempt number that just failed.</param>
+    /// <returns>The <see cref="TimeSpan"/> to delay before the next attempt.</returns>
+    public static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
+    {
+        if (response.Headers.RetryAfter?.Delta is { } delta)
+            return delta + TimeSpan.FromSeconds(1);
+
+        if (response.Headers.RetryAfter?.Date is { } date)
+        {
+            var wait = date - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero)
+                return wait + TimeSpan.FromSeconds(1);
+        }
+
+        return GetBackoffDelay(attempt);
+    }
+
+    /// <summary>
+    /// Computes an exponential backoff delay with up to 20% random jitter for the given attempt number.
+    /// The base delay is capped at <see cref="MaxDelaySeconds"/> before jitter is added.
+    /// </summary>
+    /// <param name="attempt">The 1-based attempt number that just failed.</param>
+    /// <returns>A <see cref="TimeSpan"/> in the range <c>[base, base * 1.2)</c> where <c>base = min(2^(attempt-1) * 2, 120)</c>.</returns>
+    public static TimeSpan GetBackoffDelay(int attempt)
+    {
+        double seconds = Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
+        double jitter = seconds * 0.2 * Random.Shared.NextDouble();
+
+        return TimeSpan.FromSeconds(seconds + jitter);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Onboarding/AccountOnboardingService.cs
@@ -16,13 +16,13 @@ public sealed class AccountOnboardingService(IAccountRepository accountRepositor
         if (account.SyncConfig is Option<AccountSyncConfig>.None)
             account.SyncConfig = ResolveDefaultSyncConfig(account.Profile.Email);
 
-        await accountRepository.UpsertAsync(ToEntity(account), ct);
+        await accountRepository.UpsertAsync(ToEntity(account), ct).ConfigureAwait(false);
 
         foreach (var (folderId, folderName) in account.FolderNames)
-            await syncRuleRepository.UpsertAsync(account.Id, $"/{folderName}", RuleType.Include, folderId.Id, ct);
+            await syncRuleRepository.UpsertAsync(account.Id, $"/{folderName}", RuleType.Include, folderId.Id, ct).ConfigureAwait(false);
 
         if (account.IsActive)
-            await accountRepository.SetActiveAccountAsync(account.Id, ct);
+            await accountRepository.SetActiveAccountAsync(account.Id, ct).ConfigureAwait(false);
 
         return account;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/SyncRuleService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Rules/SyncRuleService.cs
@@ -17,12 +17,12 @@ public sealed class SyncRuleService(ISyncRuleRepository syncRuleRepository, ILog
         string ruleTypeName = ruleType.ToString();
         OneDriveSyncClientMessages.RulePersisting(logger, ruleTypeName, parentRemotePath, accountId.Id);
 
-        await syncRuleRepository.DeleteChildRulesAsync(accountId, parentRemotePath, cancellationToken);
+        await syncRuleRepository.DeleteChildRulesAsync(accountId, parentRemotePath, cancellationToken).ConfigureAwait(false);
 
         foreach (var (remotePath, remoteItemId) in nodes)
-            await syncRuleRepository.UpsertAsync(accountId, remotePath, ruleType, remoteItemId, cancellationToken);
+            await syncRuleRepository.UpsertAsync(accountId, remotePath, ruleType, remoteItemId, cancellationToken).ConfigureAwait(false);
 
-        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken);
+        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken).ConfigureAwait(false);
 
         return rules.Count(rule => rule.RuleType == RuleType.Include);
     }
@@ -30,7 +30,7 @@ public sealed class SyncRuleService(ISyncRuleRepository syncRuleRepository, ILog
     /// <inheritdoc />
     public async Task<IReadOnlyDictionary<string, RuleType>> GetRuleStatesAsync(AccountId accountId, CancellationToken cancellationToken)
     {
-        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken);
+        var rules = await syncRuleRepository.GetByAccountIdAsync(accountId, cancellationToken).ConfigureAwait(false);
 
         return rules.ToDictionary(rule => rule.RemotePath, rule => rule.RuleType, StringComparer.OrdinalIgnoreCase);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AppBootstrapper.cs
@@ -35,7 +35,8 @@ public sealed class AppBootstrapper(IDbContextFactory<AppDbContext> dbContextFac
             await mainWindowViewModel.InitialiseAsync().ConfigureAwait(false);
 
             progress.Report("Starting sync scheduler…");
-            syncScheduler.StartSync(TimeSpan.FromMinutes(settingsService.Current.SyncIntervalMinutes));
+            _ = syncScheduler.StartSync(TimeSpan.FromMinutes(settingsService.Current.SyncIntervalMinutes))
+                .Match(_ => true, error => throw new InvalidOperationException(error));
         }
         catch (Exception ex)
         {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/AvaloniaConfirmationDialogService.cs
@@ -63,6 +63,6 @@ public sealed class AvaloniaConfirmationDialogService : IConfirmationDialogServi
 
         await dialog.ShowDialog(mainWindow).ConfigureAwait(false);
 
-        return await tcs.Task.ConfigureAwait(false);
+        return await tcs.Task;
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/FeatureAvailabilityService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/FeatureAvailabilityService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Frozen;
+using System.Reactive;
+using AStar.Dev.Functional.Extensions;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
@@ -17,14 +19,17 @@ public sealed class FeatureAvailabilityService : IFeatureAvailabilityService, IF
     public void Freeze() => frozenSections = pendingSections.ToFrozenSet();
 
     /// <summary>
-    /// Registers a navigation section as available. This method can be called multiple times during application initialization to build up the set of available sections. Once the set is frozen, any further calls to this method will throw an exception.
+    /// Registers a navigation section as available. This method can be called multiple times during application initialization to build up the set of available sections. Once the set is frozen, any further calls to this method will return an error result.
     /// </summary>
     /// <param name="section">The navigation section to register.</param>
-    /// <exception cref="InvalidOperationException">Thrown when attempting to register a section after the set has been frozen.</exception>
-    public void Register(NavSection section)
+    /// <returns>A successful result if the section was registered, or an error result if called after the set has been frozen.</returns>
+    public Result<Unit, string> Register(NavSection section)
     {
-        if (frozenSections is not null) throw new InvalidOperationException("Cannot register sections after the set has been frozen.");
+        if (frozenSections is not null)
+            return new Result<Unit, string>.Error("Cannot register sections after the set has been frozen.");
 
         pendingSections.Add(section);
+
+        return new Result<Unit, string>.Ok(Unit.Default);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFeatureRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFeatureRegistrar.cs
@@ -1,7 +1,12 @@
+using System.Reactive;
+using AStar.Dev.Functional.Extensions;
+
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 public interface IFeatureRegistrar
 {
-    void Register(NavSection section);
+    /// <summary>Registers a navigation section as available. Returns an error if called after <see cref="Freeze"/>.</summary>
+    Result<Unit, string> Register(NavSection section);
+
     void Freeze();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/LocalDeletionDetector.cs
@@ -25,20 +25,20 @@ public sealed class LocalDeletionDetector(IGraphService graphService, ISyncedIte
 
             try
             {
-                var deleteResult = await graphService.DeleteItemAsync(accountId.Id, tokenFactory, remoteId, ct);
+                var deleteResult = await graphService.DeleteItemAsync(accountId.Id, tokenFactory, remoteId, ct).ConfigureAwait(false);
 
                 await deleteResult.MatchAsync(
                     async _ =>
                     {
                         OneDriveSyncClientMessages.LocalDeletionDetectorRemoteDeleted(logger, remoteId);
-                        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+                        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct).ConfigureAwait(false);
                         return Unit.Default;
                     },
                     deleteError =>
                     {
                         OneDriveSyncClientMessages.LocalDeletionDetectorDeleteFailed(logger, remoteId, deleteError);
                         return Unit.Default;
-                    });
+                    }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteDeletionDetector.cs
@@ -25,7 +25,7 @@ public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepos
                 continue;
 
             OneDriveSyncClientMessages.RemoteDeletionDetectorNotPresent(logger, knownItem.RemotePath);
-            await HandleRemoteDeleteAsync(accountId, knownItem, syncedItems, ct);
+            await HandleRemoteDeleteAsync(accountId, knownItem, syncedItems, ct).ConfigureAwait(false);
         }
     }
 
@@ -50,7 +50,7 @@ public sealed class RemoteDeletionDetector(ISyncedItemRepository syncedItemRepos
             }
         }
 
-        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct);
+        await syncedItemRepository.DeleteByRemoteIdAsync(accountId, knownItem.RemoteItemId, ct).ConfigureAwait(false);
         syncedItems.Remove(knownItem.RemoteItemId.Id);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/ISyncScheduler.cs
@@ -1,3 +1,5 @@
+using System.Reactive;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
@@ -16,9 +18,10 @@ public interface ISyncScheduler
 
     /// <summary>
     /// Starts the sync scheduler with the specified interval. If no interval is provided, uses the default (60 minutes).
+    /// Returns an error result if the underlying timer cannot be created.
     /// </summary>
     /// <param name="interval">The interval at which to run sync passes.</param>
-    void StartSync(TimeSpan? interval = null);
+    Result<Unit, string> StartSync(TimeSpan? interval = null);
 
     /// <summary>
     /// Stops the sync scheduler, halting all scheduled sync passes until restarted. Does not affect manual syncs triggered via TriggerNowAsync or TriggerAccountAsync.

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -40,7 +40,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
             try
             {
-                response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+                response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
@@ -51,7 +51,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                     OneDriveSyncClientMessages.DownloadThrottled(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
                     response.Dispose();
-                    await Task.Delay(delay, ct);
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
                     continue;
                 }
 
@@ -60,19 +60,19 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 EnsureDirectoryExists(localPath);
 
                 await using var stream = await response.Content.ReadAsStreamAsync(ct);
-                await WriteToFileAsync(stream, tempPath, progress, ct);
+                await WriteToFileAsync(stream, tempPath, progress, ct).ConfigureAwait(false);
 
                 return await MoveWithRetryAsync(tempPath, localPath, ct)
                     .MatchAsync<Unit, string, Result<Unit, string>>(
                         _ => { PreserveRemoteTimestamp(localPath, remoteModified); return new Result<Unit, string>.Ok(Unit.Default); },
-                        error => { TryDeleteTemp(tempPath); return new Result<Unit, string>.Error(error); });
+                        error => { TryDeleteTemp(tempPath); return new Result<Unit, string>.Error(error); }).ConfigureAwait(false);
             }
             catch (IOException) when (attempt <= HttpRetryPolicy.MaxRetries)
             {
                 TryDeleteTemp(tempPath);
                 var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
                 OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
-                await Task.Delay(delay, ct);
+                await Task.Delay(delay, ct).ConfigureAwait(false);
             }
             catch (IOException ex)
             {
@@ -83,7 +83,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
             {
                 var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
                 OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
-                await Task.Delay(delay, ct);
+                await Task.Delay(delay, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -117,7 +117,7 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 if (attempt < MaxMoveRetries)
                 {
                     OneDriveSyncClientMessages.DownloadMoveRetrying(logger, localPath, attempt, MaxMoveRetries);
-                    await Task.Delay(MoveRetryDelay, ct);
+                    await Task.Delay(MoveRetryDelay, ct).ConfigureAwait(false);
                 }
             }
         }
@@ -146,9 +146,9 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
         long written = 0;
         int read;
 
-        while ((read = await source.ReadAsync(buffer, ct)) > 0)
+        while ((read = await source.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
         {
-            await file.WriteAsync(buffer.AsMemory(0, read), ct);
+            await file.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
             written += read;
             progress?.Report(written);
         }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/HttpDownloader.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using System.Reactive;
 using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Http;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using Microsoft.Extensions.Logging;
 
@@ -18,10 +19,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSystem fileSystem, ILogger<HttpDownloader> logger) : IHttpDownloader
 {
     private const string UserAgent = "AStar.Dev.OneDrive.Sync/1.0";
-    private const int MaxRetries = 5;
     private const int MaxMoveRetries = 3;
-    private const double BaseDelaySeconds = 2.0;
-    private const double MaxDelaySeconds = 120.0;
     private static readonly TimeSpan MoveRetryDelay = TimeSpan.FromSeconds(1);
 
     /// <inheritdoc />
@@ -46,11 +44,11 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
 
                 if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
-                    if (attempt > MaxRetries)
-                        return new Result<Unit, string>.Error($"Rate limited after {MaxRetries} retries.");
+                    if (attempt > HttpRetryPolicy.MaxRetries)
+                        return new Result<Unit, string>.Error($"Rate limited after {HttpRetryPolicy.MaxRetries} retries.");
 
-                    var delay = GetRetryDelay(response, attempt);
-                    OneDriveSyncClientMessages.DownloadThrottled(logger, delay.TotalSeconds, attempt, MaxRetries);
+                    var delay = HttpRetryPolicy.GetRetryDelay(response, attempt);
+                    OneDriveSyncClientMessages.DownloadThrottled(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
                     response.Dispose();
                     await Task.Delay(delay, ct);
@@ -69,11 +67,11 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                         _ => { PreserveRemoteTimestamp(localPath, remoteModified); return new Result<Unit, string>.Ok(Unit.Default); },
                         error => { TryDeleteTemp(tempPath); return new Result<Unit, string>.Error(error); });
             }
-            catch (IOException) when (attempt <= MaxRetries)
+            catch (IOException) when (attempt <= HttpRetryPolicy.MaxRetries)
             {
                 TryDeleteTemp(tempPath);
-                var delay = GetBackoffDelay(attempt);
-                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, MaxRetries);
+                var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
+                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
                 await Task.Delay(delay, ct);
             }
             catch (IOException ex)
@@ -81,15 +79,15 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
                 TryDeleteTemp(tempPath);
                 return new Result<Unit, string>.Error($"IO error downloading '{localPath}': {ex.Message}");
             }
-            catch (HttpRequestException) when (attempt <= MaxRetries)
+            catch (HttpRequestException) when (attempt <= HttpRetryPolicy.MaxRetries)
             {
-                var delay = GetBackoffDelay(attempt);
-                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, MaxRetries);
+                var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
+                OneDriveSyncClientMessages.DownloadNetworkError(logger, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
                 await Task.Delay(delay, ct);
             }
             catch (OperationCanceledException)
             {
-                OneDriveSyncClientMessages.DownloadCancelledDuringBackoff(logger, url, attempt, MaxRetries);
+                OneDriveSyncClientMessages.DownloadCancelledDuringBackoff(logger, url, attempt, HttpRetryPolicy.MaxRetries);
                 throw;
             }
             finally
@@ -164,30 +162,4 @@ public sealed class HttpDownloader(IHttpClientFactory httpClientFactory, IFileSy
     }
 
     private void PreserveRemoteTimestamp(string localPath, DateTimeOffset remoteModified) => fileSystem.File.SetLastWriteTimeUtc(localPath, remoteModified.UtcDateTime);
-
-    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
-    {
-        if (response.Headers.RetryAfter?.Delta is { } delta)
-            return delta + AddAdditionalSecondBackoff();
-
-        if (response.Headers.RetryAfter?.Date is not { } date) return GetBackoffDelay(attempt);
-
-        var wait = date - DateTimeOffset.UtcNow;
-        if (wait > TimeSpan.Zero)
-            return wait + AddAdditionalSecondBackoff();
-
-        return GetBackoffDelay(attempt);
-    }
-
-    private static TimeSpan AddAdditionalSecondBackoff() => TimeSpan.FromSeconds(1);
-
-    private static TimeSpan GetBackoffDelay(int attempt)
-    {
-        double seconds = CalculateExponentialBackoff(attempt);
-        double jitter = seconds * 0.2 * Random.Shared.NextDouble();
-
-        return TimeSpan.FromSeconds(seconds + jitter);
-    }
-
-    private static double CalculateExponentialBackoff(int attempt) => Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/SyncedItemRegistrar.cs
@@ -28,7 +28,7 @@ public sealed class SyncedItemRegistrar(ISyncedItemRepository syncedItemReposito
         var phantomItem = SyncedItemEntityFactory.Create(accountId, item, remotePath, localPath);
         int syncedItemId = await syncedItemRepository.UpsertAsync(phantomItem, ct).ConfigureAwait(false);
 
-        var mappings = await classificationRepository.GetAllKeywordMappingsAsync(ct);
+        var mappings = await classificationRepository.GetAllKeywordMappingsAsync(ct).ConfigureAwait(false);
         var analyserResult = fileAutoCategorisor.Categorise(remotePath);
         var classifications = ClassificationCombiner.Combine(FileClassifier.Classify(remotePath, mappings), analyserResult.Match(c => (IReadOnlyList<FileClassification>)[c], () => []));
         await syncedItemRepository.UpsertClassificationsAsync(syncedItemId, classifications, ct).ConfigureAwait(false);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
@@ -40,16 +40,16 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
         OneDriveSyncClientMessages.UploadServiceStarting(logger, remotePath, fileInfo.Length / (1024.0 * 1024));
 
-        var sessionResult = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct);
+        var sessionResult = await CreateSessionWithRetryAsync(client, driveId.Value, parentFolderId, remotePath, fileInfo.LastWriteTimeUtc, ct).ConfigureAwait(false);
 
         return await sessionResult.MatchAsync(
             async sessionUrl =>
             {
-                var result = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct);
+                var result = await UploadChunksAsync(sessionUrl, localPath, fileInfo.Length, progress, ct).ConfigureAwait(false);
 
                 return result.Tap(_ => OneDriveSyncClientMessages.UploadServiceCompleted(logger, remotePath));
             },
-            error => new Result<string, string>.Error(error));
+            error => new Result<string, string>.Error(error)).ConfigureAwait(false);
     }
 
     private static async Task<Result<string, string>> CreateSessionWithRetryAsync(GraphServiceClient client, string driveId, string parentFolderId, string remotePath, DateTime lastModified, CancellationToken ct)
@@ -80,7 +80,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             .Items[parentFolderId]
             .ItemWithPath(remotePath)
             .CreateUploadSession
-            .PostAsync(requestBody, cancellationToken: ct);
+            .PostAsync(requestBody, cancellationToken: ct).ConfigureAwait(false);
 
         if (session?.UploadUrl is null)
             return new Result<string, string>.Error("Graph API did not return an upload session URL.");
@@ -94,7 +94,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
         await using var file = fileSystem.File.OpenRead(localPath);
         byte[] buffer = new byte[ChunkSize10Mb];
 
-        return await UploadNextChunkAsync(0L);
+        return await UploadNextChunkAsync(0L).ConfigureAwait(false);
 
         async Task<Result<string, string>> UploadNextChunkAsync(long uploaded)
         {
@@ -103,7 +103,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
             ct.ThrowIfCancellationRequested();
 
-            int bytesRead = await ReadChunkAsync(file, buffer, totalBytes, uploaded, ct);
+            int bytesRead = await ReadChunkAsync(file, buffer, totalBytes, uploaded, ct).ConfigureAwait(false);
 
             if (bytesRead == 0)
                 return new Result<string, string>.Error(UploadCompletedWithoutItemIdError);
@@ -119,8 +119,8 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                     if (itemId is not null)
                         return new Result<string, string>.Ok(itemId);
 
-                    return await UploadNextChunkAsync(newUploaded);
-                });
+                    return await UploadNextChunkAsync(newUploaded).ConfigureAwait(false);
+                }).ConfigureAwait(false);
         }
     }
 
@@ -128,7 +128,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
     {
         int bytesToRead = (int)Math.Min(ChunkSize10Mb, totalBytes - uploaded);
 
-        return await file.ReadAsync(buffer.AsMemory(0, bytesToRead), ct);
+        return await file.ReadAsync(buffer.AsMemory(0, bytesToRead), ct).ConfigureAwait(false);
     }
 
     private static long ComputeRangeEnd(long uploaded, int bytesRead) => uploaded + bytesRead - 1;
@@ -149,7 +149,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                 content.Headers.Add("Content-Range", $"bytes {rangeStart}-{rangeEnd}/{totalBytes}");
                 content.Headers.Add("Content-Length", chunk.Length.ToString(CultureInfo.CurrentCulture));
 
-                using var response = await http.PutAsync(sessionUrl, content, ct);
+                using var response = await http.PutAsync(sessionUrl, content, ct).ConfigureAwait(false);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
@@ -159,7 +159,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                     var delay = HttpRetryPolicy.GetRetryDelay(response, attempt);
                     OneDriveSyncClientMessages.UploadChunkThrottled(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
-                    await Task.Delay(delay, ct);
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
                     continue;
                 }
 
@@ -167,7 +167,7 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                     return new Result<string?, string>.Ok(null);
 
                 if (response.StatusCode is System.Net.HttpStatusCode.Created or System.Net.HttpStatusCode.OK)
-                    return await GetUploadedDocumentId(response, ct);
+                    return await GetUploadedDocumentId(response, ct).ConfigureAwait(false);
 
                 _ = response.EnsureSuccessStatusCode();
 
@@ -178,14 +178,14 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
                 var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
                 OneDriveSyncClientMessages.UploadChunkNetworkError(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
-                await Task.Delay(delay, ct);
+                await Task.Delay(delay, ct).ConfigureAwait(false);
             }
         }
     }
 
     private static async Task<Result<string?, string>> GetUploadedDocumentId(HttpResponseMessage response, CancellationToken ct)
     {
-        string json = await response.Content.ReadAsStringAsync(ct);
+        string json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         using var doc = System.Text.Json.JsonDocument.Parse(json);
 
         if (!doc.RootElement.TryGetProperty("id", out var idElement))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Jobs/UploadService.cs
@@ -3,6 +3,7 @@ using System.IO.Abstractions;
 using System.Runtime.InteropServices;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Home;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Http;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
@@ -25,9 +26,6 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSystem fileSystem, ILogger<UploadService> logger) : IUploadService
 {
     private const int ChunkSize10Mb = 10 * 1024 * 1024;
-    private const int MaxRetries = 5;
-    private const double BaseDelaySeconds = 2.0;
-    private const double MaxDelaySeconds = 120.0;
     private const string UploadCompletedWithoutItemIdError = "Upload completed without receiving item ID from Graph API.";
 
     /// <summary>
@@ -155,11 +153,11 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
                 if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                 {
-                    if (attempt > MaxRetries)
-                        return new Result<string?, string>.Error($"Upload rate limited after {MaxRetries} retries.");
+                    if (attempt > HttpRetryPolicy.MaxRetries)
+                        return new Result<string?, string>.Error($"Upload rate limited after {HttpRetryPolicy.MaxRetries} retries.");
 
-                    var delay = GetRetryDelay(response, attempt);
-                    OneDriveSyncClientMessages.UploadChunkThrottled(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
+                    var delay = HttpRetryPolicy.GetRetryDelay(response, attempt);
+                    OneDriveSyncClientMessages.UploadChunkThrottled(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
                     await Task.Delay(delay, ct);
                     continue;
@@ -175,10 +173,10 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
 
                 return new Result<string?, string>.Ok(null);
             }
-            catch (HttpRequestException) when (attempt <= MaxRetries)
+            catch (HttpRequestException) when (attempt <= HttpRetryPolicy.MaxRetries)
             {
-                var delay = GetBackoffDelay(attempt);
-                OneDriveSyncClientMessages.UploadChunkNetworkError(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, MaxRetries);
+                var delay = HttpRetryPolicy.GetBackoffDelay(attempt);
+                OneDriveSyncClientMessages.UploadChunkNetworkError(logger, rangeStart, rangeEnd, delay.TotalSeconds, attempt, HttpRetryPolicy.MaxRetries);
 
                 await Task.Delay(delay, ct);
             }
@@ -197,28 +195,5 @@ public sealed class UploadService(IHttpClientFactory httpClientFactory, IFileSys
             return new Result<string?, string>.Error("Upload response missing item ID.");
 
         return new Result<string?, string>.Ok(itemId);
-    }
-
-    private static TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)
-    {
-        if (response.Headers.RetryAfter?.Delta is { } delta)
-            return delta + TimeSpan.FromSeconds(1);
-
-        if (response.Headers.RetryAfter?.Date is { } date)
-        {
-            var wait = date - DateTimeOffset.UtcNow;
-            if (wait > TimeSpan.Zero)
-                return wait + TimeSpan.FromSeconds(1);
-        }
-
-        return GetBackoffDelay(attempt);
-    }
-
-    private static TimeSpan GetBackoffDelay(int attempt)
-    {
-        double seconds = Math.Min(BaseDelaySeconds * Math.Pow(2, attempt - 1), MaxDelaySeconds);
-        double jitter = seconds * 0.2 * Random.Shared.NextDouble();
-
-        return TimeSpan.FromSeconds(seconds + jitter);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -50,7 +50,7 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
             foreach (var job in jobList)
             {
                 ct.ThrowIfCancellationRequested();
-                await channel.Writer.WriteAsync(job, ct);
+                await channel.Writer.WriteAsync(job, ct).ConfigureAwait(false);
             }
         }
         finally
@@ -60,7 +60,7 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
 
         try
         {
-            await Task.WhenAll(workers);
+            await Task.WhenAll(workers).ConfigureAwait(false);
             OneDriveSyncClientMessages.SyncPipelineCompleted(logger);
         }
         catch (Exception ex)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -73,7 +73,7 @@ public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISync
             OneDriveSyncClientMessages.SyncPipelineFinalProgress(logger, tracker.Done, jobList.Count);
         }
 
-        await syncRepository.ClearCompletedJobsAsync(new AccountId(accountId));
+        await syncRepository.ClearCompletedJobsAsync(new AccountId(accountId), ct).ConfigureAwait(false);
 
         OneDriveSyncClientMessages.SyncPipelineJobsProcessed(logger, tracker.Done, jobList.Count);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -19,7 +19,7 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
         if(jobs.Count == 0)
             return;
 
-        await syncRepository.EnqueueJobsAsync(jobs).ConfigureAwait(false);
+        await syncRepository.EnqueueJobsAsync(jobs, ct).ConfigureAwait(false);
 
         var successfulJobs = new ConcurrentBag<SyncJob>();
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
@@ -24,7 +24,7 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
 
             OneDriveSyncClientMessages.SyncWorkerProcessing(logger, workerId, job.GetType().Name, job.Target.RelativePath);
 
-            await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.InProgress, Option.None<string>()).ConfigureAwait(false);
+            await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.InProgress, Option.None<string>(), ct).ConfigureAwait(false);
 
             var currentJob = job;
             string? error = null;
@@ -38,26 +38,26 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
                         reason => (currentJob, false, reason)).ConfigureAwait(false);
 
                 if (success)
-                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed, Option.None<string>()).ConfigureAwait(false);
+                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Completed, Option.None<string>(), ct).ConfigureAwait(false);
                 else
-                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, (Option<string>)error!).ConfigureAwait(false);
+                    await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, (Option<string>)error!, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 OneDriveSyncClientMessages.SyncWorkerJobCancelledRequeued(logger, workerId, job.Target.LocalPath);
-                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>()).ConfigureAwait(false);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>(), CancellationToken.None).ConfigureAwait(false);
                 throw;
             }
             catch (SyncReAuthRequiredException)
             {
-                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>()).ConfigureAwait(false);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>(), CancellationToken.None).ConfigureAwait(false);
                 throw;
             }
             catch (Exception ex)
             {
                 error = ex.Message;
                 OneDriveSyncClientMessages.SyncWorkerException(logger, workerId, ex.GetType().Name, ex.Message, job.Target.LocalPath, ex);
-                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, (Option<string>)ex.Message).ConfigureAwait(false);
+                await syncRepository.UpdateJobStateAsync(job.Status.Id, SyncJobState.Failed, (Option<string>)ex.Message, CancellationToken.None).ConfigureAwait(false);
             }
             finally
             {

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reactive;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
@@ -34,7 +35,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     public event EventHandler<string>? SyncCompleted;
 
     /// <inheritdoc />
-    public void StartSync(TimeSpan? interval = null)
+    public Result<Unit, string> StartSync(TimeSpan? interval = null)
     {
         this.interval = interval ?? DefaultInterval;
         timer?.Dispose();
@@ -42,11 +43,14 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         try
         {
             timer = new Timer(OnTimerTickAsync, state: null, dueTime: this.interval, period: this.interval);
+
+            return new Result<Unit, string>.Ok(Unit.Default);
         }
         catch (Exception ex)
         {
             OneDriveSyncClientMessages.SyncSchedulerTimerFatal(logger, ex.Message, ex);
-            throw;
+
+            return new Result<Unit, string>.Error(ex.Message);
         }
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -18,9 +18,9 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 public sealed class SyncScheduler(ISyncService syncService, IAccountRepository accountRepository, ISyncRuleRepository syncRuleRepository, ILogger<SyncScheduler> logger) : IAsyncDisposable, ISyncScheduler
 {
     private readonly ConcurrentDictionary<string, CancellationTokenSource> activeSyncs = new();
+    private readonly SemaphoreSlim fullPassSemaphore = new(1, 1);
     private Timer? timer;
     private TimeSpan interval = TimeSpan.FromMinutes(60);
-    private long runningFlag;
 
     /// <summary>
     /// Default interval for scheduled sync passes. Can be overridden by providing a different interval to StartSync or SetInterval.
@@ -63,7 +63,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     /// <inheritdoc />
     public async Task TriggerNowAsync(CancellationToken ct = default)
     {
-        if (SyncIsAlreadyRunning())
+        if (!activeSyncs.IsEmpty)
             return;
 
         await RunSyncPassAsync(ct);
@@ -124,7 +124,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
     // ReSharper disable once AsyncVoidMethod - Timer requires this signature
     private async void OnTimerTickAsync(object? state)
     {
-        if (SyncIsAlreadyRunning())
+        if (!activeSyncs.IsEmpty)
             return;
 
         try
@@ -136,8 +136,6 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
             OneDriveSyncClientMessages.SyncSchedulerTimerError(logger, ex.Message, ex);
         }
     }
-
-    private bool SyncIsAlreadyRunning() => Interlocked.Read(ref runningFlag) == 1 || !activeSyncs.IsEmpty;
 
     private static OneDriveAccount MapEntityToAccount(AccountEntity entity, IReadOnlyList<SyncRuleEntity> rules) => new()
     {
@@ -152,7 +150,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
     private async Task RunSyncPassAsync(CancellationToken ct)
     {
-        if (Interlocked.Exchange(ref runningFlag, 1) == 1)
+        if (!fullPassSemaphore.Wait(0, CancellationToken.None))
             return;
 
         try
@@ -188,7 +186,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         }
         finally
         {
-            Interlocked.Exchange(ref runningFlag, 0);
+            fullPassSemaphore.Release();
         }
     }
 
@@ -204,5 +202,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
         if (timer is not null)
             await timer.DisposeAsync();
+
+        fullPassSemaphore.Dispose();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncScheduler.cs
@@ -70,7 +70,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         if (!activeSyncs.IsEmpty)
             return;
 
-        await RunSyncPassAsync(ct);
+        await RunSyncPassAsync(ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -88,7 +88,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
             {
                 OneDriveSyncClientMessages.SyncSchedulerUnknownAccount(logger, accountId);
                 return Task.CompletedTask;
-            });
+            }).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -104,7 +104,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         SyncStarted?.Invoke(this, account.Id.Id);
         try
         {
-            await syncService.SyncAccountAsync(account, cts.Token);
+            await syncService.SyncAccountAsync(account, cts.Token).ConfigureAwait(false);
         }
         finally
         {
@@ -133,7 +133,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
         try
         {
-            await RunSyncPassAsync(CancellationToken.None);
+            await RunSyncPassAsync(CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -159,7 +159,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
 
         try
         {
-            var entities = await accountRepository.GetAllAsync(CancellationToken.None);
+            var entities = await accountRepository.GetAllAsync(CancellationToken.None).ConfigureAwait(false);
             foreach (var entity in entities.TakeWhile(_ => !ct.IsCancellationRequested))
             {
                 var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, ct).ConfigureAwait(false);
@@ -175,7 +175,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
                 SyncStarted?.Invoke(this, account.Id.Id);
                 try
                 {
-                    await syncService.SyncAccountAsync(account, cts.Token);
+                    await syncService.SyncAccountAsync(account, cts.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -205,7 +205,7 @@ public sealed class SyncScheduler(ISyncService syncService, IAccountRepository a
         activeSyncs.Clear();
 
         if (timer is not null)
-            await timer.DisposeAsync();
+            await timer.DisposeAsync().ConfigureAwait(false);
 
         fullPassSemaphore.Dispose();
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -65,7 +65,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                 tokenFactory.GetTokenAsync,
                 async conflict =>
                 {
-                    await syncRepository.AddConflictAsync(conflict).ConfigureAwait(false);
+                    await syncRepository.AddConflictAsync(conflict, ct).ConfigureAwait(false);
                     ConflictDetected?.Invoke(this, conflict);
                 },
                 args => SyncProgressChanged?.Invoke(this, args),
@@ -118,7 +118,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
             return;
         }
 
-        await syncRepository.ResolveConflictAsync(conflict.Id, policy).ConfigureAwait(false);
+        await syncRepository.ResolveConflictAsync(conflict.Id, policy, ct).ConfigureAwait(false);
         ConflictResolved?.Invoke(this, conflict);
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Onboarding/AddAccountWizardViewModel.cs
@@ -16,6 +16,7 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
     private readonly IAuthService authService;
     private readonly IGraphService graphService;
     private readonly ILocalizationService loc;
+    private readonly Lock authCtsLock = new();
     private string accountId = string.Empty;
     private string? accessToken;
     private CancellationTokenSource? authCts;
@@ -168,11 +169,16 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
 
         SetInitialSignInState();
 
-        authCts = new CancellationTokenSource();
+        lock(authCtsLock)
+            authCts = new CancellationTokenSource();
 
         try
         {
-            var result = await authService.SignInInteractiveAsync(authCts.Token);
+            CancellationToken token;
+            lock(authCtsLock)
+                token = authCts!.Token;
+
+            var result = await authService.SignInInteractiveAsync(token);
             _ = result.Match(
                 ok    => { UpdateSuccessfulLoginState(ok); return true; },
                 error => { DispatchAuthError(error); return false; });
@@ -220,8 +226,13 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
     private void SetFinalSignInState()
     {
         IsWaitingForAuth = false;
-        authCts?.Dispose();
-        authCts = null;
+        CancellationTokenSource? toDispose;
+        lock(authCtsLock)
+        {
+            toDispose = authCts;
+            authCts = null;
+        }
+        toDispose?.Dispose();
     }
 
     private void SetInitialSignInState()
@@ -237,8 +248,12 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
     [RelayCommand]
     private async Task CancelAsync()
     {
-        if(authCts is not null)
-            await authCts.CancelAsync();
+        CancellationTokenSource? toCancel;
+        lock(authCtsLock)
+            toCancel = authCts;
+
+        if(toCancel is not null)
+            await toCancel.CancelAsync();
 
         Cancelled?.Invoke(this, EventArgs.Empty);
     }
@@ -316,6 +331,12 @@ public sealed partial class AddAccountWizardViewModel : ObservableObject, IDispo
     public void Dispose()
     {
         loc.CultureChanged -= OnCultureChanged;
-        authCts?.Dispose();
+        CancellationTokenSource? toDispose;
+        lock(authCtsLock)
+        {
+            toDispose = authCts;
+            authCts = null;
+        }
+        toDispose?.Dispose();
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -36,6 +36,8 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IAccountOnboardingService, AccountOnboardingService>();
         _ = services.AddSingleton<IAuthService, AuthService>();
         _ = services.AddSingleton<IGraphClientFactory, GraphClientFactory>();
+        _ = services.AddSingleton<DriveContextCache>();
+        _ = services.AddSingleton<GraphFolderEnumerator>();
         _ = services.AddSingleton<IGraphService, GraphService>();
         _ = services.AddSingleton<IQuotaRefreshService, QuotaRefreshService>();
         _ = services.AddSingleton<IStartupService, StartupService>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -76,17 +76,15 @@ internal static class ShellServiceExtensions
         return services;
     }
 
-#pragma warning disable CA1859
-    private static void RegisterAvailableFeatures(IFeatureRegistrar registrar)
-#pragma warning restore CA1859
+    private static void RegisterAvailableFeatures(FeatureAvailabilityService registrar)
     {
-        registrar.Register(NavSection.Dashboard);
-        registrar.Register(NavSection.Accounts);
-        registrar.Register(NavSection.Activity);
-        registrar.Register(NavSection.Conflicts);
-        registrar.Register(NavSection.LogViewer);
-        registrar.Register(NavSection.Classifications);
-        registrar.Register(NavSection.Settings);
-        registrar.Register(NavSection.Help);
+        _ = registrar.Register(NavSection.Dashboard);
+        _ = registrar.Register(NavSection.Accounts);
+        _ = registrar.Register(NavSection.Activity);
+        _ = registrar.Register(NavSection.Conflicts);
+        _ = registrar.Register(NavSection.LogViewer);
+        _ = registrar.Register(NavSection.Classifications);
+        _ = registrar.Register(NavSection.Settings);
+        _ = registrar.Register(NavSection.Help);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/StartupService.cs
@@ -19,7 +19,7 @@ public sealed class StartupService(IAccountRepository repository, ISyncRuleRepos
               .MapFailureAsync(ex => ex.GetBaseException().Message);
 
     private Task<Result<(List<AccountEntity> entities, HashSet<string> cachedIds), Exception>> FetchWithCachedIdsAsync(List<AccountEntity> entities)
-        => Try.RunAsync(async () => (entities, (await authService.GetCachedAccountIdsAsync()).ToHashSet()));
+        => Try.RunAsync(async () => (entities, (await authService.GetCachedAccountIdsAsync().ConfigureAwait(false)).ToHashSet()));
 
     private Task<Result<List<OneDriveAccount>, Exception>> BuildFilteredAccountsAsync((List<AccountEntity> entities, HashSet<string> cachedIds) input)
         => Try.RunAsync(() => BuildAccountsAsync(FilterToCachedEntities(input.entities, input.cachedIds)));
@@ -33,7 +33,7 @@ public sealed class StartupService(IAccountRepository repository, ISyncRuleRepos
 
         foreach (var entity in entities)
         {
-            var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, CancellationToken.None);
+            var rules = await syncRuleRepository.GetByAccountIdAsync(entity.Id, CancellationToken.None).ConfigureAwait(false);
             accounts.Add(BuildOneDriveAccount(entity, rules));
         }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.10",
+    "ApplicationVersion": "0.7.11",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Resolves all 8 P4 issues for `AStar.Dev.OneDrive.Sync.Client` identified in the P4 review. Each issue was implemented on this branch with TDD discipline (failing test committed before production code).

## Type of change

- [x] Bug fix
- [x] Refactor

## Related issues / links

Closes #503, Closes #504, Closes #505, Closes #506, Closes #507, Closes #508, Closes #509, Closes #510

## Changes per issue

| Issue | Title | Commit |
|-------|-------|--------|
| #509 | Remove dead `appLifetimeCts`; defer DI container build to `OnFrameworkInitializationCompleted` | c78d823 |
| #504 | Replace `Path.Combine` with `CombinePath` extension everywhere in client | 08a1e68 |
| #508 | Forward `CancellationToken` through `ISyncRepository` and all callers | 1f42419 |
| #505 | Extract shared `HttpRetryPolicy` from `HttpDownloader` and `UploadService` | 4c9574d |
| #506 | Replace `Interlocked` running flag with `SemaphoreSlim(1,1)`; guard `authCts` with `Lock` | 1f035cd |
| #507 | Extract `DriveContextCache` and `GraphFolderEnumerator` from `GraphService` god class | c4f5676 |
| #510 | `Result` returns for `Register`/`StartSync`; `IFileInfo` export/import API; remove CA1859 pragma | 0ef0815 |
| #503 | `ConfigureAwait(false)` sweep on all infrastructure/repository awaits | 680f58b |

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation

New/updated test classes: `GivenAnHttpRetryPolicy`, `GivenADriveContextCache`, `GivenAFeatureAvailabilityService`, `GivenASyncRepository` (token-forwarding tests), `GivenASyncScheduler` (concurrency test), `GivenAnHttpDownloaderBackoff` (migrated to `HttpRetryPolicy`), `GivenAGraphService` (updated ctor args).

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`, `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally — `Build succeeded. 0 Warning(s) 0 Error(s)`
- [x] Tests pass (`dotnet test`) — `Passed! Failed: 0, Passed: 1682, Skipped: 0, Total: 1682`
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/
```

---

## Notes for reviewers

- `ConfigureAwait(false)` is intentionally absent from `Dispatcher.UIThread.InvokeAsync` calls and `tcs.Task` inside `AvaloniaConfirmationDialogService` — those must stay on the UI synchronization context.
- `System.Reactive.Unit` is used for `Result<Unit, string>` return types (not a local type); test files use `using ReactiveUnit = System.Reactive.Unit` alias to avoid namespace collision with the `*.Tests.Unit` namespace.
- `DriveContextCache` and `GraphFolderEnumerator` are `internal` — `InternalsVisibleTo` in `AssemblyAttributes.cs` exposes them to the test project.