### PR TITLE
feat(onedrive-sync-client): add IFileOpenerService to open local files in OS default app

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAFileOpenerService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAFileOpenerService.cs
@@ -1,0 +1,53 @@
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Shell;
+
+public sealed class GivenAFileOpenerService
+{
+    private readonly FileOpenerService sut = new();
+
+    [Fact]
+    public void when_file_does_not_exist_then_open_file_does_not_throw()
+    {
+        Should.NotThrow(() => sut.OpenFile("/nonexistent/path/to/file.txt"));
+    }
+
+    [Fact]
+    public void when_path_is_empty_string_then_open_file_does_not_throw()
+    {
+        Should.NotThrow(() => sut.OpenFile(string.Empty));
+    }
+
+    [Fact]
+    public void when_on_linux_then_opener_is_xdg_open()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        FileOpenerService.GetOpener().ShouldBe("xdg-open");
+    }
+
+    [Fact]
+    public void when_on_macos_then_opener_is_open()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+
+        FileOpenerService.GetOpener().ShouldBe("open");
+    }
+
+    [Fact]
+    public void when_on_windows_then_opener_is_explorer()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        FileOpenerService.GetOpener().ShouldBe("explorer");
+    }
+
+    [Fact]
+    public void when_getting_opener_then_a_non_empty_string_is_returned()
+    {
+        FileOpenerService.GetOpener().ShouldNotBeNullOrEmpty();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/FileOpenerService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/FileOpenerService.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+/// <inheritdoc />
+public sealed class FileOpenerService : IFileOpenerService
+{
+    /// <inheritdoc />
+    public void OpenFile(string localPath)
+    {
+        if (!File.Exists(localPath))
+            return;
+
+        _ = Process.Start(GetOpener(), localPath);
+    }
+
+    internal static string GetOpener()
+        => OperatingSystem.IsWindows() ? "explorer"
+         : OperatingSystem.IsMacOS()   ? "open"
+         : "xdg-open";
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFileOpenerService.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/IFileOpenerService.cs
@@ -1,0 +1,8 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+
+public interface IFileOpenerService
+{
+    /// <summary>Opens the specified file in the platform's default application. No-op if the file does not exist.</summary>
+    /// <param name="localPath">The absolute local path of the file to open.</param>
+    void OpenFile(string localPath);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -29,6 +29,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IFeatureAvailabilityService>(featureAvailability);
         _ = services.AddSingleton<IFeatureRegistrar>(featureAvailability);
         _ = services.AddSingleton<IFileManagerService, FileManagerService>();
+        _ = services.AddTransient<IFileOpenerService, FileOpenerService>();
         _ = services.AddSingleton(inMemoryLogSink);
         _ = services.AddSingleton<ILogEntryProvider>(inMemoryLogSink);
         _ = services.AddSingleton<IFileSystem, RealFileSystem>();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.8.1",
+    "ApplicationVersion": "0.9.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Adds `IFileOpenerService` / `FileOpenerService` to the OneDrive sync client. Mirrors the existing `FileManagerService` pattern exactly — cross-platform `Process.Start` (xdg-open / open / explorer) with a no-op guard when the file does not exist. Required by Phase 5 (search ViewModel click-to-open).

## Type of change

- [x] Feature

## Related issues / links

Closes #554

## How was this tested?

- [x] Unit tests added/updated

New tests in `GivenAFileOpenerService`:
- No-op when path does not exist (does not throw)
- No-op when path is empty string (does not throw)
- Platform-specific opener selection (Linux → xdg-open, macOS → open, Windows → explorer)
- `GetOpener()` always returns a non-empty string

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — Passed: 1798, Failed: 0
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- `GetOpener()` is `internal static` — accessible via `InternalsVisibleTo` already configured in `AssemblyAttributes.cs`.
- Registered as `Transient` in `ShellServiceExtensions` (stateless service, no shared state).
- `appsettings.json` version bumped `0.8.1` → `0.9.0` (feature).