### PR TITLE
feat(onedrive-sync-client): add SearchAsync to ISyncedItemRepository (#553)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncedItemRepository.cs
@@ -1,0 +1,188 @@
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Data.Repositories;
+
+public sealed class GivenASyncedItemRepository
+{
+    private static SyncedItemEntity FileItem(string accountId = "user-1", string remotePath = "/file.txt", long? sizeInBytes = 1024, bool isFolder = false) => new()
+    {
+        AccountId = new AccountId(accountId),
+        RemoteItemId = new OneDriveItemId(Guid.NewGuid().ToString()),
+        RemotePath = remotePath,
+        LocalPath = "/local" + remotePath,
+        IsFolder = isFolder,
+        RemoteModifiedAt = DateTimeOffset.UtcNow,
+        SizeInBytes = sizeInBytes
+    };
+
+    private static (AppDbContext seedingContext, IDbContextFactory<AppDbContext> factory) CreateInMemoryFactory()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var seedingContext = new AppDbContext(options);
+        _ = seedingContext.Database.EnsureCreated();
+        var factory = Substitute.For<IDbContextFactory<AppDbContext>>();
+        factory.CreateDbContextAsync(Arg.Any<CancellationToken>()).Returns(_ => Task.FromResult(new AppDbContext(options)));
+
+        return (seedingContext, factory);
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_name_fragment_then_only_matching_items_are_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/docs/report.pdf"));
+        db.SyncedItems.Add(FileItem(remotePath: "/photos/holiday.jpg"));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), nameFragment: "report");
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/docs/report.pdf");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_min_bytes_then_items_below_threshold_are_excluded()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/small.txt", sizeInBytes: 100));
+        db.SyncedItems.Add(FileItem(remotePath: "/large.bin", sizeInBytes: 5000));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), minBytes: 1000);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/large.bin");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_max_bytes_then_items_above_threshold_are_excluded()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/small.txt", sizeInBytes: 100));
+        db.SyncedItems.Add(FileItem(remotePath: "/large.bin", sizeInBytes: 5000));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), maxBytes: 500);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/small.txt");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_size_filter_and_item_has_null_size_then_item_is_excluded()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/unknown-size.bin", sizeInBytes: null));
+        db.SyncedItems.Add(FileItem(remotePath: "/known.txt", sizeInBytes: 500));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), minBytes: 100);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/known.txt");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_tag_filter_then_only_tagged_items_are_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        var taggedItem = FileItem(remotePath: "/photo.jpg");
+        var untaggedItem = FileItem(remotePath: "/doc.txt");
+        db.SyncedItems.AddRange(taggedItem, untaggedItem);
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = taggedItem.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), tags: ["Image"]);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/photo.jpg");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_duplicates_only_then_only_duplicate_files_are_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/docs/file.pdf", sizeInBytes: 2048));
+        db.SyncedItems.Add(FileItem(remotePath: "/backup/file.pdf", sizeInBytes: 2048));
+        db.SyncedItems.Add(FileItem(remotePath: "/unique.txt", sizeInBytes: 999));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), duplicatesOnly: true);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+        results.ShouldAllBe(r => r.RemotePath.EndsWith("file.pdf"));
+    }
+
+    [Fact]
+    public async Task when_search_is_called_then_folders_are_always_excluded()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/docs", isFolder: true));
+        db.SyncedItems.Add(FileItem(remotePath: "/docs/file.txt", isFolder: false));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"));
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/docs/file.txt");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_with_combined_name_and_size_criteria_then_both_filters_apply()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/docs/report.pdf", sizeInBytes: 5000));
+        db.SyncedItems.Add(FileItem(remotePath: "/docs/summary.pdf", sizeInBytes: 100));
+        db.SyncedItems.Add(FileItem(remotePath: "/photos/photo.jpg", sizeInBytes: 5000));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"), nameFragment: ".pdf", minBytes: 1000);
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].RemotePath.ShouldBe("/docs/report.pdf");
+    }
+
+    [Fact]
+    public async Task when_search_is_called_then_tag_names_are_populated_in_result()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        var item = FileItem(remotePath: "/photo.jpg");
+        db.SyncedItems.Add(item);
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = item.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = item.Id, Level1 = "Media", TagName = "Media", IsSpecial = false });
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var criteria = SyncedItemSearchCriteriaFactory.Create(new AccountId("user-1"));
+
+        var results = await repository.SearchAsync(criteria, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(1);
+        results[0].TagNames.Count.ShouldBe(2);
+        results[0].TagNames.ShouldContain("Image");
+        results[0].TagNames.ShouldContain("Media");
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
@@ -21,4 +21,7 @@ public interface ISyncedItemRepository
 
     /// <summary>Removes all synced items for the specified account. Used when clearing state before a full re-enumeration.</summary>
     Task DeleteAllAsync(AccountId accountId, CancellationToken cancellationToken);
+
+    /// <summary>Searches synced items for the specified account using the provided criteria.</summary>
+    Task<IReadOnlyList<SyncedItemSearchResult>> SearchAsync(SyncedItemSearchCriteria criteria, CancellationToken cancellationToken);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -85,4 +85,6 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
                    .Where(i => i.AccountId == accountId)
                    .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    public Task<IReadOnlyList<SyncedItemSearchResult>> SearchAsync(SyncedItemSearchCriteria criteria, CancellationToken cancellationToken) => throw new NotImplementedException();
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -86,5 +86,57 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
                    .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public Task<IReadOnlyList<SyncedItemSearchResult>> SearchAsync(SyncedItemSearchCriteria criteria, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public async Task<IReadOnlyList<SyncedItemSearchResult>> SearchAsync(SyncedItemSearchCriteria criteria, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = db.SyncedItems.Where(i => i.AccountId == criteria.AccountId && !i.IsFolder);
+
+        if (!string.IsNullOrEmpty(criteria.NameFragment))
+            query = query.Where(i => i.RemotePath.Contains(criteria.NameFragment));
+
+        if (criteria.MinBytes.HasValue)
+            query = query.Where(i => i.SizeInBytes != null && i.SizeInBytes >= criteria.MinBytes.Value);
+
+        if (criteria.MaxBytes.HasValue)
+            query = query.Where(i => i.SizeInBytes != null && i.SizeInBytes <= criteria.MaxBytes.Value);
+
+        if (criteria.Tags.Count > 0)
+        {
+            var tagList = criteria.Tags.ToList();
+            query = query.Where(i => db.SyncedItemClassifications.Any(c => c.SyncedItemId == i.Id && tagList.Contains(c.TagName)));
+        }
+
+        if (criteria.DuplicatesOnly)
+        {
+            var candidates = await db.SyncedItems
+                .Where(i => i.AccountId == criteria.AccountId && !i.IsFolder && i.SizeInBytes != null)
+                .Select(i => new { i.Id, i.SizeInBytes, FileName = i.RemotePath.Substring(i.RemotePath.LastIndexOf('/') + 1) })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var duplicateIds = candidates
+                .GroupBy(i => new { i.SizeInBytes, i.FileName })
+                .Where(g => g.Count() > 1)
+                .SelectMany(g => g.Select(i => i.Id))
+                .ToHashSet();
+
+            query = query.Where(i => duplicateIds.Contains(i.Id));
+        }
+
+        var items = await query
+            .Select(i => new
+            {
+                i.Id,
+                i.AccountId,
+                i.RemoteItemId,
+                i.RemotePath,
+                i.LocalPath,
+                i.RemoteModifiedAt,
+                i.SizeInBytes,
+                TagNames = db.SyncedItemClassifications.Where(c => c.SyncedItemId == i.Id).Select(c => c.TagName).ToList()
+            })
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return items.Select(i => SyncedItemSearchResultFactory.Create(i.Id, i.AccountId, i.RemoteItemId, i.RemotePath, i.LocalPath, i.RemoteModifiedAt, i.SizeInBytes, i.TagNames)).ToList();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchCriteria.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchCriteria.cs
@@ -1,0 +1,6 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Criteria for searching synced items in the repository.</summary>
+public sealed record SyncedItemSearchCriteria(AccountId AccountId, string? NameFragment, long? MinBytes, long? MaxBytes, IReadOnlyList<string> Tags, bool DuplicatesOnly);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchCriteriaFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchCriteriaFactory.cs
@@ -1,0 +1,10 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncedItemSearchCriteria"/>.</summary>
+public static class SyncedItemSearchCriteriaFactory
+{
+    /// <summary>Creates a <see cref="SyncedItemSearchCriteria"/> with the specified search parameters.</summary>
+    public static SyncedItemSearchCriteria Create(AccountId accountId, string? nameFragment = null, long? minBytes = null, long? maxBytes = null, IReadOnlyList<string>? tags = null, bool duplicatesOnly = false) => new(accountId, nameFragment, minBytes, maxBytes, tags ?? [], duplicatesOnly);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchResult.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchResult.cs
@@ -1,0 +1,6 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>A single result from a synced-item search query.</summary>
+public sealed record SyncedItemSearchResult(int Id, AccountId AccountId, OneDriveItemId RemoteItemId, string RemotePath, string LocalPath, DateTimeOffset RemoteModifiedAt, long? SizeInBytes, IReadOnlyList<string> TagNames);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchResultFactory.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Domain/SyncedItemSearchResultFactory.cs
@@ -1,0 +1,10 @@
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Domain;
+
+/// <summary>Factory for <see cref="SyncedItemSearchResult"/>.</summary>
+public static class SyncedItemSearchResultFactory
+{
+    /// <summary>Creates a <see cref="SyncedItemSearchResult"/> from the provided field values.</summary>
+    public static SyncedItemSearchResult Create(int id, AccountId accountId, OneDriveItemId remoteItemId, string remotePath, string localPath, DateTimeOffset remoteModifiedAt, long? sizeInBytes, IReadOnlyList<string> tagNames) => new(id, accountId, remoteItemId, remotePath, localPath, remoteModifiedAt, sizeInBytes, tagNames);
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.9.0",
+    "ApplicationVersion": "0.9.1",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Implements Phase 2 of the `file-search-with-thumbnails` feature — a query API on `ISyncedItemRepository` to drive the search panel.

## Type of change

- [x] Feature

## Related issues / links

Closes #553

## How was this tested?

- [x] Unit tests added/updated

9 new unit tests in `GivenASyncedItemRepository` covering:
- Name fragment filter
- Min/max byte size filters
- Null-size exclusion when size filter is active
- Tag filter (via `SyncedItemClassificationEntity`)
- Duplicates-only toggle (groups by filename + size, materialises IDs first to avoid untranslatable EF subquery)
- Folder exclusion (always excluded regardless of criteria)
- Combined name + size filter
- TagNames populated in result

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

New types:
- `Domain/SyncedItemSearchCriteria` + `SyncedItemSearchCriteriaFactory`
- `Domain/SyncedItemSearchResult` + `SyncedItemSearchResultFactory`

Modified:
- `Data/Repositories/ISyncedItemRepository` — added `SearchAsync`
- `Data/Repositories/SyncedItemRepository` — implemented `SearchAsync`
- `appsettings.json` — version bumped to 0.9.1

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`) — 1902/1902 pass, 0 regressions
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/AStar.Dev.OneDrive.Sync.Client.Tests.Unit.csproj --filter "GivenASyncedItemRepository"
```

---

## Notes for reviewers

Duplicate detection materialises a candidate ID set to a `HashSet<int>` before the outer filter — EF Core cannot translate `GroupBy+SelectMany` as an embedded correlated subquery on either InMemory or SQLite providers.