### PR TITLE
feat(onedrive-sync-client): add IFileTypeClassifier to OneDrive sync client

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenASyncClientFileTypeClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Classifications/GivenASyncClientFileTypeClassifier.cs
@@ -1,0 +1,153 @@
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Classifications;
+
+public sealed class GivenASyncClientFileTypeClassifier
+{
+    private readonly SyncClientFileTypeClassifier sut = new();
+
+    [Theory]
+    [InlineData(".jpg")]
+    [InlineData(".jpeg")]
+    [InlineData(".png")]
+    [InlineData(".gif")]
+    [InlineData(".bmp")]
+    [InlineData(".tiff")]
+    [InlineData(".tif")]
+    [InlineData(".webp")]
+    [InlineData(".svg")]
+    [InlineData(".heic")]
+    [InlineData(".raw")]
+    [InlineData(".ico")]
+    [InlineData(".avif")]
+    public void when_classifying_image_extension_then_returns_image(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Image);
+
+    [Theory]
+    [InlineData(".pdf")]
+    [InlineData(".doc")]
+    [InlineData(".docx")]
+    [InlineData(".txt")]
+    [InlineData(".rtf")]
+    [InlineData(".odt")]
+    [InlineData(".md")]
+    [InlineData(".pages")]
+    [InlineData(".epub")]
+    public void when_classifying_document_extension_then_returns_document(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Document);
+
+    [Theory]
+    [InlineData(".xls")]
+    [InlineData(".xlsx")]
+    [InlineData(".csv")]
+    [InlineData(".ods")]
+    [InlineData(".numbers")]
+    public void when_classifying_spreadsheet_extension_then_returns_spreadsheet(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Spreadsheet);
+
+    [Theory]
+    [InlineData(".ppt")]
+    [InlineData(".pptx")]
+    [InlineData(".odp")]
+    [InlineData(".key")]
+    public void when_classifying_presentation_extension_then_returns_presentation(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Presentation);
+
+    [Theory]
+    [InlineData(".mp4")]
+    [InlineData(".avi")]
+    [InlineData(".mov")]
+    [InlineData(".mkv")]
+    [InlineData(".wmv")]
+    [InlineData(".flv")]
+    [InlineData(".webm")]
+    [InlineData(".m4v")]
+    public void when_classifying_video_extension_then_returns_video(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Video);
+
+    [Theory]
+    [InlineData(".mp3")]
+    [InlineData(".wav")]
+    [InlineData(".flac")]
+    [InlineData(".aac")]
+    [InlineData(".ogg")]
+    [InlineData(".m4a")]
+    [InlineData(".wma")]
+    public void when_classifying_audio_extension_then_returns_audio(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Audio);
+
+    [Theory]
+    [InlineData(".zip")]
+    [InlineData(".rar")]
+    [InlineData(".7z")]
+    [InlineData(".tar")]
+    [InlineData(".gz")]
+    [InlineData(".bz2")]
+    [InlineData(".xz")]
+    public void when_classifying_archive_extension_then_returns_archive(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Archive);
+
+    [Theory]
+    [InlineData(".cs")]
+    [InlineData(".py")]
+    [InlineData(".js")]
+    [InlineData(".ts")]
+    [InlineData(".java")]
+    [InlineData(".cpp")]
+    [InlineData(".c")]
+    [InlineData(".h")]
+    [InlineData(".go")]
+    [InlineData(".rs")]
+    [InlineData(".rb")]
+    [InlineData(".php")]
+    [InlineData(".html")]
+    [InlineData(".css")]
+    [InlineData(".json")]
+    [InlineData(".xml")]
+    [InlineData(".yaml")]
+    [InlineData(".yml")]
+    [InlineData(".sh")]
+    [InlineData(".ps1")]
+    [InlineData(".sql")]
+    public void when_classifying_code_extension_then_returns_code(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Code);
+
+    [Theory]
+    [InlineData(".db")]
+    [InlineData(".sqlite")]
+    [InlineData(".sqlite3")]
+    [InlineData(".mdb")]
+    [InlineData(".accdb")]
+    public void when_classifying_database_extension_then_returns_database(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Database);
+
+    [Theory]
+    [InlineData(".exe")]
+    [InlineData(".dll")]
+    [InlineData(".so")]
+    [InlineData(".dylib")]
+    public void when_classifying_executable_extension_then_returns_executable(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Executable);
+
+    [Theory]
+    [InlineData(".xyz")]
+    [InlineData(".unknown")]
+    [InlineData(".foo")]
+    public void when_classifying_unknown_extension_then_returns_unknown(string extension) =>
+        sut.Classify(extension).ShouldBe(FileType.Unknown);
+
+    [Fact]
+    public void when_classifying_empty_string_then_returns_unknown() =>
+        sut.Classify(string.Empty).ShouldBe(FileType.Unknown);
+
+    [Fact]
+    public void when_classifying_null_then_returns_unknown() =>
+        sut.Classify(null!).ShouldBe(FileType.Unknown);
+
+    [Theory]
+    [InlineData(".JPG")]
+    [InlineData(".PNG")]
+    [InlineData(".DOCX")]
+    public void when_classifying_uppercase_extension_then_returns_correct_type(string extension) =>
+        sut.Classify(extension).ShouldNotBe(FileType.Unknown);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileType.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/FileType.cs
@@ -1,0 +1,38 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+/// <summary>Classifies the broad category of a file based on its extension.</summary>
+public enum FileType
+{
+    /// <summary>Image files such as JPEG, PNG, GIF.</summary>
+    Image,
+
+    /// <summary>Document files such as PDF, DOCX, TXT.</summary>
+    Document,
+
+    /// <summary>Spreadsheet files such as XLSX, CSV.</summary>
+    Spreadsheet,
+
+    /// <summary>Presentation files such as PPTX, KEY.</summary>
+    Presentation,
+
+    /// <summary>Video files such as MP4, MKV.</summary>
+    Video,
+
+    /// <summary>Audio files such as MP3, FLAC.</summary>
+    Audio,
+
+    /// <summary>Archive files such as ZIP, TAR.</summary>
+    Archive,
+
+    /// <summary>Source code files such as CS, PY, JS.</summary>
+    Code,
+
+    /// <summary>Database files such as SQLite, MDB.</summary>
+    Database,
+
+    /// <summary>Executable or native library files.</summary>
+    Executable,
+
+    /// <summary>Extension not recognised by the classifier.</summary>
+    Unknown
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileTypeClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/IFileTypeClassifier.cs
@@ -1,0 +1,9 @@
+namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+/// <summary>Classifies a file extension into a broad <see cref="FileType"/> category.</summary>
+public interface IFileTypeClassifier
+{
+    /// <summary>Returns the <see cref="FileType"/> for the given file extension.</summary>
+    /// <param name="fileExtension">The file extension including the leading dot, e.g. <c>.jpg</c>. Null or empty returns <see cref="FileType.Unknown"/>.</param>
+    FileType Classify(string fileExtension);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/SyncClientFileTypeClassifier.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Classifications/SyncClientFileTypeClassifier.cs
@@ -1,0 +1,115 @@
+using System.Collections.Frozen;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Classifications;
+
+/// <summary>Classifies file extensions into broad <see cref="FileType"/> categories for the OneDrive sync client.</summary>
+public sealed class SyncClientFileTypeClassifier : IFileTypeClassifier
+{
+    private static readonly FrozenDictionary<string, FileType> extensionMap =
+        new Dictionary<string, FileType>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".jpg"] = FileType.Image,
+            [".jpeg"] = FileType.Image,
+            [".png"] = FileType.Image,
+            [".gif"] = FileType.Image,
+            [".bmp"] = FileType.Image,
+            [".tiff"] = FileType.Image,
+            [".tif"] = FileType.Image,
+            [".webp"] = FileType.Image,
+            [".svg"] = FileType.Image,
+            [".heic"] = FileType.Image,
+            [".raw"] = FileType.Image,
+            [".ico"] = FileType.Image,
+            [".avif"] = FileType.Image,
+
+            [".pdf"] = FileType.Document,
+            [".doc"] = FileType.Document,
+            [".docx"] = FileType.Document,
+            [".txt"] = FileType.Document,
+            [".rtf"] = FileType.Document,
+            [".odt"] = FileType.Document,
+            [".md"] = FileType.Document,
+            [".pages"] = FileType.Document,
+            [".epub"] = FileType.Document,
+
+            [".xls"] = FileType.Spreadsheet,
+            [".xlsx"] = FileType.Spreadsheet,
+            [".csv"] = FileType.Spreadsheet,
+            [".ods"] = FileType.Spreadsheet,
+            [".numbers"] = FileType.Spreadsheet,
+
+            [".ppt"] = FileType.Presentation,
+            [".pptx"] = FileType.Presentation,
+            [".odp"] = FileType.Presentation,
+            [".key"] = FileType.Presentation,
+
+            [".mp4"] = FileType.Video,
+            [".avi"] = FileType.Video,
+            [".mov"] = FileType.Video,
+            [".mkv"] = FileType.Video,
+            [".wmv"] = FileType.Video,
+            [".flv"] = FileType.Video,
+            [".webm"] = FileType.Video,
+            [".m4v"] = FileType.Video,
+
+            [".mp3"] = FileType.Audio,
+            [".wav"] = FileType.Audio,
+            [".flac"] = FileType.Audio,
+            [".aac"] = FileType.Audio,
+            [".ogg"] = FileType.Audio,
+            [".m4a"] = FileType.Audio,
+            [".wma"] = FileType.Audio,
+
+            [".zip"] = FileType.Archive,
+            [".rar"] = FileType.Archive,
+            [".7z"] = FileType.Archive,
+            [".tar"] = FileType.Archive,
+            [".gz"] = FileType.Archive,
+            [".bz2"] = FileType.Archive,
+            [".xz"] = FileType.Archive,
+
+            [".cs"] = FileType.Code,
+            [".py"] = FileType.Code,
+            [".js"] = FileType.Code,
+            [".ts"] = FileType.Code,
+            [".java"] = FileType.Code,
+            [".cpp"] = FileType.Code,
+            [".c"] = FileType.Code,
+            [".h"] = FileType.Code,
+            [".go"] = FileType.Code,
+            [".rs"] = FileType.Code,
+            [".rb"] = FileType.Code,
+            [".php"] = FileType.Code,
+            [".html"] = FileType.Code,
+            [".css"] = FileType.Code,
+            [".json"] = FileType.Code,
+            [".xml"] = FileType.Code,
+            [".yaml"] = FileType.Code,
+            [".yml"] = FileType.Code,
+            [".sh"] = FileType.Code,
+            [".ps1"] = FileType.Code,
+            [".sql"] = FileType.Code,
+
+            [".db"] = FileType.Database,
+            [".sqlite"] = FileType.Database,
+            [".sqlite3"] = FileType.Database,
+            [".mdb"] = FileType.Database,
+            [".accdb"] = FileType.Database,
+
+            [".exe"] = FileType.Executable,
+            [".dll"] = FileType.Executable,
+            [".so"] = FileType.Executable,
+            [".dylib"] = FileType.Executable,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public FileType Classify(string fileExtension)
+    {
+        if (string.IsNullOrEmpty(fileExtension))
+            return FileType.Unknown;
+
+        return extensionMap.TryGetValue(fileExtension, out FileType type)
+            ? type
+            : FileType.Unknown;
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ShellServiceExtensions.cs
@@ -71,6 +71,7 @@ internal static class ShellServiceExtensions
         _ = services.AddSingleton<IFilePickerService, AvaloniaFilePickerService>();
         _ = services.AddSingleton<IConfirmationDialogService, AvaloniaConfirmationDialogService>();
         _ = services.AddSingleton<IFileClassificationExportImportService, FileClassificationExportImportService>();
+        _ = services.AddSingleton<IFileTypeClassifier, SyncClientFileTypeClassifier>();
         _ = services.AddOneDriveClient();
 
         return services;

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.8.1",
+    "ApplicationVersion": "0.9.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Adds `IFileTypeClassifier` / `SyncClientFileTypeClassifier` to the OneDrive sync client. Maps file extensions to a `FileType` enum (Image, Document, Spreadsheet, Presentation, Video, Audio, Archive, Code, Database, Executable, Unknown). Required by Phase 5 to drive thumbnail-vs-icon display logic in search results.

`FileTypeClassifier` from `AStar.Dev.File.App` cannot be referenced from the sync client (different app, no shared dependency), so the extension map is duplicated here. A follow-up issue to extract it to a shared NuGet package should be raised.

## Type of change

- [x] Feature

## Related issues / links

Closes #555

## How was this tested?

- [x] Unit tests added/updated

91 new theory-based tests in `GivenASyncClientFileTypeClassifier` covering all extension categories:
- Image, Document, Spreadsheet, Presentation, Video, Audio, Archive, Code, Database, Executable
- Unknown extension → `FileType.Unknown`
- Empty / null extension → `FileType.Unknown`
- Case-insensitive matching (`.JPG` → `Image`)

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — Passed: 1883, Failed: 0
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [x] Documentation updated (if applicable)
- [x] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- `FrozenDictionary` used for the extension map (read-only lookup built at startup, idiomatic .NET 10).
- `FileType` enum duplicated in `Classifications/` namespace — extraction to a shared NuGet is a follow-up.
- Registered as `Singleton` in `ShellServiceExtensions` (stateless, single shared instance is safe).
- `appsettings.json` version bumped `0.8.1` → `0.9.0` (feature).