### PR TITLE
feat(onedrive-sync-client): add SyncedFileResultViewModel and SyncedFileSearchViewModel

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
@@ -1,0 +1,131 @@
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Search;
+using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Search;
+
+public sealed class GivenASyncedFileSearchViewModel
+{
+    private static readonly AccountId TestAccountId = new("acc-1");
+    private static readonly OneDriveItemId TestItemId = new("item-1");
+
+    private readonly ISyncedItemRepository repository = Substitute.For<ISyncedItemRepository>();
+    private readonly IFileOpenerService fileOpenerService = Substitute.For<IFileOpenerService>();
+    private readonly IFileTypeClassifier fileTypeClassifier = Substitute.For<IFileTypeClassifier>();
+    private readonly IAccountRepository accountRepository = Substitute.For<IAccountRepository>();
+    private readonly IUiDispatcher dispatcher = new InlineUiDispatcher();
+
+    private SyncedFileSearchViewModel CreateSut()
+    {
+        var vm = new SyncedFileSearchViewModel(repository, fileOpenerService, fileTypeClassifier, accountRepository, dispatcher);
+        vm.SetActiveAccount(TestAccountId);
+        return vm;
+    }
+
+    private static SyncedItemSearchResult MakeResult(string localPath = "/tmp/nonexistent_file_astar.jpg", IReadOnlyList<string>? tags = null) => new(1, TestAccountId, TestItemId, "/remote/file.jpg", localPath, DateTimeOffset.UtcNow, 1024, tags ?? []);
+
+    [Fact]
+    public async Task when_search_executes_then_criteria_name_fragment_matches_view_model_property()
+    {
+        SyncedItemSearchCriteria? captured = null;
+        repository.SearchAsync(Arg.Do<SyncedItemSearchCriteria>(c => captured = c), Arg.Any<CancellationToken>()).Returns([]);
+        var sut = CreateSut();
+        sut.NameFragment = "report";
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        captured!.NameFragment.ShouldBe("report");
+    }
+
+    [Fact]
+    public async Task when_search_executes_then_criteria_min_size_matches_view_model_property()
+    {
+        SyncedItemSearchCriteria? captured = null;
+        repository.SearchAsync(Arg.Do<SyncedItemSearchCriteria>(c => captured = c), Arg.Any<CancellationToken>()).Returns([]);
+        var sut = CreateSut();
+        sut.MinSize = 1024;
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        captured!.MinBytes.ShouldBe(1024);
+    }
+
+    [Fact]
+    public async Task when_search_executes_then_criteria_max_size_matches_view_model_property()
+    {
+        SyncedItemSearchCriteria? captured = null;
+        repository.SearchAsync(Arg.Do<SyncedItemSearchCriteria>(c => captured = c), Arg.Any<CancellationToken>()).Returns([]);
+        var sut = CreateSut();
+        sut.MaxSize = 1_048_576;
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        captured!.MaxBytes.ShouldBe(1_048_576);
+    }
+
+    [Fact]
+    public async Task when_search_executes_then_criteria_duplicates_only_matches_view_model_property()
+    {
+        SyncedItemSearchCriteria? captured = null;
+        repository.SearchAsync(Arg.Do<SyncedItemSearchCriteria>(c => captured = c), Arg.Any<CancellationToken>()).Returns([]);
+        var sut = CreateSut();
+        sut.DuplicatesOnly = true;
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        captured!.DuplicatesOnly.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task when_search_returns_results_then_results_collection_is_populated()
+    {
+        repository.SearchAsync(Arg.Any<SyncedItemSearchCriteria>(), Arg.Any<CancellationToken>()).Returns([MakeResult(), MakeResult()]);
+        var sut = CreateSut();
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        sut.Results.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task when_search_returns_results_then_result_count_is_updated()
+    {
+        repository.SearchAsync(Arg.Any<SyncedItemSearchCriteria>(), Arg.Any<CancellationToken>()).Returns([MakeResult(), MakeResult(), MakeResult()]);
+        var sut = CreateSut();
+
+        await sut.SearchCommand.ExecuteAsync(null);
+
+        sut.ResultCount.ShouldBe(3);
+    }
+
+    [Fact]
+    public void when_duplicates_only_is_true_then_show_duplicate_disclaimer_is_true()
+    {
+        var sut = CreateSut();
+        sut.DuplicatesOnly = true;
+
+        sut.ShowDuplicateDisclaimer.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void when_duplicates_only_is_false_then_show_duplicate_disclaimer_is_false()
+    {
+        var sut = CreateSut();
+        sut.DuplicatesOnly = false;
+
+        sut.ShowDuplicateDisclaimer.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_result_local_path_does_not_exist_then_open_file_command_is_disabled()
+    {
+        var result = MakeResult(localPath: "/this/path/does/not/exist/astar_test_file.jpg");
+        var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
+
+        vm.OpenFileCommand.CanExecute(null).ShouldBeFalse();
+    }
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileResultViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileResultViewModel.cs
@@ -1,0 +1,63 @@
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Search;
+
+public sealed partial class SyncedFileResultViewModel : ObservableObject
+{
+    private readonly IFileOpenerService fileOpenerService;
+    private readonly IUiDispatcher dispatcher;
+
+    public SyncedFileResultViewModel(SyncedItemSearchResult result, IFileTypeClassifier fileTypeClassifier, IFileOpenerService fileOpenerService, IUiDispatcher dispatcher)
+    {
+        this.fileOpenerService = fileOpenerService;
+        this.dispatcher = dispatcher;
+        FileName = Path.GetFileName(result.LocalPath);
+        FormattedSize = FormatSize(result.SizeInBytes);
+        TagName = string.Join(", ", result.TagNames);
+        LocalPath = result.LocalPath;
+        FileType = fileTypeClassifier.Classify(Path.GetExtension(result.LocalPath));
+        IsLocalPresent = File.Exists(result.LocalPath);
+    }
+
+    public string FileName { get; }
+    public string FormattedSize { get; }
+    public string TagName { get; }
+    public string LocalPath { get; }
+    public FileType FileType { get; }
+    public bool IsLocalPresent { get; }
+
+    [ObservableProperty]
+    public partial IImage? Thumbnail { get; set; }
+
+    [RelayCommand(CanExecute = nameof(IsLocalPresent))]
+    private void OpenFile() => fileOpenerService.OpenFile(LocalPath);
+
+    public async Task LoadThumbnailAsync()
+    {
+        if (!IsLocalPresent || FileType != FileType.Image)
+            return;
+
+        var bitmap = await Task.Run(() =>
+        {
+            using var stream = File.OpenRead(LocalPath);
+            return Avalonia.Media.Imaging.Bitmap.DecodeToWidth(stream, 150);
+        });
+
+        dispatcher.Post(() => Thumbnail = bitmap);
+    }
+
+    private static string FormatSize(long? bytes) => bytes switch
+    {
+        null => string.Empty,
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        < 1024L * 1024 * 1024 => $"{bytes / (1024.0 * 1024):F1} MB",
+        _ => $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
+    };
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
@@ -1,0 +1,80 @@
+using System.Collections.ObjectModel;
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
+using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Search;
+
+public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repository, IFileOpenerService fileOpenerService, IFileTypeClassifier fileTypeClassifier, IAccountRepository accountRepository, IUiDispatcher dispatcher) : ObservableObject
+{
+    private readonly IAccountRepository accountRepository = accountRepository;
+    private AccountId? activeAccountId;
+
+    [ObservableProperty]
+    public partial string? NameFragment { get; set; }
+
+    [ObservableProperty]
+    public partial long? MinSize { get; set; }
+
+    [ObservableProperty]
+    public partial long? MaxSize { get; set; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowDuplicateDisclaimer))]
+    public partial bool DuplicatesOnly { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsSearching { get; set; }
+
+    [ObservableProperty]
+    public partial int ResultCount { get; private set; }
+
+    public ObservableCollection<SyncedFileResultViewModel> Results { get; } = [];
+    public ObservableCollection<string> SelectedTags { get; } = [];
+    public ObservableCollection<string> AvailableTags { get; } = [];
+
+    public bool ShowDuplicateDisclaimer => DuplicatesOnly;
+
+    public void SetActiveAccount(AccountId accountId) => activeAccountId = accountId;
+
+    [RelayCommand]
+    private async Task SearchAsync(CancellationToken cancellationToken)
+    {
+        if (activeAccountId is null)
+            return;
+
+        IsSearching = true;
+        Results.Clear();
+        ResultCount = 0;
+
+        try
+        {
+            var criteria = SyncedItemSearchCriteriaFactory.Create(
+                activeAccountId.Value,
+                string.IsNullOrWhiteSpace(NameFragment) ? null : NameFragment,
+                MinSize,
+                MaxSize,
+                SelectedTags.Count > 0 ? [.. SelectedTags] : null,
+                DuplicatesOnly);
+
+            var results = await repository.SearchAsync(criteria, cancellationToken);
+
+            dispatcher.Post(() =>
+            {
+                foreach (var result in results)
+                    Results.Add(new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher));
+
+                ResultCount = Results.Count;
+            });
+        }
+        finally
+        {
+            IsSearching = false;
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Implements Phase 5 of the `file-search-with-thumbnails` feature (issue #556). Adds the ViewModel pair that drives the synced-file search UI:

- **`SyncedFileResultViewModel`** — represents one result card. Populates `FileName`, `FormattedSize`, `TagName`, `LocalPath`, `FileType`, `IsLocalPresent`, and `Thumbnail (IImage?)`. `OpenFileCommand` is gated on `IsLocalPresent`. `LoadThumbnailAsync()` decodes image files on a background thread via `Bitmap.DecodeToWidth(stream, 150)` then marshals the result to the UI thread via `IUiDispatcher`.
- **`SyncedFileSearchViewModel`** — holds search criteria (`NameFragment`, `MinSize`, `MaxSize`, `SelectedTags`, `DuplicatesOnly`), `SearchCommand` (builds `SyncedItemSearchCriteria` → calls `ISyncedItemRepository.SearchAsync` → maps results), `ResultCount`, `IsSearching`, `ShowDuplicateDisclaimer`, `AvailableTags`. `SetActiveAccount(AccountId)` is called by the shell before first search.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #556

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

Nine new unit tests in `GivenASyncedFileSearchViewModel` cover:
- Criteria building (NameFragment, MinSize, MaxSize, DuplicatesOnly)
- Result mapping and collection population
- `ResultCount` updated after search
- `ShowDuplicateDisclaimer` toggling with `DuplicatesOnly`
- `OpenFileCommand` disabled when local path does not exist

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/`
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/`

---

## TDD Checklist (required)

- [x] Builds locally
- [x] Tests pass (`dotnet test`)
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/
```

---

## Notes for reviewers

- `accountRepository` is stored as a field (unused in Phase 5) — wired for Phase 7 when `AvailableTags` loading is added.
- Thumbnail loading is intentionally untested at unit level (requires real image file + Avalonia bitmap pipeline); integration/UI tests cover this in Phase 6.
- DI registration (`ViewModelExtensions`) and nav wiring are Phase 7 (issue to be raised separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)