### PR TITLE
test(onedrive-sync): add sync pipeline cancellation path tests (#511)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalDeletionDetector.cs
@@ -106,4 +106,30 @@ public sealed class GivenALocalDeletionDetector
 
         await _graphService.Received(1).DeleteItemAsync(Arg.Is("user-1"), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-ok"), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task when_cancellation_requested_mid_loop_then_remaining_items_not_deleted()
+    {
+        using var cts = new CancellationTokenSource();
+        var mockFileSystem = new MockFileSystem();
+
+        _graphService.DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-first"), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                cts.Cancel();
+                return new Result<System.Reactive.Unit, string>.Ok(System.Reactive.Unit.Default);
+            });
+
+        var syncedItems = new Dictionary<string, SyncedItemEntity>
+        {
+            ["item-first"]  = new() { RemoteItemId = new OneDriveItemId("item-first"),  RemotePath = "/first.txt",  LocalPath = $"{BaseDir}/first.txt",  IsFolder = false },
+            ["item-second"] = new() { RemoteItemId = new OneDriveItemId("item-second"), RemotePath = "/second.txt", LocalPath = $"{BaseDir}/second.txt", IsFolder = false }
+        };
+        var sut = CreateSut(mockFileSystem);
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+
+        await sut.DetectAndApplyAsync(_accountId, tokenFactory, syncedItems, cts.Token);
+
+        await _graphService.DidNotReceive().DeleteItemAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Is("item-second"), Arg.Any<CancellationToken>());
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -166,4 +166,38 @@ public sealed class GivenARemoteFolderEnumerator
         result.Rules.ShouldHaveSingleItem();
         result.Rules[0].RemotePath.ShouldBe("/Documents");
     }
+
+    [Fact]
+    public async Task when_cancellation_requested_during_rule_loop_then_partial_results_returned()
+    {
+        using var cts = new CancellationTokenSource();
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1"), IncludeRule("/Pictures", remoteItemId: "folder-2")]);
+        _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Is("folder-1"), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                cts.Cancel();
+                return new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt")]);
+            });
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: cts.Token);
+
+        result.DeltaItems.ShouldHaveSingleItem();
+        result.DeltaItems[0].Id.Id.ShouldBe("item-a");
+    }
+
+    [Fact]
+    public async Task when_drive_id_resolution_fails_then_result_had_no_rules_is_false()
+    {
+        _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
+        _graphService.GetDriveIdAsync(Arg.Any<string>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<DriveId, string>.Error("drive-id-resolution-failed"));
+        Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
+
+        var result = await CreateSut().EnumerateAsync(CreateAccount(), tokenFactory, ct: TestContext.Current.CancellationToken);
+
+        result.HadNoRules.ShouldBeFalse();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncScheduler.cs
@@ -555,6 +555,50 @@ public sealed class GivenASyncScheduler
         await firstPass;
     }
 
+    [Fact]
+    public async Task when_dispose_async_called_while_account_is_syncing_then_sync_token_is_cancelled()
+    {
+        CancellationToken capturedToken = default;
+        var syncStarted = new TaskCompletionSource();
+        var mockSyncService = Substitute.For<ISyncService>();
+        mockSyncService.SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                capturedToken = callInfo.ArgAt<CancellationToken>(1);
+                syncStarted.SetResult();
+                await Task.Delay(Timeout.Infinite, capturedToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            });
+
+        var scheduler = CreateScheduler(mockSyncService, Substitute.For<IAccountRepository>(), Substitute.For<ISyncRuleRepository>());
+        var account = new OneDriveAccount { Id = new AccountId("dispose-test") };
+
+        var triggerTask = scheduler.TriggerAccountAsync(account, TestContext.Current.CancellationToken);
+        await syncStarted.Task;
+
+        await scheduler.DisposeAsync();
+        await triggerTask;
+
+        capturedToken.IsCancellationRequested.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_trigger_now_called_with_pre_cancelled_token_then_sync_service_not_called()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var mockSyncService = Substitute.For<ISyncService>();
+        var mockRepository = Substitute.For<IAccountRepository>();
+        mockRepository.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([new AccountEntity { Id = new AccountId("account-pre-cancel"), Profile = AccountProfileFactory.Create("Test", "test@test.com") }]);
+
+        var scheduler = CreateScheduler(mockSyncService, mockRepository, BuildSyncRuleRepository());
+
+        await scheduler.TriggerNowAsync(cts.Token);
+
+        await mockSyncService.DidNotReceive().SyncAccountAsync(Arg.Any<OneDriveAccount>(), Arg.Any<CancellationToken>());
+    }
+
     private static ISyncRuleRepository BuildSyncRuleRepository()
     {
         var repo = Substitute.For<ISyncRuleRepository>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderIoExceptionRetry.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Jobs/GivenAnHttpDownloaderIoExceptionRetry.cs
@@ -49,10 +49,72 @@ public sealed class GivenAnHttpDownloaderIoExceptionRetry
         result.ShouldBeAssignableTo<Result<System.Reactive.Unit, string>.Error>();
     }
 
+    [Fact]
+    public async Task when_ct_cancelled_during_io_exception_backoff_then_operation_cancelled_exception_propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new CancellingIoHandler(cts)));
+
+        var sut = new HttpDownloader(factory, new MockFileSystem(), Substitute.For<ILogger<HttpDownloader>>());
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task when_io_exception_occurs_on_first_attempt_then_temp_file_deleted_before_retry()
+    {
+        int callCount = 0;
+        var mockFileSystem = new MockFileSystem();
+        var deletedPaths = new List<string>();
+
+        var spyFile = Substitute.For<System.IO.Abstractions.IFile>();
+        spyFile.Exists(Arg.Any<string>()).Returns(false);
+        spyFile.When(f => f.Delete(Arg.Any<string>()))
+            .Do(callInfo => deletedPaths.Add(callInfo.ArgAt<string>(0)));
+        spyFile.When(f => f.Move(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>()))
+            .Do(callInfo => mockFileSystem.File.Move(callInfo.ArgAt<string>(0), callInfo.ArgAt<string>(1), callInfo.ArgAt<bool>(2)));
+        spyFile.When(f => f.SetLastWriteTimeUtc(Arg.Any<string>(), Arg.Any<DateTime>()))
+            .Do(x => mockFileSystem.File.SetLastWriteTimeUtc(x.ArgAt<string>(0), x.ArgAt<DateTime>(1)));
+
+        var spyFs = Substitute.For<System.IO.Abstractions.IFileSystem>();
+        spyFs.File.Returns(spyFile);
+        spyFs.FileStream.Returns(mockFileSystem.FileStream);
+        spyFs.Directory.Returns(mockFileSystem.Directory);
+        spyFs.Path.Returns(mockFileSystem.Path);
+
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new FakeHttpMessageHandler(_ =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new IoThrowingContent() }
+                    : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("data", Encoding.UTF8) };
+            })));
+
+        var sut = new HttpDownloader(factory, spyFs, Substitute.For<ILogger<HttpDownloader>>());
+
+        await sut.DownloadAsync(DownloadUrl, LocalPath, RemoteModified, ct: TestContext.Current.CancellationToken);
+
+        deletedPaths.ShouldContain(path => path.StartsWith(LocalPath + ".") && path.EndsWith(".download"));
+    }
+
     private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
             Task.FromResult(respond(request));
+    }
+
+    private sealed class CancellingIoHandler(CancellationTokenSource cts) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cts.Cancel();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new IoThrowingContent() });
+        }
     }
 
     private sealed class IoThrowingContent : HttpContent

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -331,8 +331,6 @@ public sealed class GivenASyncPassOrchestrator
         capturedPath.ShouldBe("/my/local/path");
     }
 
-    // --- enumeration progress throttle ---
-
     [Fact]
     public async Task when_enumeration_fires_99_item_discovered_callbacks_then_no_enumeration_progress_events_are_raised()
     {
@@ -391,5 +389,44 @@ public sealed class GivenASyncPassOrchestrator
             ct: TestContext.Current.CancellationToken);
 
         enumerationProgressEvents.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_cancellation_requested_before_enumeration_then_operation_cancelled_exception_propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Option.None<DriveStateEntity>());
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromCanceled<RemoteEnumerationResult>(callInfo.ArgAt<CancellationToken>(3)));
+
+        var sut     = CreateSut();
+        var account = CreateAccount();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task when_cancellation_requested_after_enumeration_starts_then_operation_cancelled_exception_propagates()
+    {
+        using var cts = new CancellationTokenSource();
+
+        _driveStateRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Option.None<DriveStateEntity>());
+        _remoteFolderEnumerator.EnumerateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                cts.Cancel();
+                return Task.FromCanceled<RemoteEnumerationResult>(callInfo.ArgAt<CancellationToken>(3));
+            });
+
+        var sut     = CreateSut();
+        var account = CreateAccount();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.OrchestrateAsync(account, CreateSyncConfig(), _ => Task.FromResult("token"), _ => Task.CompletedTask, ct: cts.Token));
     }
 }


### PR DESCRIPTION
# Summary

- Adds cancellation-path tests across the sync pipeline (9 new tests in 5 files)
- `GivenASyncScheduler`: dispose cancels in-flight sync; pre-cancelled token short-circuits scheduled pass
- `GivenASyncPassOrchestrator`: OCE propagates when cancelled before/after enumeration starts
- `GivenAnHttpDownloaderIoExceptionRetry`: OCE propagates during IOException backoff delay; temp file deleted before retry
- `GivenARemoteFolderEnumerator`: partial results returned on mid-loop cancellation; drive-id resolution failure sets HadNoRules
- `GivenALocalDeletionDetector`: mid-loop cancellation halts remaining deletes

Closes #511

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #511

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1691/1691
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj
```

---

## Notes for reviewers

- One test name corrected from issue spec (`drive_state_upsert_not_called` → `operation_cancelled_exception_propagates`): production code calls `UpsertAsync` before enumeration, so the original assertion was incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)