### PR TITLE
test(onedrive-sync): add SyncWorker re-auth exception path tests (#512)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Jobs;
 using Microsoft.Extensions.Logging;
@@ -139,5 +140,35 @@ public sealed class GivenASyncWorker
         await CreateSut().RunAsync(channel.Reader, AccountId, tokenFactory, (_, _, _) => { }, TestContext.Current.CancellationToken);
 
         await _handler.Received(1).HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task when_handler_throws_sync_re_auth_required_exception_then_job_state_set_to_queued()
+    {
+        var job = MakeDownloadJob();
+        _handler.CanHandle(job).Returns(true);
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result<SyncJob, string>>>(_ => throw new SyncReAuthRequiredException());
+
+        try
+        {
+            await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+        }
+        catch(SyncReAuthRequiredException) { }
+
+        await _syncRepository.Received(1).UpdateJobStateAsync(job.Status.Id, SyncJobState.Queued, Option.None<string>(), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task when_handler_throws_sync_re_auth_required_exception_then_exception_is_rethrown()
+    {
+        var job = MakeDownloadJob();
+        _handler.CanHandle(job).Returns(true);
+        _handler.HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>())
+            .Returns<Task<Result<SyncJob, string>>>(_ => throw new SyncReAuthRequiredException());
+
+        var act = async () => await RunWorkerWithJobsAsync(CreateSut(), [job], TestContext.Current.CancellationToken);
+
+        await act.ShouldThrowAsync<SyncReAuthRequiredException>();
     }
 }


### PR DESCRIPTION
# Summary

- Adds 2 missing tests to `GivenASyncWorker` covering the `SyncReAuthRequiredException` catch block in `SyncWorker.RunAsync`
- `when_handler_throws_sync_re_auth_required_exception_then_job_state_set_to_queued` — verifies job is reset to Queued before rethrow
- `when_handler_throws_sync_re_auth_required_exception_then_exception_is_rethrown` — verifies the exception escapes `RunAsync`

Closes #512

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [x] Maintenance

## Related issues / links

Closes #512

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1684/1684
- [x] No new analyzer warnings
- [ ] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj --filter "GivenASyncWorker"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)