### PR TITLE
feat(onedrive-sync-client): classify downloads inline as each job completes (#550)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -187,7 +187,7 @@ dotnet_naming_style.prefix_t_style.capitalization                  = pascal_case
 
 # Private fields: _camelCase
 dotnet_naming_rule.private_fields_underscore.symbols               = private_field_symbols
-dotnet_naming_rule.private_fields_underscore.style                = underscore_camel_style
+dotnet_naming_rule.private_fields_underscore.style                = camel_case
 dotnet_naming_rule.private_fields_underscore.severity             = warning
 
 dotnet_naming_symbols.private_field_symbols.applicable_kinds       = field

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncService.cs
@@ -37,7 +37,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -58,7 +58,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var service = BuildSut();
@@ -77,7 +77,7 @@ public sealed class GivenASyncService
             Arg.Any<Func<CancellationToken, Task<string>>>(),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
-            Arg.Any<Action<JobCompletedEventArgs>>(),
+            Arg.Any<Func<JobCompletedEventArgs, Task>>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -142,7 +142,7 @@ public sealed class GivenASyncService
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new SyncReAuthRequiredException()));
 
         var service = BuildSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceLocalisingStrings.cs
@@ -91,7 +91,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(false);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -107,7 +107,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(true);
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -123,7 +123,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
         var progressMessages = new List<string>();
         var sut = CreateSut();
@@ -181,7 +181,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         var sut = CreateSut();
@@ -196,7 +196,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
         var sut = CreateSut();
@@ -211,7 +211,7 @@ public sealed class GivenASyncServiceLocalisingStrings
     {
         _authService.AcquireTokenSilentAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         var sut = CreateSut();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/GivenASyncServiceSyncingAnAccount.cs
@@ -38,7 +38,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             .Returns(AuthResultFactory.Success("token", "user-1", AccountProfileFactory.Create("User", "user@outlook.com")));
 
     private void SetupOrchestratorReturns(bool didRun) =>
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(didRun);
 
     [Fact]
@@ -132,7 +132,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_operation_cancelled_then_progress_is_sync_cancelled_localisation_key_with_idle_state()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new OperationCanceledException()));
 
         string? capturedMessage = null;
@@ -157,7 +157,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
     public async Task when_orchestrator_throws_unexpected_exception_then_progress_is_error_state_with_exception_message()
     {
         SetupAuthSuccess();
-        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<CancellationToken>())
+        _syncPassOrchestrator.OrchestrateAsync(Arg.Any<OneDriveAccount>(), Arg.Any<AccountSyncConfig>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Func<SyncConflict, Task>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<bool>(new InvalidOperationException("unexpected")));
 
         SyncState? capturedState = null;
@@ -251,7 +251,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             Arg.Do<Func<CancellationToken, Task<string>>>(f => capturedFactory = f),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
-            Arg.Any<Action<JobCompletedEventArgs>>(),
+            Arg.Any<Func<JobCompletedEventArgs, Task>>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -276,7 +276,7 @@ public sealed class GivenASyncServiceSyncingAnAccount
             Arg.Do<Func<CancellationToken, Task<string>>>(f => capturedFactory = f),
             Arg.Any<Func<SyncConflict, Task>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
-            Arg.Any<Action<JobCompletedEventArgs>>(),
+            Arg.Any<Func<JobCompletedEventArgs, Task>>(),
             Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenAParallelSyncPipeline.cs
@@ -63,7 +63,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(EmptyJobStream(), TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(EmptyJobStream(), TokenFactory, progressEvents.Add, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents.ShouldBeEmpty();
     }
@@ -74,7 +74,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(EmptyJobStream(), TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(EmptyJobStream(), TokenFactory, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.ShouldBeEmpty();
     }
@@ -84,7 +84,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync(EmptyJobStream(), TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(EmptyJobStream(), TokenFactory, _ => { }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.DidNotReceive().ClearCompletedJobsAsync(Arg.Any<AccountId>(), TestContext.Current.CancellationToken);
     }
@@ -95,7 +95,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(1);
     }
@@ -106,7 +106,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new ConcurrentBag<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt"), MakeDownloadJob("a/3.txt")), TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob("a/1.txt"), MakeDownloadJob("a/2.txt"), MakeDownloadJob("a/3.txt")), TokenFactory, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents.Count.ShouldBe(3);
     }
@@ -116,7 +116,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).ClearCompletedJobsAsync(Arg.Any<AccountId>(), TestContext.Current.CancellationToken);
     }
@@ -126,7 +126,7 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).ClearCompletedJobsAsync(new AccountId(AccountIdValue), TestContext.Current.CancellationToken);
     }
@@ -137,7 +137,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, progressEvents.Add, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].SyncState.ShouldBe(SyncState.Idle);
     }
@@ -148,7 +148,7 @@ public sealed class GivenAParallelSyncPipeline
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, progressEvents.Add, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, progressEvents.Add, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         progressEvents[^1].CurrentFile.ShouldBe(string.Empty);
     }
@@ -159,7 +159,7 @@ public sealed class GivenAParallelSyncPipeline
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, completedEvents.Add, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         completedEvents[0].Job.Status.State.ShouldBe(SyncJobState.Completed);
     }
@@ -174,7 +174,7 @@ public sealed class GivenAParallelSyncPipeline
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
-        }, _ => { }, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
+        }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: TestContext.Current.CancellationToken);
 
         perJobProgressEvents.Count.ShouldBe(1);
         perJobProgressEvents[0].SyncState.ShouldBe(SyncState.Syncing);
@@ -190,7 +190,7 @@ public sealed class GivenAParallelSyncPipeline
         {
             if(args.CurrentFile != string.Empty)
                 perJobProgressEvents.Add(args);
-        }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 1, ct: TestContext.Current.CancellationToken);
+        }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, workerCount: 1, ct: TestContext.Current.CancellationToken);
 
         perJobProgressEvents.Count.ShouldBe(1);
         perJobProgressEvents[0].SyncState.ShouldBe(SyncState.Syncing);
@@ -205,7 +205,7 @@ public sealed class GivenAParallelSyncPipeline
 
         try
         {
-            await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, ct: cts.Token);
+            await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, ct: cts.Token);
         }
         catch(OperationCanceledException) { }
 
@@ -217,17 +217,17 @@ public sealed class GivenAParallelSyncPipeline
     {
         var sut = CreateSut();
 
-        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => { }, AccountIdValue, FolderIdValue, workerCount: 3, ct: TestContext.Current.CancellationToken);
+        await sut.RunAsync(JobStream(MakeDownloadJob()), TokenFactory, _ => { }, _ => Task.CompletedTask, AccountIdValue, FolderIdValue, workerCount: 3, ct: TestContext.Current.CancellationToken);
 
         _workerFactory.Received(3).Create(Arg.Any<int>());
     }
 
     private sealed class SucceedingDownloadWorker : ISyncWorker
     {
-        public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
+        public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncJob, bool, string?, Task> onJobComplete, CancellationToken ct)
         {
             await foreach(var job in reader.ReadAllAsync(ct))
-                onJobComplete(job, true, null);
+                await onJobComplete(job, true, null);
         }
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncJobExecutor.cs
@@ -37,7 +37,7 @@ public sealed class GivenASyncJobExecutor
         _syncedItemRepository.UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(1));
         _settingsService.Current.Returns(new AppSettings());
 
-        _pipeline.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+        _pipeline.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(async call =>
             {
                 await foreach (var _ in call.Arg<IAsyncEnumerable<SyncJob>>().ConfigureAwait(false))
@@ -78,7 +78,7 @@ public sealed class GivenASyncJobExecutor
     }
 
     private void SimulateJobCompleted(SyncJob completedJob)
-        => _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        => _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
                     .Do(call =>
                     {
                         var jobs = call.Arg<IAsyncEnumerable<SyncJob>>();
@@ -86,7 +86,7 @@ public sealed class GivenASyncJobExecutor
                         {
                             await foreach (var _ in jobs.ConfigureAwait(false)) { }
                         }).GetAwaiter().GetResult();
-                        call.Arg<Action<JobCompletedEventArgs>>()(new JobCompletedEventArgs(completedJob));
+                        call.Arg<Func<JobCompletedEventArgs, Task>>()(new JobCompletedEventArgs(completedJob)).GetAwaiter().GetResult();
                     });
 
     [Fact]
@@ -95,9 +95,9 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, EmptyJobStream(), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, EmptyJobStream(), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
-        await _pipeline.DidNotReceive().RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await _pipeline.DidNotReceive().RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncRepository.Received(1).EnqueueJobAsync(Arg.Any<SyncJob>(), Arg.Any<CancellationToken>());
     }
@@ -120,7 +120,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "item-1"), Arg.Any<CancellationToken>());
     }
@@ -135,7 +135,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
     }
@@ -152,7 +152,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Documents")), Arg.Any<CancellationToken>());
     }
@@ -167,7 +167,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Color")), Arg.Any<CancellationToken>());
     }
@@ -184,7 +184,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(mockFileSystem);
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Is<IReadOnlyList<FileClassification>>(list => list.Any(c => c.Level1 == "Color")), Arg.Any<CancellationToken>());
     }
@@ -199,7 +199,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(mockFileSystem);
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertAsync(Arg.Is<SyncedItemEntity>(e => e.RemoteItemId.Id == "uploaded-remote-id"), Arg.Any<CancellationToken>());
     }
@@ -216,7 +216,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(mockFileSystem);
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.Received(1).UpsertClassificationsAsync(syncedItemId, Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
     }
@@ -226,7 +226,7 @@ public sealed class GivenASyncJobExecutor
     {
         var job1 = MakeJob("item-1", SyncDirection.Download);
         var job2 = MakeJob("item-2", SyncDirection.Download);
-        _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var jobs = call.Arg<IAsyncEnumerable<SyncJob>>();
@@ -234,14 +234,14 @@ public sealed class GivenASyncJobExecutor
                 {
                     await foreach (var _ in jobs.ConfigureAwait(false)) { }
                 }).GetAwaiter().GetResult();
-                var onJobCompleted = call.Arg<Action<JobCompletedEventArgs>>();
-                onJobCompleted(new JobCompletedEventArgs(job1.Complete()));
-                onJobCompleted(new JobCompletedEventArgs(job2.Complete()));
+                var onJobCompleted = call.Arg<Func<JobCompletedEventArgs, Task>>();
+                onJobCompleted(new JobCompletedEventArgs(job1.Complete())).GetAwaiter().GetResult();
+                onJobCompleted(new JobCompletedEventArgs(job2.Complete())).GetAwaiter().GetResult();
             });
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job1, job2), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job1, job2), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _classificationRepository.Received(1).GetAllKeywordMappingsAsync(Arg.Any<CancellationToken>());
     }
@@ -254,7 +254,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.DidNotReceive().UpsertAsync(Arg.Any<SyncedItemEntity>(), Arg.Any<CancellationToken>());
     }
@@ -267,7 +267,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], _ => { }, _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _syncedItemRepository.DidNotReceive().UpsertClassificationsAsync(Arg.Any<int>(), Arg.Any<IReadOnlyList<FileClassification>>(), Arg.Any<CancellationToken>());
     }
@@ -276,7 +276,7 @@ public sealed class GivenASyncJobExecutor
     public async Task when_jobs_execute_then_on_progress_callback_is_forwarded_from_pipeline()
     {
         var job = MakeJob("item-1", SyncDirection.Download);
-        _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Action<JobCompletedEventArgs>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
+        _pipeline.When(p => p.RunAsync(Arg.Any<IAsyncEnumerable<SyncJob>>(), Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<Action<SyncProgressEventArgs>>(), Arg.Any<Func<JobCompletedEventArgs, Task>>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>()))
             .Do(call =>
             {
                 var jobs = call.Arg<IAsyncEnumerable<SyncJob>>();
@@ -291,7 +291,7 @@ public sealed class GivenASyncJobExecutor
         Func<CancellationToken, Task<string>> tokenFactory = _ => Task.FromResult("token");
         var sut = CreateSut(new MockFileSystem());
 
-        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], args => progressReceived.Add(args), _ => { }, TestContext.Current.CancellationToken);
+        await sut.ExecuteAsync(_account, tokenFactory, JobStream(job), [], args => progressReceived.Add(args), _ => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         progressReceived.ShouldHaveSingleItem();
         progressReceived[0].CurrentFile.ShouldBe("file.txt");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncPassOrchestrator.cs
@@ -220,7 +220,7 @@ public sealed class GivenASyncPassOrchestrator
             Arg.Any<IAsyncEnumerable<SyncJob>>(),
             Arg.Any<Dictionary<string, SyncedItemEntity>>(),
             Arg.Any<Action<SyncProgressEventArgs>>(),
-            Arg.Any<Action<JobCompletedEventArgs>>(),
+            Arg.Any<Func<JobCompletedEventArgs, Task>>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncProgressTracker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncProgressTracker.cs
@@ -30,152 +30,152 @@ public sealed class GivenASyncProgressTracker
         return tracker;
     }
 
-    private static void CompleteJobs(SyncProgressTracker sut, int count, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs>? onJobCompleted = null)
+    private static async Task CompleteJobs(SyncProgressTracker sut, int count, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task>? onJobCompleted = null)
     {
         for (var i = 0; i < count; i++)
-            sut.RecordCompletion(MakeDownloadJob($"folder/file{i}.txt"), true, null, onProgress, onJobCompleted ?? (_ => { }));
+            await sut.RecordCompletion(MakeDownloadJob($"folder/file{i}.txt"), true, null, onProgress, onJobCompleted ?? (_ => Task.CompletedTask));
     }
 
     [Fact]
-    public void when_single_job_completes_then_sync_state_is_syncing()
+    public async Task when_single_job_completes_then_sync_state_is_syncing()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(1);
 
-        sut.RecordCompletion(MakeDownloadJob(), true, null, progressEvents.Add, _ => { });
+        await sut.RecordCompletion(MakeDownloadJob(), true, null, progressEvents.Add, _ => Task.CompletedTask);
 
         progressEvents[0].SyncState.ShouldBe(SyncState.Syncing);
     }
 
     [Fact]
-    public void when_job_succeeds_then_on_job_completed_receives_completed_state()
+    public async Task when_job_succeeds_then_on_job_completed_receives_completed_state()
     {
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateTracker(1);
 
-        sut.RecordCompletion(MakeDownloadJob(), true, null, _ => { }, completedEvents.Add);
+        await sut.RecordCompletion(MakeDownloadJob(), true, null, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; });
 
         completedEvents[0].Job.Status.State.ShouldBe(SyncJobState.Completed);
     }
 
     [Fact]
-    public void when_job_fails_then_on_job_completed_receives_failed_state()
+    public async Task when_job_fails_then_on_job_completed_receives_failed_state()
     {
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateTracker(1);
 
-        sut.RecordCompletion(MakeDownloadJob(), false, "download error", _ => { }, completedEvents.Add);
+        await sut.RecordCompletion(MakeDownloadJob(), false, "download error", _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; });
 
         completedEvents[0].Job.Status.State.ShouldBe(SyncJobState.Failed);
     }
 
     [Fact]
-    public void when_single_job_completes_then_on_progress_is_called_once()
+    public async Task when_single_job_completes_then_on_progress_is_called_once()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(1);
 
-        sut.RecordCompletion(MakeDownloadJob(), true, null, progressEvents.Add, _ => { });
+        await sut.RecordCompletion(MakeDownloadJob(), true, null, progressEvents.Add, _ => Task.CompletedTask);
 
         progressEvents.Count.ShouldBe(1);
     }
 
     [Fact]
-    public void when_job_completes_then_on_job_completed_is_called_once()
+    public async Task when_job_completes_then_on_job_completed_is_called_once()
     {
         var completedEvents = new List<JobCompletedEventArgs>();
         var sut = CreateTracker(1);
 
-        sut.RecordCompletion(MakeDownloadJob(), true, null, _ => { }, completedEvents.Add);
+        await sut.RecordCompletion(MakeDownloadJob(), true, null, _ => { }, args => { completedEvents.Add(args); return Task.CompletedTask; });
 
         completedEvents.Count.ShouldBe(1);
     }
 
     [Fact]
-    public void when_last_of_two_jobs_completes_then_sync_state_is_syncing()
+    public async Task when_last_of_two_jobs_completes_then_sync_state_is_syncing()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(2);
 
-        sut.RecordCompletion(MakeDownloadJob("a/1.txt"), true, null, progressEvents.Add, _ => { });
-        sut.RecordCompletion(MakeDownloadJob("a/2.txt"), true, null, progressEvents.Add, _ => { });
+        await sut.RecordCompletion(MakeDownloadJob("a/1.txt"), true, null, progressEvents.Add, _ => Task.CompletedTask);
+        await sut.RecordCompletion(MakeDownloadJob("a/2.txt"), true, null, progressEvents.Add, _ => Task.CompletedTask);
 
         progressEvents.Last().SyncState.ShouldBe(SyncState.Syncing);
     }
 
     [Fact]
-    public void when_99_of_1000_jobs_complete_then_no_progress_event_fires()
+    public async Task when_99_of_1000_jobs_complete_then_no_progress_event_fires()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(1000);
 
-        CompleteJobs(sut, 99, progressEvents.Add);
+        await CompleteJobs(sut, 99, progressEvents.Add);
 
         progressEvents.ShouldBeEmpty();
     }
 
     [Fact]
-    public void when_100th_of_1000_jobs_completes_then_exactly_one_progress_event_fires()
+    public async Task when_100th_of_1000_jobs_completes_then_exactly_one_progress_event_fires()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(1000);
 
-        CompleteJobs(sut, 100, progressEvents.Add);
+        await CompleteJobs(sut, 100, progressEvents.Add);
 
         progressEvents.Count.ShouldBe(1);
     }
 
     [Fact]
-    public void when_100th_of_1000_jobs_completes_then_sync_state_is_syncing()
+    public async Task when_100th_of_1000_jobs_completes_then_sync_state_is_syncing()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(1000);
 
-        CompleteJobs(sut, 100, progressEvents.Add);
+        await CompleteJobs(sut, 100, progressEvents.Add);
 
         progressEvents[0].SyncState.ShouldBe(SyncState.Syncing);
     }
 
     [Fact]
-    public void when_201_jobs_complete_then_progress_fires_at_100_200_and_final()
+    public async Task when_201_jobs_complete_then_progress_fires_at_100_200_and_final()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(201);
 
-        CompleteJobs(sut, 201, progressEvents.Add);
+        await CompleteJobs(sut, 201, progressEvents.Add);
 
         progressEvents.Count.ShouldBe(3);
     }
 
     [Fact]
-    public void when_final_job_completes_at_non_100_boundary_then_progress_still_fires()
+    public async Task when_final_job_completes_at_non_100_boundary_then_progress_still_fires()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(999);
 
-        CompleteJobs(sut, 999, progressEvents.Add);
+        await CompleteJobs(sut, 999, progressEvents.Add);
 
         progressEvents.Last().SyncState.ShouldBe(SyncState.Syncing);
     }
 
     [Fact]
-    public void when_total_is_exactly_100_then_only_one_progress_event_fires()
+    public async Task when_total_is_exactly_100_then_only_one_progress_event_fires()
     {
         var progressEvents = new List<SyncProgressEventArgs>();
         var sut = CreateTracker(100);
 
-        CompleteJobs(sut, 100, progressEvents.Add);
+        await CompleteJobs(sut, 100, progressEvents.Add);
 
         progressEvents.Count.ShouldBe(1);
     }
 
     [Fact]
-    public void when_on_job_completed_fires_for_every_job_regardless_of_throttle()
+    public async Task when_on_job_completed_fires_for_every_job_regardless_of_throttle()
     {
         var jobCompletedCount = 0;
         var sut = CreateTracker(1000);
 
-        CompleteJobs(sut, 99, _ => { }, _ => jobCompletedCount++);
+        await CompleteJobs(sut, 99, _ => { }, _ => { jobCompletedCount++; return Task.CompletedTask; });
 
         jobCompletedCount.ShouldBe(99);
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorker.cs
@@ -45,6 +45,8 @@ public sealed class GivenASyncWorker
         {
             completed.Add(job);
             errors.Add(error);
+
+            return Task.CompletedTask;
         }, ct);
 
         return (completed, errors);
@@ -137,7 +139,7 @@ public sealed class GivenASyncWorker
         channel.Writer.TryWrite(job);
         channel.Writer.Complete();
 
-        await CreateSut().RunAsync(channel.Reader, AccountId, tokenFactory, (_, _, _) => { }, TestContext.Current.CancellationToken);
+        await CreateSut().RunAsync(channel.Reader, AccountId, tokenFactory, (_, _, _) => Task.CompletedTask, TestContext.Current.CancellationToken);
 
         await _handler.Received(1).HandleAsync(job, AccountId, Arg.Any<Func<CancellationToken, Task<string>>>(), Arg.Any<CancellationToken>());
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorkerCancellationLogging.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Sync/Pipeline/GivenASyncWorkerCancellationLogging.cs
@@ -50,7 +50,7 @@ public sealed class GivenASyncWorkerCancellationLogging
 
         try
         {
-            await CreateSut(logger).RunAsync(channel.Reader, AccountId, _ => Task.FromResult(AccessToken), (_, _, _) => { }, cts.Token);
+            await CreateSut(logger).RunAsync(channel.Reader, AccountId, _ => Task.FromResult(AccessToken), (_, _, _) => Task.CompletedTask, cts.Token);
         }
         catch (OperationCanceledException) { }
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncJobExecutor.cs
@@ -15,5 +15,5 @@ public interface ISyncJobExecutor
     /// as it arrives, and persists a <see cref="SyncedItemEntity"/> for each successfully completed download or upload.
     /// Progress and job-completion events are forwarded via the provided callbacks.
     /// </summary>
-    Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IAsyncEnumerable<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct);
+    Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IAsyncEnumerable<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task> onJobCompleted, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPassOrchestrator.cs
@@ -15,5 +15,5 @@ public interface ISyncPassOrchestrator
     /// <paramref name="syncConfig"/> is the unwrapped sync configuration, resolved by the caller before invoking this method.
     /// Returns <see langword="true"/> when at least one sync rule was active; <see langword="false"/> when no folders were selected.
     /// </summary>
-    Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default);
+    Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Func<JobCompletedEventArgs, Task>? onJobCompleted = null, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncPipeline.cs
@@ -15,5 +15,5 @@ public interface ISyncPipeline
     /// <param name="folderId">The folder identifier used in progress events.</param>
     /// <param name="workerCount">Maximum number of concurrent workers. Defaults to 4.</param>
     /// <param name="ct">Token used to cancel the pipeline.</param>
-    Task RunAsync(IAsyncEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default);
+    Task RunAsync(IAsyncEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ISyncWorker.cs
@@ -7,5 +7,5 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public interface ISyncWorker
 {
     /// <summary>Processes all jobs from <paramref name="reader"/> until the channel completes or <paramref name="ct"/> is cancelled.</summary>
-    Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct);
+    Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncJob, bool, string?, Task> onJobComplete, CancellationToken ct);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/ParallelSyncPipeline.cs
@@ -25,13 +25,13 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class ParallelSyncPipeline(ISyncWorkerFactory workerFactory, ISyncRepository syncRepository, ILogger<ParallelSyncPipeline> logger, IOptions<SyncSettings> syncSettings) : ISyncPipeline
 {
     /// <inheritdoc />
-    public async Task RunAsync(IAsyncEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default)
+    public async Task RunAsync(IAsyncEnumerable<SyncJob> jobs, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task> onJobCompleted, string accountId, string folderId, int workerCount = 4, CancellationToken ct = default)
     {
         var tracker = new SyncProgressTracker(accountId, folderId, syncSettings.Value.ProgressReportInterval);
         var channel = Channel.CreateBounded<SyncJob>(new BoundedChannelOptions(workerCount * 4) { FullMode = BoundedChannelFullMode.Wait, SingleReader = false, SingleWriter = true });
 
         var workers = Enumerable.Range(1, workerCount)
-            .Select(workerId => workerFactory.Create(workerId).RunAsync(channel.Reader, accountId, tokenFactory, (job, success, error) => tracker.RecordCompletion(job, success, error, onProgress, onJobCompleted), ct))
+            .Select(workerId => workerFactory.Create(workerId).RunAsync(channel.Reader, accountId, tokenFactory, async (job, success, error) => await tracker.RecordCompletion(job, success, error, onProgress, onJobCompleted).ConfigureAwait(false), ct))
             .ToList();
 
         int enqueued = 0;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncJobExecutor.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemRepository syncedItemRepository, ISyncPipeline syncPipeline, IFileClassificationRepository classificationRepository, IFileSystem fileSystem, ISettingsService settingsService, IFileAutoCategorisor fileAutoCategorisor) : ISyncJobExecutor
 {
     /// <inheritdoc />
-    public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IAsyncEnumerable<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted, CancellationToken ct)
+    public async Task ExecuteAsync(OneDriveAccount account, Func<CancellationToken, Task<string>> tokenFactory, IAsyncEnumerable<SyncJob> jobs, Dictionary<string, SyncedItemEntity> syncedItems, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task> onJobCompleted, CancellationToken ct)
     {
         var enumerator = jobs.GetAsyncEnumerator(ct);
         bool hasFirst;
@@ -35,48 +35,41 @@ public sealed class SyncJobExecutor(ISyncRepository syncRepository, ISyncedItemR
             return;
         }
 
-        var successfulJobs = new ConcurrentBag<SyncJob>();
+        var mappings = await classificationRepository.GetAllKeywordMappingsAsync(ct).ConfigureAwait(false);
         var firstJob = enumerator.Current;
 
         await syncPipeline.RunAsync(
             EnqueueAndYield(firstJob, enumerator, ct),
             tokenFactory,
             onProgress,
-            args =>
+            async args =>
             {
                 if (args.Job.Status.State == SyncJobState.Completed)
-                    successfulJobs.Add(args.Job);
-                onJobCompleted(args);
+                {
+                    string remotePath = NormaliseRemotePath(args.Job.Target.RelativePath);
+
+                    if (args.Job is DownloadSyncJob)
+                    {
+                        var entity = SyncedItemEntityFactory.CreateFromDownloadJob(account.Id, args.Job, remotePath);
+                        int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
+                        syncedItems[args.Job.Remote.RemoteItemId.Id] = entity;
+                        await ClassifyAsync(syncedItemId, remotePath, mappings, ct).ConfigureAwait(false);
+                    }
+                    else if (args.Job is UploadSyncJob uploadJob && uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId)
+                    {
+                        var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, uploadJob, uploadedId.Value, remotePath, fileSystem);
+                        int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
+                        syncedItems[uploadedId.Value] = entity;
+                        await ClassifyAsync(syncedItemId, remotePath, mappings, ct).ConfigureAwait(false);
+                    }
+                }
+
+                await onJobCompleted(args).ConfigureAwait(false);
             },
             account.Id.Id,
             string.Empty,
             settingsService.Current.ConcurrentWorkerCount,
             ct).ConfigureAwait(false);
-
-        if (successfulJobs.IsEmpty)
-            return;
-
-        var mappings = await classificationRepository.GetAllKeywordMappingsAsync(ct).ConfigureAwait(false);
-
-        foreach (var job in successfulJobs)
-        {
-            string remotePath = NormaliseRemotePath(job.Target.RelativePath);
-
-            if (job is DownloadSyncJob)
-            {
-                var entity = SyncedItemEntityFactory.CreateFromDownloadJob(account.Id, job, remotePath);
-                int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
-                syncedItems[job.Remote.RemoteItemId.Id] = entity;
-                await ClassifyAsync(syncedItemId, remotePath, mappings, ct).ConfigureAwait(false);
-            }
-            else if (job is UploadSyncJob uploadJob && uploadJob.UploadedRemoteItemId is Option<string>.Some uploadedId)
-            {
-                var entity = SyncedItemEntityFactory.CreateFromUploadJob(account.Id, uploadJob, uploadedId.Value, remotePath, fileSystem);
-                int syncedItemId = await syncedItemRepository.UpsertAsync(entity, ct).ConfigureAwait(false);
-                syncedItems[uploadedId.Value] = entity;
-                await ClassifyAsync(syncedItemId, remotePath, mappings, ct).ConfigureAwait(false);
-            }
-        }
     }
 
     private async IAsyncEnumerable<SyncJob> EnqueueAndYield(SyncJob first, IAsyncEnumerator<SyncJob> rest, [EnumeratorCancellation] CancellationToken ct = default)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncPassOrchestrator.cs
@@ -15,7 +15,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 
 internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository, IDriveStateRepository driveStateRepository, SyncServiceDependencies dependencies, IOptions<SyncSettings> syncSettings, ILocalizationService localizationService) : ISyncPassOrchestrator
 {
-    public async Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Action<JobCompletedEventArgs>? onJobCompleted = null, CancellationToken ct = default)
+    public async Task<bool> OrchestrateAsync(OneDriveAccount account, AccountSyncConfig syncConfig, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncConflict, Task> conflictCallback, Action<SyncProgressEventArgs>? onProgress = null, Func<JobCompletedEventArgs, Task>? onJobCompleted = null, CancellationToken ct = default)
     {
         var driveState = (await driveStateRepository.GetByAccountIdAsync(account.Id, ct).ConfigureAwait(false))
             .Match(v => v, () => new DriveStateEntity { AccountId = account.Id });
@@ -52,7 +52,7 @@ internal sealed class SyncPassOrchestrator(IAccountRepository accountRepository,
         }
 
         if (hasJobs)
-            await dependencies.JobExecutor.ExecuteAsync(account, tokenFactory, jobChannel.Reader.ReadAllAsync(ct), context.SyncedItems, onProgress ?? (_ => { }), onJobCompleted ?? (_ => { }), ct).ConfigureAwait(false);
+            await dependencies.JobExecutor.ExecuteAsync(account, tokenFactory, jobChannel.Reader.ReadAllAsync(ct), context.SyncedItems, onProgress ?? (_ => { }), onJobCompleted ?? (_ => Task.CompletedTask), ct).ConfigureAwait(false);
 
         await producerTask.ConfigureAwait(false);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressTracker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncProgressTracker.cs
@@ -31,7 +31,7 @@ internal sealed class SyncProgressTracker(string accountId, string folderId, int
         }
     }
 
-    internal void RecordCompletion(SyncJob job, bool success, string? error, Action<SyncProgressEventArgs> onProgress, Action<JobCompletedEventArgs> onJobCompleted)
+    internal async Task RecordCompletion(SyncJob job, bool success, string? error, Action<SyncProgressEventArgs> onProgress, Func<JobCompletedEventArgs, Task> onJobCompleted)
     {
         int completedSoFar;
         bool shouldReportProgress;
@@ -51,6 +51,6 @@ internal sealed class SyncProgressTracker(string accountId, string folderId, int
         if (shouldReportProgress)
             onProgress(new SyncProgressEventArgs(accountId, folderId, completedSoFar, currentTotal, job.Target.RelativePath, SyncState.Syncing));
 
-        onJobCompleted(new JobCompletedEventArgs(completedJob));
+        await onJobCompleted(new JobCompletedEventArgs(completedJob)).ConfigureAwait(false);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/Pipeline/SyncWorker.cs
@@ -16,7 +16,7 @@ namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers, ISyncRepository syncRepository, ILogger<SyncWorker> logger) : ISyncWorker
 {
     /// <inheritdoc />
-    public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Action<SyncJob, bool, string?> onJobComplete, CancellationToken ct)
+    public async Task RunAsync(ChannelReader<SyncJob> reader, string accountId, Func<CancellationToken, Task<string>> tokenFactory, Func<SyncJob, bool, string?, Task> onJobComplete, CancellationToken ct)
     {
         await foreach (var job in reader.ReadAllAsync(ct))
         {
@@ -61,7 +61,7 @@ public sealed class SyncWorker(int workerId, IReadOnlyList<IJobHandler> handlers
             }
             finally
             {
-                onJobComplete(currentJob, success, error);
+                await onJobComplete(currentJob, success, error).ConfigureAwait(false);
             }
         }
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Sync/SyncService.cs
@@ -69,7 +69,7 @@ public sealed class SyncService(IAuthService authService, ISyncRepository syncRe
                     ConflictDetected?.Invoke(this, conflict);
                 },
                 args => SyncProgressChanged?.Invoke(this, args),
-                args => JobCompleted?.Invoke(this, args),
+                args => { JobCompleted?.Invoke(this, args); return Task.CompletedTask; },
                 ct).ConfigureAwait(false);
 
             if (!didRun)


### PR DESCRIPTION
# Summary

Changes `onJobCompleted` from `Action<JobCompletedEventArgs>` to `Func<JobCompletedEventArgs, Task>` at every layer of the sync pipeline stack, and moves entity upsert + classification into the per-job callback so each file is classified as soon as its worker finishes — not after the entire sync pass completes.

## Type of change

- [x] Feature

## Related issues / links

Closes #550

## How was this tested?

- [x] Unit tests added/updated

All 1792 unit tests pass. Existing tests migrated to the async callback signature; no new test count delta was needed — the behaviour change (inline vs bulk) is exercised by the existing classification and upsert assertions.

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client` — sync pipeline stack only.

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1792 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit
```

---

## Notes for reviewers

- `SyncJobExecutor.ExecuteAsync`: `GetAllKeywordMappingsAsync` is now called once **before** `syncPipeline.RunAsync` (previously called after). Mappings may be stale for the duration of one sync pass — this is the accepted trade-off per the issue spec (Option B).
- The `finally` block in `SyncWorker.RunAsync` now `await`s the callback. This is valid C# — `await` in `finally` is supported.
- `SimulateJobCompleted` in `GivenASyncJobExecutor` uses `.GetAwaiter().GetResult()` inside NSubstitute's synchronous `.Do()` callback — intentional, no async alternative exists there.
- `.editorconfig` changes are the author's own, included as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)