### PR TITLE
test(onedrive-sync-client): add tests for untested small classes (#516)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToBadgeBackgroundConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToBadgeBackgroundConverter.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public sealed class GivenASyncStateToBadgeBackgroundConverter
+{
+    private static readonly SyncStateToBadgeBackgroundConverter Sut = SyncStateToBadgeBackgroundConverter.Instance;
+
+    [Theory]
+    [InlineData(FolderSyncState.Synced,   "#EAF3DE")]
+    [InlineData(FolderSyncState.Syncing,  "#E6F1FB")]
+    [InlineData(FolderSyncState.Included, "#E6F1FB")]
+    [InlineData(FolderSyncState.Partial,  "#FAEEDA")]
+    [InlineData(FolderSyncState.Conflict, "#FAEEDA")]
+    [InlineData(FolderSyncState.Error,    "#FCEBEB")]
+    [InlineData(FolderSyncState.Excluded, "#F1EFE8")]
+    public void when_folder_sync_state_is_provided_then_correct_color_is_returned(FolderSyncState state, string expectedHex)
+    {
+        var result = (Color)Sut.Convert(state, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse(expectedHex));
+    }
+
+    [Fact]
+    public void when_value_is_null_then_transparent_is_returned()
+    {
+        var result = Sut.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Colors.Transparent);
+    }
+
+    [Fact]
+    public void when_value_is_non_folder_sync_state_then_transparent_is_returned()
+    {
+        var result = Sut.Convert("not a state", typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Colors.Transparent);
+    }
+
+    [Fact]
+    public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+    {
+        var first = SyncStateToBadgeBackgroundConverter.Instance;
+        var second = SyncStateToBadgeBackgroundConverter.Instance;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+    {
+        _ = Should.Throw<NotSupportedException>(() =>
+            Sut.ConvertBack(Colors.Transparent, typeof(FolderSyncState), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToBadgeForegroundConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToBadgeForegroundConverter.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using AStar.Dev.OneDrive.Sync.Client.Home;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public sealed class GivenASyncStateToBadgeForegroundConverter
+{
+    private static readonly SyncStateToBadgeForegroundConverter Sut = SyncStateToBadgeForegroundConverter.Instance;
+
+    [Theory]
+    [InlineData(FolderSyncState.Synced,   "#27500A")]
+    [InlineData(FolderSyncState.Syncing,  "#0C447C")]
+    [InlineData(FolderSyncState.Included, "#0C447C")]
+    [InlineData(FolderSyncState.Partial,  "#633806")]
+    [InlineData(FolderSyncState.Conflict, "#633806")]
+    [InlineData(FolderSyncState.Error,    "#791F1F")]
+    [InlineData(FolderSyncState.Excluded, "#5F5E5A")]
+    public void when_folder_sync_state_is_provided_then_correct_color_is_returned(FolderSyncState state, string expectedHex)
+    {
+        var result = (Color)Sut.Convert(state, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse(expectedHex));
+    }
+
+    [Fact]
+    public void when_value_is_null_then_transparent_is_returned()
+    {
+        var result = Sut.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Colors.Transparent);
+    }
+
+    [Fact]
+    public void when_value_is_non_folder_sync_state_then_transparent_is_returned()
+    {
+        var result = Sut.Convert("not a state", typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Colors.Transparent);
+    }
+
+    [Fact]
+    public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+    {
+        var first = SyncStateToBadgeForegroundConverter.Instance;
+        var second = SyncStateToBadgeForegroundConverter.Instance;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+    {
+        _ = Should.Throw<NotSupportedException>(() =>
+            Sut.ConvertBack(Colors.Transparent, typeof(FolderSyncState), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToForegroundConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenASyncStateToForegroundConverter.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public sealed class GivenASyncStateToForegroundConverter
+{
+    private static readonly SyncStateToForegroundConverter Sut = SyncStateToForegroundConverter.Instance;
+
+    [Theory]
+    [InlineData(SyncState.Syncing,  "#185FA5")]
+    [InlineData(SyncState.Pending,  "#BA7517")]
+    [InlineData(SyncState.Conflict, "#E24B4A")]
+    [InlineData(SyncState.Error,    "#E24B4A")]
+    [InlineData(SyncState.Idle,     "#1D9E75")]
+    [InlineData(SyncState.Completed,"#1D9E75")]
+    public void when_sync_state_is_provided_then_correct_brush_color_is_returned(SyncState state, string expectedHex)
+    {
+        var result = (SolidColorBrush)Sut.Convert(state, typeof(IBrush), null, CultureInfo.InvariantCulture)!;
+
+        result.Color.ShouldBe(Color.Parse(expectedHex));
+    }
+
+    [Fact]
+    public void when_value_is_null_then_transparent_brush_is_returned()
+    {
+        var result = Sut.Convert(null, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Brushes.Transparent);
+    }
+
+    [Fact]
+    public void when_value_is_non_sync_state_then_transparent_brush_is_returned()
+    {
+        var result = Sut.Convert("not a state", typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Brushes.Transparent);
+    }
+
+    [Fact]
+    public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+    {
+        var first = SyncStateToForegroundConverter.Instance;
+        var second = SyncStateToForegroundConverter.Instance;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+    {
+        _ = Should.Throw<NotSupportedException>(() =>
+            Sut.ConvertBack(Brushes.Transparent, typeof(SyncState), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenAnIntZeroToBoolConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/GivenAnIntZeroToBoolConverter.cs
@@ -1,0 +1,65 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public sealed class GivenAnIntZeroToBoolConverter
+{
+    private static readonly IntZeroToBoolConverter Sut = IntZeroToBoolConverter.Instance;
+
+    [Fact]
+    public void when_value_is_zero_then_result_is_true()
+    {
+        var result = Sut.Convert(0, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(true);
+    }
+
+    [Fact]
+    public void when_value_is_one_then_result_is_false()
+    {
+        var result = Sut.Convert(1, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void when_value_is_negative_then_result_is_false()
+    {
+        var result = Sut.Convert(-1, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void when_value_is_null_then_result_is_false()
+    {
+        var result = Sut.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void when_value_is_non_integer_then_result_is_false()
+    {
+        var result = Sut.Convert("zero", typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+    {
+        var first = IntZeroToBoolConverter.Instance;
+        var second = IntZeroToBoolConverter.Instance;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+    {
+        _ = Should.Throw<NotSupportedException>(() =>
+            Sut.ConvertBack(true, typeof(int), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenAConflictCountToColorConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Dashboard/GivenAConflictCountToColorConverter.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Dashboard;
+
+public sealed class GivenAConflictCountToColorConverter
+{
+    private static readonly ConflictCountToColorConverter Sut = ConflictCountToColorConverter.Instance;
+
+    [Fact]
+    public void when_conflict_count_is_zero_then_primary_text_color_is_returned()
+    {
+        var result = (Color)Sut.Convert(0, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse("#1A1917"));
+    }
+
+    [Fact]
+    public void when_conflict_count_is_positive_then_red_color_is_returned()
+    {
+        var result = (Color)Sut.Convert(1, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse("#E24B4A"));
+    }
+
+    [Fact]
+    public void when_conflict_count_is_greater_than_one_then_red_color_is_returned()
+    {
+        var result = (Color)Sut.Convert(5, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse("#E24B4A"));
+    }
+
+    [Fact]
+    public void when_value_is_null_then_primary_text_color_is_returned()
+    {
+        var result = (Color)Sut.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse("#1A1917"));
+    }
+
+    [Fact]
+    public void when_value_is_non_integer_then_primary_text_color_is_returned()
+    {
+        var result = (Color)Sut.Convert("not a number", typeof(Color), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(Color.Parse("#1A1917"));
+    }
+
+    [Fact]
+    public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+    {
+        var first = ConflictCountToColorConverter.Instance;
+        var second = ConflictCountToColorConverter.Instance;
+
+        first.ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+    {
+        _ = Should.Throw<NotSupportedException>(() =>
+            Sut.ConvertBack(Colors.Transparent, typeof(int), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAVersionInfoFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenAVersionInfoFactory.cs
@@ -1,0 +1,41 @@
+using AStar.Dev.Functional.Extensions;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
+
+public sealed class GivenAVersionInfoFactory
+{
+    [Fact]
+    public void when_creating_with_some_etag_then_etag_is_set()
+    {
+        var info = VersionInfoFactory.Create(Option.Some("etag-abc"), Option.None<string>());
+
+        info.ETag.ShouldBe(Option.Some("etag-abc"));
+    }
+
+    [Fact]
+    public void when_creating_with_some_ctag_then_ctag_is_set()
+    {
+        var info = VersionInfoFactory.Create(Option.None<string>(), Option.Some("ctag-xyz"));
+
+        info.CTag.ShouldBe(Option.Some("ctag-xyz"));
+    }
+
+    [Fact]
+    public void when_creating_with_none_values_then_both_are_none()
+    {
+        var info = VersionInfoFactory.Create(Option.None<string>(), Option.None<string>());
+
+        info.ETag.ShouldBe(Option.None<string>());
+        info.CTag.ShouldBe(Option.None<string>());
+    }
+
+    [Fact]
+    public void when_creating_with_both_some_then_both_are_preserved()
+    {
+        var info = VersionInfoFactory.Create(Option.Some("etag-1"), Option.Some("ctag-2"));
+
+        info.ETag.ShouldBe(Option.Some("etag-1"));
+        info.CTag.ShouldBe(Option.Some("ctag-2"));
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenStorageQuotaExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenStorageQuotaExtensions.cs
@@ -1,0 +1,57 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Entities;
+
+public sealed class GivenStorageQuotaExtensions
+{
+    [Fact]
+    public void when_total_bytes_is_zero_then_fraction_is_zero()
+    {
+        var quota = StorageQuotaFactory.Create(0, 0);
+
+        quota.Fraction().ShouldBe(0);
+    }
+
+    [Fact]
+    public void when_used_equals_total_then_fraction_is_one()
+    {
+        var quota = StorageQuotaFactory.Create(1_000_000, 1_000_000);
+
+        quota.Fraction().ShouldBe(1.0);
+    }
+
+    [Fact]
+    public void when_used_is_half_of_total_then_fraction_is_point_five()
+    {
+        var quota = StorageQuotaFactory.Create(1_000_000, 500_000);
+
+        quota.Fraction().ShouldBe(0.5);
+    }
+
+    [Fact]
+    public void when_used_is_zero_then_fraction_is_zero()
+    {
+        var quota = StorageQuotaFactory.Create(1_000_000, 0);
+
+        quota.Fraction().ShouldBe(0.0);
+    }
+
+    [Fact]
+    public void when_used_exceeds_total_then_fraction_is_clamped_to_one()
+    {
+        var quota = StorageQuotaFactory.Create(1_000_000, 2_000_000);
+
+        quota.Fraction().ShouldBe(1.0);
+    }
+
+    [Theory]
+    [InlineData(100, 25, 0.25)]
+    [InlineData(100, 75, 0.75)]
+    [InlineData(200, 50, 0.25)]
+    public void when_fraction_calculated_then_result_matches_expected(long total, long used, double expected)
+    {
+        var quota = StorageQuotaFactory.Create(total, used);
+
+        quota.Fraction().ShouldBe(expected);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalChangeDetector.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenALocalChangeDetector.cs
@@ -135,19 +135,6 @@ public sealed class GivenALocalChangeDetector
     }
 
     [Fact]
-    public void when_new_file_is_not_in_lookup_then_job_relative_path_is_used_for_upload_target()
-    {
-        var mockFileSystem = new MockFileSystem();
-        mockFileSystem.Initialize().WithFile($"{BasePath}/Documents/report.txt").Which(m => m.HasStringContent("data"));
-        var sut = CreateSut(mockFileSystem);
-        var rules = new[] { Rule("/Documents", RuleType.Include) };
-
-        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
-
-        jobs[0].Target.RelativePath.ShouldBe("Documents/report.txt");
-    }
-
-    [Fact]
     public void when_new_file_is_not_in_lookup_then_job_folder_id_is_root()
     {
         var mockFileSystem = new MockFileSystem();
@@ -219,6 +206,41 @@ public sealed class GivenALocalChangeDetector
         var rules = new[] { Rule("/Documents", RuleType.Include) };
 
         var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
+
+        jobs.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void when_known_file_last_write_exactly_equals_remote_modified_plus_five_seconds_then_file_is_skipped()
+    {
+        const string filePath = $"{BasePath}/Documents/boundary.txt";
+        var remoteModifiedAt = new DateTimeOffset(2025, 3, 15, 9, 0, 0, TimeSpan.Zero);
+        var lastWrite = remoteModifiedAt.AddSeconds(5).UtcDateTime;
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent("data"));
+        mockFileSystem.File.SetLastWriteTimeUtc(filePath, lastWrite);
+        var lookup = new Dictionary<string, SyncedItemEntity>
+        {
+            [filePath] = new() { RemoteModifiedAt = remoteModifiedAt, RemoteItemId = new OneDriveItemId("remote-id-boundary") }
+        };
+        var sut = CreateSut(mockFileSystem);
+        var rules = new[] { Rule("/Documents", RuleType.Include) };
+
+        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, lookup);
+
+        jobs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void when_file_is_zero_bytes_and_not_in_lookup_then_upload_job_is_created()
+    {
+        const string filePath = $"{BasePath}/Documents/empty.txt";
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile(filePath).Which(m => m.HasStringContent(string.Empty));
+        var sut = CreateSut(mockFileSystem);
+        var rules = new[] { Rule("/Documents", RuleType.Include) };
+
+        var jobs = sut.DetectNewAndModifiedFiles(AccountId, BasePath, rules, EmptyLookup());
 
         jobs.Count.ShouldBe(1);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncRuleEvaluator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncRuleEvaluator.cs
@@ -147,4 +147,24 @@ public sealed class GivenASyncRuleEvaluator
 
         result.ShouldBeTrue();
     }
+
+    [Fact]
+    public void when_include_rule_is_root_slash_then_all_paths_are_included()
+    {
+        var rules = new[] { Rule("/", RuleType.Include) };
+
+        bool result = SyncRuleEvaluator.IsIncluded("/Documents/Reports/q1.pdf", rules);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_path_contains_unicode_characters_and_rule_matches_then_is_included()
+    {
+        var rules = new[] { Rule("/Ärger/日本語", RuleType.Include) };
+
+        bool result = SyncRuleEvaluator.IsIncluded("/ärger/日本語/file.txt", rules);
+
+        result.ShouldBeTrue();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenALogEntryFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenALogEntryFactory.cs
@@ -1,0 +1,63 @@
+using Serilog.Events;
+using AStar.Dev.OneDrive.Sync.Client.LogViewer;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.LogViewer;
+
+public sealed class GivenALogEntryFactory
+{
+    [Fact]
+    public void when_creating_entry_then_timestamp_is_preserved()
+    {
+        var timestamp = new DateTimeOffset(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        var entry = LogEntryFactory.Create(timestamp, LogEventLevel.Information, "msg", null);
+
+        entry.Timestamp.ShouldBe(timestamp);
+    }
+
+    [Fact]
+    public void when_creating_entry_then_level_is_preserved()
+    {
+        var entry = LogEntryFactory.Create(DateTimeOffset.UtcNow, LogEventLevel.Error, "msg", null);
+
+        entry.Level.ShouldBe(LogEventLevel.Error);
+    }
+
+    [Fact]
+    public void when_creating_entry_then_rendered_message_is_preserved()
+    {
+        var entry = LogEntryFactory.Create(DateTimeOffset.UtcNow, LogEventLevel.Information, "hello world", null);
+
+        entry.RenderedMessage.ShouldBe("hello world");
+    }
+
+    [Fact]
+    public void when_creating_entry_with_account_id_then_account_id_is_preserved()
+    {
+        var entry = LogEntryFactory.Create(DateTimeOffset.UtcNow, LogEventLevel.Information, "msg", "acc-123");
+
+        entry.AccountId.ShouldBe("acc-123");
+    }
+
+    [Fact]
+    public void when_creating_entry_with_null_account_id_then_account_id_is_null()
+    {
+        var entry = LogEntryFactory.Create(DateTimeOffset.UtcNow, LogEventLevel.Information, "msg", null);
+
+        entry.AccountId.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(LogEventLevel.Verbose)]
+    [InlineData(LogEventLevel.Debug)]
+    [InlineData(LogEventLevel.Information)]
+    [InlineData(LogEventLevel.Warning)]
+    [InlineData(LogEventLevel.Error)]
+    [InlineData(LogEventLevel.Fatal)]
+    public void when_creating_entry_with_each_level_then_level_is_preserved(LogEventLevel level)
+    {
+        var entry = LogEntryFactory.Create(DateTimeOffset.UtcNow, level, "msg", null);
+
+        entry.Level.ShouldBe(level);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenAnInMemoryLogSink.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/LogViewer/GivenAnInMemoryLogSink.cs
@@ -1,0 +1,120 @@
+using Serilog.Events;
+using AStar.Dev.OneDrive.Sync.Client.LogViewer;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.LogViewer;
+
+public sealed class GivenAnInMemoryLogSink
+{
+    private static LogEvent MakeEvent(LogEventLevel level = LogEventLevel.Information, string message = "test message", params LogEventProperty[] properties)
+        => new(DateTimeOffset.UtcNow, level, null, new Serilog.Events.MessageTemplate(message, []), properties);
+
+    private static LogEventProperty AccountIdProperty(string accountId)
+        => new("AccountId", new ScalarValue(accountId));
+
+    [Fact]
+    public void when_emit_called_then_entry_appears_in_snapshot()
+    {
+        var sut = new InMemoryLogSink();
+
+        sut.Emit(MakeEvent());
+
+        sut.GetSnapshot().ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void when_emit_called_multiple_times_then_snapshot_count_matches()
+    {
+        var sut = new InMemoryLogSink();
+
+        sut.Emit(MakeEvent());
+        sut.Emit(MakeEvent());
+        sut.Emit(MakeEvent());
+
+        sut.GetSnapshot().Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void when_emit_called_then_entry_level_matches_event_level()
+    {
+        var sut = new InMemoryLogSink();
+
+        sut.Emit(MakeEvent(LogEventLevel.Warning));
+
+        sut.GetSnapshot()[0].Level.ShouldBe(LogEventLevel.Warning);
+    }
+
+    [Fact]
+    public void when_emit_called_with_account_id_property_then_entry_account_id_is_extracted()
+    {
+        var sut = new InMemoryLogSink();
+
+        sut.Emit(MakeEvent(properties: AccountIdProperty("acc-test")));
+
+        sut.GetSnapshot()[0].AccountId.ShouldBe("acc-test");
+    }
+
+    [Fact]
+    public void when_emit_called_without_account_id_property_then_entry_account_id_is_null()
+    {
+        var sut = new InMemoryLogSink();
+
+        sut.Emit(MakeEvent());
+
+        sut.GetSnapshot()[0].AccountId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_emit_called_then_entry_added_observable_fires()
+    {
+        var sut = new InMemoryLogSink();
+        LogEntry? received = null;
+        sut.EntryAdded.Subscribe(e => received = e);
+
+        sut.Emit(MakeEvent());
+
+        received.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void when_emit_called_then_entry_added_observable_fires_correct_level()
+    {
+        var sut = new InMemoryLogSink();
+        LogEntry? received = null;
+        sut.EntryAdded.Subscribe(e => received = e);
+
+        sut.Emit(MakeEvent(LogEventLevel.Error));
+
+        received!.Level.ShouldBe(LogEventLevel.Error);
+    }
+
+    [Fact]
+    public void when_dispose_called_then_observable_is_completed()
+    {
+        var sut = new InMemoryLogSink();
+        bool completed = false;
+        sut.EntryAdded.Subscribe(_ => { }, () => completed = true);
+
+        sut.Dispose();
+
+        completed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_get_snapshot_called_then_returns_immutable_copy()
+    {
+        var sut = new InMemoryLogSink();
+        sut.Emit(MakeEvent());
+        var snapshot = sut.GetSnapshot();
+
+        sut.Emit(MakeEvent());
+
+        snapshot.Count.ShouldBe(1);
+        sut.GetSnapshot().Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void when_default_capacity_is_inspected_then_value_is_500()
+    {
+        InMemoryLogSink.DefaultCapacity.ShouldBe(500);
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenWizardConverters.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Onboarding/GivenWizardConverters.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using Avalonia.Media;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Onboarding;
+
+public sealed class GivenWizardConverters
+{
+    public sealed class GivenABoolToAccentConverter
+    {
+        private static readonly BoolToAccentConverter Sut = BoolToAccentConverter.Instance;
+
+        [Fact]
+        public void when_value_is_true_then_active_color_is_returned()
+        {
+            var result = (Color)Sut.Convert(true, typeof(Color), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(Color.Parse("#185FA5"));
+        }
+
+        [Fact]
+        public void when_value_is_false_then_inactive_color_is_returned()
+        {
+            var result = (Color)Sut.Convert(false, typeof(Color), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(Color.Parse("#D3D1C7"));
+        }
+
+        [Fact]
+        public void when_value_is_null_then_inactive_color_is_returned()
+        {
+            var result = (Color)Sut.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(Color.Parse("#D3D1C7"));
+        }
+
+        [Fact]
+        public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+        {
+            var first = BoolToAccentConverter.Instance;
+            var second = BoolToAccentConverter.Instance;
+
+            first.ShouldBeSameAs(second);
+        }
+
+        [Fact]
+        public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+        {
+            _ = Should.Throw<NotSupportedException>(() =>
+                Sut.ConvertBack(Colors.Transparent, typeof(bool), null, CultureInfo.InvariantCulture));
+        }
+    }
+
+    public sealed class GivenAStringNotEmptyConverter
+    {
+        private static readonly StringNotEmptyConverter Sut = StringNotEmptyConverter.Instance;
+
+        [Fact]
+        public void when_value_is_non_empty_string_then_result_is_true()
+        {
+            var result = Sut.Convert("hello", typeof(bool), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        public void when_value_is_empty_string_then_result_is_false()
+        {
+            var result = Sut.Convert(string.Empty, typeof(bool), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(false);
+        }
+
+        [Fact]
+        public void when_value_is_null_then_result_is_false()
+        {
+            var result = Sut.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(false);
+        }
+
+        [Fact]
+        public void when_value_is_whitespace_then_result_is_true()
+        {
+            var result = Sut.Convert("   ", typeof(bool), null, CultureInfo.InvariantCulture);
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        public void when_instance_accessed_multiple_times_then_same_instance_is_returned()
+        {
+            var first = StringNotEmptyConverter.Instance;
+            var second = StringNotEmptyConverter.Instance;
+
+            first.ShouldBeSameAs(second);
+        }
+
+        [Fact]
+        public void when_convert_back_is_called_then_not_supported_exception_is_thrown()
+        {
+            _ = Should.Throw<NotSupportedException>(() =>
+                Sut.ConvertBack(true, typeof(string), null, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncRuleEvaluator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncRuleEvaluator.cs
@@ -22,7 +22,7 @@ public static class SyncRuleEvaluator
             char afterPrefix = remotePath.Length > rule.RemotePath.Length
                 ? remotePath[rule.RemotePath.Length]
                 : (char)0;
-            if(remotePath.Length > rule.RemotePath.Length && afterPrefix != '/')
+            if(rule.RemotePath != "/" && remotePath.Length > rule.RemotePath.Length && afterPrefix != '/')
                 continue;
 
             if(match is null || rule.RemotePath.Length > match.RemotePath.Length)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.7.11",
+    "ApplicationVersion": "0.7.12",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
## Summary

- Add `GivenAnInMemoryLogSink`: covers `Emit`, `GetSnapshot`, `EntryAdded` observable, `Dispose`, and `AccountId` property extraction
- Add `GivenALogEntryFactory`: covers `Create` across all `LogEventLevel` values
- Add `GivenStorageQuotaExtensions`: covers `Fraction` boundaries (zero total, used=total, used>total clamp, mid-range)
- Add `GivenAVersionInfoFactory`: covers `Some`/`None` ETag and CTag combinations
- Add converter tests for `IntZeroToBoolConverter`, `SyncStateToBadgeBackgroundConverter`, `SyncStateToBadgeForegroundConverter`, `SyncStateToForegroundConverter`: full enum coverage, null/non-type guards, `ConvertBack` throws
- Add `GivenWizardConverters`: covers `BoolToAccentConverter` and `StringNotEmptyConverter`
- Add `GivenAConflictCountToColorConverter`: zero, positive, null, and non-integer inputs

## Type of change

- [x] Maintenance

## Related issues / links

Closes #516

## How was this tested?

- [x] Unit tests added/updated

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 106 new tests, 0 failures
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/
```

---

## Notes for reviewers

`StringNotEmptyConverter` uses `IsNullOrEmpty` (not `IsNullOrWhiteSpace`), so whitespace-only strings return `true` — the test reflects actual production behaviour, not an assumption.