### PR TITLE
fix(onedrive-sync): use ConcurrentBag to eliminate race in parallel pipeline test (#524)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -87,7 +88,7 @@ public sealed class GivenAParallelSyncPipeline
     [Fact]
     public async Task when_three_download_jobs_are_processed_then_on_job_completed_is_called_three_times()
     {
-        var completedEvents = new List<JobCompletedEventArgs>();
+        var completedEvents = new ConcurrentBag<JobCompletedEventArgs>();
         var jobs = new[] { MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt"), MakeDownloadJob("a/3.txt") };
         var sut = CreateSut();
 


### PR DESCRIPTION
# Summary

`GivenAParallelSyncPipeline.when_three_download_jobs_are_processed_then_on_job_completed_is_called_three_times` failed intermittently under full-suite parallel load. `SyncProgressTracker.RecordCompletion` calls `onJobCompleted` outside its lock, so 4 concurrent workers race on `List<T>.Add`, silently dropping items under CPU pressure. Changed the event collector in the affected test to `ConcurrentBag<T>`, which is thread-safe for concurrent additions.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #524

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1682/1682
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj --filter "GivenAParallelSyncPipeline"
```

---

## Notes for reviewers

- Single test change: `List<JobCompletedEventArgs>` → `ConcurrentBag<JobCompletedEventArgs>` in the 3-job parallel test.
- Sibling tests using `List<T>` are safe — they run with 1 job (no parallel write contention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)