### PR TITLE
fix(onedrive-sync-client): stream Graph folder enumeration to eliminate 3GB memory spike (#548)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Graph/GivenAGraphService.cs
@@ -93,7 +93,10 @@ public sealed class GivenAGraphService : IDisposable
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
-        await Should.ThrowAsync<OperationCanceledException>(() => sut.EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token));
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in sut.EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: cts.Token)) { }
+        });
     }
 
     [Fact]
@@ -235,9 +238,10 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
+        var items = new List<DeltaItem>();
+        await foreach (var item in CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken))
+            items.Add(item);
 
-        var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(3);
         items.ShouldContain(i => i.Id.Id == "file-root");
         items.ShouldContain(i => i.Id.Id == "subfolder-001" && i is FolderDeltaItem);
@@ -270,9 +274,10 @@ public sealed class GivenAGraphService : IDisposable
                     }
                 }));
 
-        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken);
+        var items = new List<DeltaItem>();
+        await foreach (var item in CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, "root", ct: TestContext.Current.CancellationToken))
+            items.Add(item);
 
-        var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(2);
         items.ShouldContain(i => i.Id.Id == "subfolder-A");
         items.ShouldContain(i => i.Id.Id == AnyFolderId);
@@ -369,10 +374,11 @@ public sealed class GivenAGraphService : IDisposable
                 }));
 
         var reportedCounts = new List<int>();
+        var items = new List<DeltaItem>();
 
-        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken);
+        await foreach (var item in CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, onItemDiscovered: count => reportedCounts.Add(count), ct: TestContext.Current.CancellationToken))
+            items.Add(item);
 
-        var items = result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Ok>()!.Value;
         items.Count.ShouldBe(1);
         reportedCounts.ShouldContain(1);
         reportedCounts.ShouldNotContain(2);
@@ -487,7 +493,7 @@ public sealed class GivenAGraphService : IDisposable
     }
 
     [Fact]
-    public async Task when_enumerate_folder_returns_server_error_then_result_is_error()
+    public async Task when_enumerate_folder_returns_server_error_then_exception_is_thrown_when_iterating()
     {
         server.Given(Request.Create().UsingAnyMethod())
             .RespondWith(Response.Create()
@@ -495,9 +501,10 @@ public sealed class GivenAGraphService : IDisposable
                 .WithHeader("Content-Type", "application/json")
                 .WithBodyAsJson(new { error = new { code = "generalException", message = "Server error" } }));
 
-        var result = await CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: TestContext.Current.CancellationToken);
-
-        result.ShouldBeAssignableTo<Result<List<DeltaItem>, string>.Error>();
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            await foreach (var _ in CreateSut().EnumerateFolderAsync(_ => Task.FromResult(AnyAccessToken), new DriveId(AnyDriveId), AnyFolderId, AnyRemotePath, ct: TestContext.Current.CancellationToken)) { }
+        });
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -47,6 +47,12 @@ public sealed class GivenARemoteFolderEnumerator
         yield break;
     }
 
+    private static async IAsyncEnumerable<DeltaItem> ItemStream(params DeltaItem[] items)
+    {
+        foreach (var item in items)
+            yield return item;
+    }
+
     [Fact]
     public async Task when_no_rules_configured_then_context_had_no_rules_flag_is_set()
     {
@@ -111,7 +117,7 @@ public sealed class GivenARemoteFolderEnumerator
         _graphService.GetFolderIdByPathAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns("folder-resolved");
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+            .Returns(EmptyStream());
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();
 
@@ -126,7 +132,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+            .Returns(EmptyStream());
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();
 
@@ -141,7 +147,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
+            .Returns(ItemStream(FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")));
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();
 
@@ -157,7 +163,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")]));
+            .Returns(ItemStream(FileItem("item-a", "a.txt", "/Documents/a.txt"), FileItem("item-b", "b.txt", "/Documents/b.txt")));
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();
         var items = new List<DeltaItem>();
@@ -176,7 +182,7 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1")]);
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<List<DeltaItem>, string>.Ok([]));
+            .Returns(EmptyStream());
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();
 
@@ -193,10 +199,10 @@ public sealed class GivenARemoteFolderEnumerator
         _syncRuleRepository.GetByAccountIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
             .Returns([IncludeRule("/Documents", remoteItemId: "folder-1"), IncludeRule("/Pictures", remoteItemId: "folder-2")]);
         _graphService.EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Is("folder-1"), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
+            .Returns(_ =>
             {
                 cts.Cancel();
-                return new Result<List<DeltaItem>, string>.Ok([FileItem("item-a", "a.txt", "/Documents/a.txt")]);
+                return ItemStream(FileItem("item-a", "a.txt", "/Documents/a.txt"));
             });
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var context = new RemoteEnumerationContext();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Detection/GivenARemoteFolderEnumerator.cs
@@ -106,7 +106,7 @@ public sealed class GivenARemoteFolderEnumerator
 
         await foreach (var _ in CreateSut().StreamAsync(CreateAccount(), tokenFactory, context, ct: TestContext.Current.CancellationToken)) { }
 
-        await _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
+        _graphService.DidNotReceive().EnumerateFolderAsync(Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<DriveId>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<int>?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphFolderEnumerator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
@@ -20,28 +21,25 @@ internal sealed class GraphFolderEnumerator(IGraphClientFactory graphClientFacto
         "eTag", "cTag", DownloadUrlKey
     ];
 
-    /// <summary>Enumerates all descendants of the specified folder, returning a flat list of <see cref="DeltaItem"/> instances. Cycles in the folder graph are detected and broken.</summary>
-    internal async Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered, CancellationToken ct)
+    /// <summary>Streams all descendants of the specified folder, yielding each item as it arrives from the Graph API. Cycles in the folder graph are detected and broken.</summary>
+    internal async IAsyncEnumerable<DeltaItem> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered, [EnumeratorCancellation] CancellationToken ct)
     {
-        try
-        {
-            var client = graphClientFactory.CreateClient(tokenFactory);
-            List<DeltaItem> items = [];
-            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            await EnumerateSubFolderAsync(client, driveId, folderId, remotePath, items, visited, onItemDiscovered, ct).ConfigureAwait(false);
+        var client = graphClientFactory.CreateClient(tokenFactory);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int count = 0;
 
-            return new Result<List<DeltaItem>, string>.Ok(items);
-        }
-        catch(Exception ex) when(ex is not OperationCanceledException and not SyncReAuthRequiredException)
+        await foreach (var item in EnumerateSubFolderAsync(client, driveId, folderId, remotePath, visited, ct))
         {
-            return new Result<List<DeltaItem>, string>.Error(ex.Message);
+            count++;
+            onItemDiscovered?.Invoke(count);
+            yield return item;
         }
     }
 
-    private static async Task EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, List<DeltaItem> items, HashSet<string> visited, Action<int>? onItemDiscovered, CancellationToken ct)
+    private static async IAsyncEnumerable<DeltaItem> EnumerateSubFolderAsync(GraphServiceClient client, DriveId driveId, string parentId, string relativePath, HashSet<string> visited, [EnumeratorCancellation] CancellationToken ct)
     {
         if(!visited.Add(parentId))
-            return;
+            yield break;
 
         var page = await client.Drives[driveId.Value].Items[parentId].Children
             .GetAsync(req => req.QueryParameters.Select = childrenSelect, ct).ConfigureAwait(false);
@@ -51,12 +49,11 @@ internal sealed class GraphFolderEnumerator(IGraphClientFactory graphClientFacto
             foreach(var item in page.Value)
             {
                 string itemPath = BuildRelativePath(relativePath, item);
-
-                items.Add(MapToDeltaItem(item, itemPath));
-                onItemDiscovered?.Invoke(items.Count);
+                yield return MapToDeltaItem(item, itemPath);
 
                 if(item.Folder is not null && item.Id is not null)
-                    await EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, items, visited, onItemDiscovered, ct).ConfigureAwait(false);
+                    await foreach(var child in EnumerateSubFolderAsync(client, driveId, item.Id, itemPath, visited, ct))
+                        yield return child;
             }
 
             if(!OdataNextLinkGuard.IsSafe(page.OdataNextLink))

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/GraphService.cs
@@ -147,7 +147,7 @@ internal sealed class GraphService(IUploadService uploadService, IGraphClientFac
     }
 
     /// <inheritdoc />
-    public Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
+    public IAsyncEnumerable<DeltaItem> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default)
         => graphFolderEnumerator.EnumerateFolderAsync(tokenFactory, driveId, folderId, remotePath, onItemDiscovered, ct);
 
     /// <inheritdoc />

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Graph/IGraphService.cs
@@ -19,8 +19,8 @@ public interface IGraphService
     /// <summary>Returns the user's OneDrive storage quota.</summary>
     Task<Result<(long Total, long Used), string>> GetQuotaAsync(string accountId, Func<CancellationToken, Task<string>> tokenFactory, CancellationToken ct = default);
 
-    /// <summary>Enumerates all descendants (files and folders) of the given folder. ETag and CTag are populated on each returned DeltaItem.</summary>
-    Task<Result<List<DeltaItem>, string>> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
+    /// <summary>Streams all descendants (files and folders) of the given folder. Items are yielded per Graph API page; no buffering. ETag and CTag are populated on each yielded DeltaItem.</summary>
+    IAsyncEnumerable<DeltaItem> EnumerateFolderAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string folderId, string remotePath, Action<int>? onItemDiscovered = null, CancellationToken ct = default);
 
     /// <summary>Resolves the OneDrive item ID for a path relative to the drive root. Returns null if the path does not exist.</summary>
     Task<string?> GetFolderIdByPathAsync(Func<CancellationToken, Task<string>> tokenFactory, DriveId driveId, string remotePath, CancellationToken ct = default);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Detection/RemoteFolderEnumerator.cs
@@ -61,24 +61,36 @@ public sealed class RemoteFolderEnumerator(IGraphService graphService, ISyncRule
             }
 
             OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerating(logger, rule.RemotePath, account.Id.Id);
-            var items = await graphService.EnumerateFolderAsync(tokenFactory, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct)
-                .MatchAsync<List<DeltaItem>, string, List<DeltaItem>?>(
-                    deltaItems => deltaItems,
-                    error =>
-                    {
-                        OneDriveSyncClientMessages.RemoteFolderEnumeratorFailed(logger, rule.RemotePath, error);
-                        return null;
-                    }).ConfigureAwait(false);
+            var folderEnumerator = graphService.EnumerateFolderAsync(tokenFactory, driveId.Value, folderId, rule.RemotePath, onItemDiscovered, ct).GetAsyncEnumerator(ct);
+            int itemCount = 0;
 
-            if (items is null)
-                continue;
-
-            OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerated(logger, items.Count, rule.RemotePath);
-
-            foreach (var item in items)
+            try
             {
-                context.SeenRemoteIds.Add(item.Id.Id);
-                yield return item;
+                while (true)
+                {
+                    bool hasNext;
+                    try
+                    {
+                        hasNext = await folderEnumerator.MoveNextAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException and not SyncReAuthRequiredException)
+                    {
+                        OneDriveSyncClientMessages.RemoteFolderEnumeratorFailed(logger, rule.RemotePath, ex.Message);
+                        break;
+                    }
+
+                    if (!hasNext)
+                        break;
+
+                    itemCount++;
+                    context.SeenRemoteIds.Add(folderEnumerator.Current.Id.Id);
+                    yield return folderEnumerator.Current;
+                }
+            }
+            finally
+            {
+                await folderEnumerator.DisposeAsync().ConfigureAwait(false);
+                OneDriveSyncClientMessages.RemoteFolderEnumeratorEnumerated(logger, itemCount, rule.RemotePath);
             }
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.8.0",
+    "ApplicationVersion": "0.8.1",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Fixes a ~3GB RAM spike during sync caused by `GraphFolderEnumerator` buffering the entire OneDrive folder tree into a `List<DeltaItem>` before yielding any item. With 300k files, this held the full dataset in memory simultaneously. The pipeline's bounded channel (workers×4 backpressure) was correctly designed but undermined by full materialisation upstream.

## Type of change

- [x] Bug fix

## Related issues / links

Closes #548

## How was this tested?

- [x] Unit tests added/updated — `GivenAGraphService` and `GivenARemoteFolderEnumerator` updated to assert on the new `IAsyncEnumerable<DeltaItem>` streaming contract
- [x] Manual validation — verified 1792 tests pass, 0 failures, 0 warnings

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — `Infrastructure/Graph/` and `Infrastructure/Sync/Detection/`

---

## TDD Checklist (required)

- [x] Builds locally — `0 Warning(s)  0 Error(s)`
- [x] Tests pass (`dotnet test`) — `Failed: 0, Passed: 1792`
- [x] No new analyzer warnings
- [x] Public API changes reviewed — `IGraphService.EnumerateFolderAsync` signature changed from `Task<Result<List<DeltaItem>, string>>` to `IAsyncEnumerable<DeltaItem>`
- [x] Documentation updated (if applicable) — XML doc on interface updated

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj --verbosity normal
```

---

## Notes for reviewers

**Root cause:** `GraphFolderEnumerator.EnumerateSubFolderAsync` accumulated every item into `List<DeltaItem> items = []` recursively across all pages before returning. `RemoteFolderEnumerator.StreamAsync` then awaited the full `Result<List<DeltaItem>>` before entering its `yield return` loop — making the `IAsyncEnumerable` streaming illusory.

**Fix:**
- `GraphFolderEnumerator` converted to `async IAsyncEnumerable<DeltaItem>` — yields each item as it arrives per Graph API page
- `IGraphService`/`GraphService` signatures updated to match
- `RemoteFolderEnumerator` uses a manual `IAsyncEnumerator` pattern (same pattern as `SyncJobExecutor`) to preserve per-rule error handling without `yield return` inside a `try/catch`

Memory is now bounded by the `ParallelSyncPipeline` channel capacity (workers×4) regardless of drive size. Version bumped 0.8.0 → 0.8.1.