### PR TITLE
feat(onedrive-sync-client): add SizeInBytes column to SyncedItemEntity

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Entities/GivenASyncedItemEntityFactory.cs
@@ -113,4 +113,54 @@ public sealed class GivenASyncedItemEntityFactory
 
         entity.LocalPath.ShouldBe("/local/file.txt");
     }
+
+    [Fact]
+    public void when_creating_from_file_delta_item_then_size_in_bytes_is_set()
+    {
+        var item = CreateDeltaItem(Option.None<string>(), Option.None<string>());
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/file.txt", "/local/file.txt");
+
+        entity.SizeInBytes.ShouldBe(100L);
+    }
+
+    [Fact]
+    public void when_creating_from_folder_delta_item_then_size_in_bytes_is_null()
+    {
+        var item = DeltaItemFactory.CreateFolder(new OneDriveItemId("folder-1"), new DriveId("drive-1"), Option.None<OneDriveFolderId>(), ItemPathFactory.Create("docs"), VersionInfoFactory.Create(null, null));
+
+        var entity = SyncedItemEntityFactory.Create(new AccountId("acc-1"), item, "/docs", "/local/docs");
+
+        entity.SizeInBytes.ShouldBeNull();
+    }
+
+    [Fact]
+    public void when_creating_from_download_job_then_size_in_bytes_matches_metadata()
+    {
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("item-1"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "/file.txt");
+        var metadata = SyncFileMetadataFactory.Create(4096L, DateTimeOffset.UtcNow.AddDays(-1));
+        var job = SyncJobFactory.CreateDownload(remote, target, metadata);
+
+        var entity = SyncedItemEntityFactory.CreateFromDownloadJob(new AccountId("acc-1"), job, "/file.txt");
+
+        entity.SizeInBytes.ShouldBe(4096L);
+    }
+
+    [Fact]
+    public void when_creating_from_upload_job_then_size_in_bytes_matches_file_on_disk()
+    {
+        var mockFileSystem = new MockFileSystem();
+        mockFileSystem.Initialize().WithFile("/local/file.txt").Which(m => m.HasStringContent("hello world"));
+
+        var remote = RemoteItemRefFactory.Create(new AccountId("acc-1"), new OneDriveFolderId(string.Empty), new OneDriveItemId("original-id"));
+        var target = SyncFileTargetFactory.Create("/local/file.txt", "file.txt");
+        var metadata = SyncFileMetadataFactory.Create(100L, DateTimeOffset.UtcNow.AddDays(-1));
+        var job = SyncJobFactory.CreateUpload(remote, target, metadata);
+        long expectedSize = mockFileSystem.FileInfo.New("/local/file.txt").Length;
+
+        var entity = SyncedItemEntityFactory.CreateFromUploadJob(new AccountId("acc-1"), job, "uploaded-remote-id", "/file.txt", mockFileSystem);
+
+        entity.SizeInBytes.ShouldBe(expectedSize);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemEntityConfiguration.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Configuration/SyncedItemEntityConfiguration.cs
@@ -17,6 +17,7 @@ public class SyncedItemEntityConfiguration : IEntityTypeConfiguration<SyncedItem
                    .HasConversion(id => id.Id, str => new OneDriveItemId(str));
         _ = builder.HasIndex(e => new { e.AccountId, e.RemoteItemId }).IsUnique();
         _ = builder.HasIndex(e => new { e.AccountId, e.LocalPath });
+        _ = builder.HasIndex(e => new { e.AccountId, e.SizeInBytes });
         _ = builder.OwnsOne(e => e.Tags, b =>
         {
             _ = b.Property(v => v.ETag).HasColumnName("ETag")

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntity.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntity.cs
@@ -54,6 +54,11 @@ public sealed class SyncedItemEntity
     public VersionInfo Tags { get; set; } = VersionInfoFactory.Create(Option.None<string>(), Option.None<string>());
 
     /// <summary>
+    /// The size of the file in bytes at the time it was last synchronized. Null for folders or when size was not available at sync time.
+    /// </summary>
+    public long? SizeInBytes { get; set; }
+
+    /// <summary>
     /// Navigation property to the associated AccountEntity, allowing for access to the account's profile information, sync configuration, and other related data. This relationship is established through the AccountId foreign key, enabling the sync client to easily retrieve and manage the synchronized item in the context of the corresponding account. The navigation property is marked as nullable to indicate that there may be cases where the account information is not available or has been deleted, allowing for graceful handling of such scenarios within the application.
     /// </summary>
     [ForeignKey(nameof(AccountId))]

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Entities/SyncedItemEntityFactory.cs
@@ -27,7 +27,8 @@ public static class SyncedItemEntityFactory
             LocalPath = localPath,
             IsFolder = false,
             RemoteModifiedAt = item.LastModified.MapOrDefault(v => v, DateTimeOffset.MinValue),
-            Tags = item.VersionInfo
+            Tags = item.VersionInfo,
+            SizeInBytes = item.Size
         };
 
     /// <summary>
@@ -48,7 +49,8 @@ public static class SyncedItemEntityFactory
             LocalPath = localPath,
             IsFolder = true,
             RemoteModifiedAt = DateTimeOffset.MinValue,
-            Tags = item.VersionInfo
+            Tags = item.VersionInfo,
+            SizeInBytes = null
         };
 
     /// <summary>
@@ -68,7 +70,8 @@ public static class SyncedItemEntityFactory
             LocalPath = job.Target.LocalPath,
             IsFolder = false,
             RemoteModifiedAt = job.Metadata.RemoteModified,
-            Tags = job.Metadata.VersionInfo.Match(v => v, () => VersionInfoFactory.Create(Option.None<string>(), Option.None<string>()))
+            Tags = job.Metadata.VersionInfo.Match(v => v, () => VersionInfoFactory.Create(Option.None<string>(), Option.None<string>())),
+            SizeInBytes = job.Metadata.FileSize
         };
 
     /// <summary>
@@ -91,6 +94,7 @@ public static class SyncedItemEntityFactory
             RemotePath = remotePath,
             LocalPath = job.Target.LocalPath,
             IsFolder = false,
-            RemoteModifiedAt = new DateTimeOffset(fileSystem.FileInfo.New(job.Target.LocalPath).LastWriteTimeUtc, TimeSpan.Zero)
+            RemoteModifiedAt = new DateTimeOffset(fileSystem.FileInfo.New(job.Target.LocalPath).LastWriteTimeUtc, TimeSpan.Zero),
+            SizeInBytes = fileSystem.FileInfo.New(job.Target.LocalPath).Length
         };
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260615153923_AddSizeInBytesToSyncedItems.Designer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260615153923_AddSizeInBytesToSyncedItems.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using AStar.Dev.OneDrive.Sync.Client.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615153923_AddSizeInBytesToSyncedItems")]
+    partial class AddSizeInBytesToSyncedItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260615153923_AddSizeInBytesToSyncedItems.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Migrations/20260615153923_AddSizeInBytesToSyncedItems.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AStar.Dev.OneDrive.Sync.Client.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSizeInBytesToSyncedItems : Migration
+    {
+        private static readonly string[] accountIdSizeInBytesColumns = ["AccountId", "SizeInBytes"];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "SizeInBytes",
+                table: "SyncedItems",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SyncedItems_AccountId_SizeInBytes",
+                table: "SyncedItems",
+                columns: accountIdSizeInBytesColumns);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_SyncedItems_AccountId_SizeInBytes",
+                table: "SyncedItems");
+
+            migrationBuilder.DropColumn(
+                name: "SizeInBytes",
+                table: "SyncedItems");
+        }
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.8.1",
+    "ApplicationVersion": "0.9.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Adds a nullable `SizeInBytes long?` column to `SyncedItemEntity` so that file size is persisted after synchronisation. Size is already available in the domain (`FileDeltaItem.Size`, `SyncFileMetadata.FileSize`) but was previously discarded. This column is required for size-range filtering and duplicate detection in the upcoming file-search feature.

## Type of change

- [x] Feature

## Related issues / links

Closes #552

## How was this tested?

- [x] Unit tests added/updated

New tests in `GivenASyncedItemEntityFactory` cover all three factory overloads:
- `Create(AccountId, FileDeltaItem, ...)` → `SizeInBytes = item.Size`
- `CreateFromDownloadJob` → `SizeInBytes = job.Metadata.FileSize`
- `CreateFromUploadJob` → `SizeInBytes = fileSystem.FileInfo.New(localPath).Length`
- `Create(AccountId, FolderDeltaItem, ...)` → `SizeInBytes = null`

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — Passed: 1796, Failed: 0
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Column is nullable — existing rows get `null`, no back-fill required.
- EF migration `AddSizeInBytesToSyncedItems` adds the column plus a composite index on `(AccountId, SizeInBytes)`.
- Migration array arg fixed for CA1861 (`static readonly` field).
- `appsettings.json` version bumped `0.8.1` → `0.9.0` (feature).