### PR TITLE
feat(onedrive-sync-client): add SyncedFileSearchView — Phase 6 (#557)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Assets/GivenTheSearchLocalisationKeys.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Assets/GivenTheSearchLocalisationKeys.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Assets;
+
+public sealed class GivenTheSearchLocalisationKeys
+{
+    private static readonly string JsonPath = Path.GetFullPath(
+        Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            "..", "..", "..", "..", "..", "apps", "desktop", "AStar.Dev.OneDrive.Sync.Client", "Assets", "Localization", "en-GB.json"));
+
+    private static JsonElement RootElement()
+    {
+        var json = File.ReadAllText(JsonPath);
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    [Fact]
+    public void when_read_then_search_title_key_exists() =>
+        RootElement().TryGetProperty("Search.Title", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_name_label_key_exists() =>
+        RootElement().TryGetProperty("Search.Name.Label", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_name_placeholder_key_exists() =>
+        RootElement().TryGetProperty("Search.Name.Placeholder", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_min_size_label_key_exists() =>
+        RootElement().TryGetProperty("Search.MinSize.Label", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_max_size_label_key_exists() =>
+        RootElement().TryGetProperty("Search.MaxSize.Label", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_tags_label_key_exists() =>
+        RootElement().TryGetProperty("Search.Tags.Label", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_duplicates_only_label_key_exists() =>
+        RootElement().TryGetProperty("Search.DuplicatesOnly.Label", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_button_key_exists() =>
+        RootElement().TryGetProperty("Search.Button", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_duplicate_disclaimer_key_exists() =>
+        RootElement().TryGetProperty("Search.DuplicateDisclaimer", out _).ShouldBeTrue();
+
+    [Fact]
+    public void when_read_then_search_no_results_key_exists() =>
+        RootElement().TryGetProperty("Search.NoResults", out _).ShouldBeTrue();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
@@ -3,6 +3,7 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 
@@ -18,10 +19,11 @@ public sealed class GivenASyncedFileSearchViewModel
     private readonly IFileTypeClassifier fileTypeClassifier = Substitute.For<IFileTypeClassifier>();
     private readonly IAccountRepository accountRepository = Substitute.For<IAccountRepository>();
     private readonly IUiDispatcher dispatcher = new InlineUiDispatcher();
+    private readonly ILocalizationService loc = Substitute.For<ILocalizationService>();
 
     private SyncedFileSearchViewModel CreateSut()
     {
-        var vm = new SyncedFileSearchViewModel(repository, fileOpenerService, fileTypeClassifier, accountRepository, dispatcher);
+        var vm = new SyncedFileSearchViewModel(repository, fileOpenerService, fileTypeClassifier, accountRepository, dispatcher, loc);
         vm.SetActiveAccount(TestAccountId);
         return vm;
     }
@@ -127,5 +129,51 @@ public sealed class GivenASyncedFileSearchViewModel
         var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
 
         vm.OpenFileCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void when_instantiated_then_search_title_text_delegates_to_localisation_service()
+    {
+        loc.GetLocal("Search.Title").Returns("Search files");
+        var sut = CreateSut();
+
+        sut.SearchTitleText.ShouldBe("Search files");
+    }
+
+    [Fact]
+    public void when_instantiated_then_search_button_text_delegates_to_localisation_service()
+    {
+        loc.GetLocal("Search.Button").Returns("Search");
+        var sut = CreateSut();
+
+        sut.SearchButtonText.ShouldBe("Search");
+    }
+
+    [Fact]
+    public void when_instantiated_then_duplicate_disclaimer_text_delegates_to_localisation_service()
+    {
+        loc.GetLocal("Search.DuplicateDisclaimer").Returns("Showing duplicate files only.");
+        var sut = CreateSut();
+
+        sut.DuplicateDisclaimerText.ShouldBe("Showing duplicate files only.");
+    }
+
+    [Fact]
+    public void when_result_is_not_local_present_then_card_opacity_is_reduced()
+    {
+        var result = MakeResult(localPath: "/this/path/does/not/exist/astar_test_file.jpg");
+        var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
+
+        vm.CardOpacity.ShouldBe(0.4);
+    }
+
+    [Fact]
+    public void when_result_is_local_present_then_card_opacity_is_full()
+    {
+        fileTypeClassifier.Classify(Arg.Any<string>()).Returns(FileType.Document);
+        var result = MakeResult(localPath: "/tmp/nonexistent_file_astar.jpg");
+        var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
+
+        vm.CardOpacity.ShouldBe(1.0);
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
@@ -170,10 +170,18 @@ public sealed class GivenASyncedFileSearchViewModel
     [Fact]
     public void when_result_is_local_present_then_card_opacity_is_full()
     {
-        fileTypeClassifier.Classify(Arg.Any<string>()).Returns(FileType.Document);
-        var result = MakeResult(localPath: "/tmp/nonexistent_file_astar.jpg");
-        var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
+        var existingPath = Path.GetTempFileName();
+        try
+        {
+            fileTypeClassifier.Classify(Arg.Any<string>()).Returns(FileType.Document);
+            var result = MakeResult(localPath: existingPath);
+            var vm = new SyncedFileResultViewModel(result, fileTypeClassifier, fileOpenerService, dispatcher);
 
-        vm.CardOpacity.ShouldBe(1.0);
+            vm.CardOpacity.ShouldBe(1.0);
+        }
+        finally
+        {
+            File.Delete(existingPath);
+        }
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -199,5 +199,15 @@
   "Sync.NoChanges":                "No changes",
   "Dashboard.NoSyncPath": "No local sync path configured",
   "Dashboard.Pending": "Pending",
-  "Dashboard.AllSynced": "All synced"
+  "Dashboard.AllSynced": "All synced",
+  "Search.Title": "Search files",
+  "Search.Name.Label": "Name",
+  "Search.Name.Placeholder": "Enter filename...",
+  "Search.MinSize.Label": "Min size (bytes)",
+  "Search.MaxSize.Label": "Max size (bytes)",
+  "Search.Tags.Label": "Tags",
+  "Search.DuplicatesOnly.Label": "Duplicates only",
+  "Search.Button": "Search",
+  "Search.DuplicateDisclaimer": "Showing duplicate files only.",
+  "Search.NoResults": "No results found."
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
@@ -199,5 +199,15 @@
   "Sync.NoChanges":                "US-No changes",
   "Dashboard.NoSyncPath": "US-No local sync path configured",
   "Dashboard.Pending": "US-Pending",
-  "Dashboard.AllSynced": "US-All synced"
+  "Dashboard.AllSynced": "US-All synced",
+  "Search.Title": "US-Search files",
+  "Search.Name.Label": "US-Name",
+  "Search.Name.Placeholder": "US-Enter filename...",
+  "Search.MinSize.Label": "US-Min size (bytes)",
+  "Search.MaxSize.Label": "US-Max size (bytes)",
+  "Search.Tags.Label": "US-Tags",
+  "Search.DuplicatesOnly.Label": "US-Duplicates only",
+  "Search.Button": "US-Search",
+  "Search.DuplicateDisclaimer": "US-Showing duplicate files only.",
+  "Search.NoResults": "US-No results found."
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileResultViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileResultViewModel.cs
@@ -31,6 +31,7 @@ public sealed partial class SyncedFileResultViewModel : ObservableObject
     public string LocalPath { get; }
     public FileType FileType { get; }
     public bool IsLocalPresent { get; }
+    public double CardOpacity => IsLocalPresent ? 1.0 : 0.4;
 
     [ObservableProperty]
     public partial IImage? Thumbnail { get; set; }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml
@@ -1,0 +1,226 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:search="clr-namespace:AStar.Dev.OneDrive.Sync.Client.Search"
+             x:Class="AStar.Dev.OneDrive.Sync.Client.Search.SyncedFileSearchView"
+             x:DataType="search:SyncedFileSearchViewModel"
+             VerticalContentAlignment="Stretch"
+             HorizontalContentAlignment="Stretch">
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- ── Criteria panel (Auto row) ── -->
+        <Border Grid.Row="0"
+                BorderThickness="0,0,0,1"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                Background="{DynamicResource BackgroundSecondaryBrush}"
+                Padding="16,12">
+            <StackPanel Spacing="10">
+
+                <!-- Name field -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{Binding NameLabelText}"
+                               FontSize="{StaticResource FontSizeXs}"
+                               Foreground="{DynamicResource TextTertiaryBrush}"/>
+                    <TextBox Text="{Binding NameFragment}"
+                             PlaceholderText="{Binding NamePlaceholderText}"
+                             FontSize="{StaticResource FontSizeSm}"
+                             CornerRadius="{StaticResource RadiusMd}"/>
+                </StackPanel>
+
+                <!-- Size row -->
+                <Grid ColumnDefinitions="*,8,*">
+                    <StackPanel Grid.Column="0" Spacing="4">
+                        <TextBlock Text="{Binding MinSizeLabelText}"
+                                   FontSize="{StaticResource FontSizeXs}"
+                                   Foreground="{DynamicResource TextTertiaryBrush}"/>
+                        <NumericUpDown Value="{Binding MinSize}"
+                                       Minimum="0"
+                                       Increment="1024"
+                                       FormatString="0"
+                                       FontSize="{StaticResource FontSizeSm}"
+                                       CornerRadius="{StaticResource RadiusMd}"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Spacing="4">
+                        <TextBlock Text="{Binding MaxSizeLabelText}"
+                                   FontSize="{StaticResource FontSizeXs}"
+                                   Foreground="{DynamicResource TextTertiaryBrush}"/>
+                        <NumericUpDown Value="{Binding MaxSize}"
+                                       Minimum="0"
+                                       Increment="1024"
+                                       FormatString="0"
+                                       FontSize="{StaticResource FontSizeSm}"
+                                       CornerRadius="{StaticResource RadiusMd}"/>
+                    </StackPanel>
+                </Grid>
+
+                <!-- Tags multi-select (visible only when tags are available) -->
+                <StackPanel Spacing="4"
+                            IsVisible="{Binding AvailableTags.Count, Converter={StaticResource IntZeroToBoolConverter}, ConverterParameter=negate}">
+                    <TextBlock Text="{Binding TagsLabelText}"
+                               FontSize="{StaticResource FontSizeXs}"
+                               Foreground="{DynamicResource TextTertiaryBrush}"/>
+                    <ItemsControl ItemsSource="{Binding AvailableTags}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type x:String}">
+                                <CheckBox Content="{Binding}"
+                                          Margin="0,0,8,4"
+                                          FontSize="{StaticResource FontSizeSm}"
+                                          Command="{Binding $parent[UserControl].((search:SyncedFileSearchViewModel)DataContext).ToggleTagCommand}"
+                                          CommandParameter="{Binding}"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <!-- Duplicates toggle + Search button -->
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                    <ToggleButton Grid.Column="0"
+                                  Content="{Binding DuplicatesOnlyLabelText}"
+                                  IsChecked="{Binding DuplicatesOnly}"
+                                  Padding="12,6"
+                                  FontSize="{StaticResource FontSizeSm}"
+                                  CornerRadius="{StaticResource RadiusMd}"
+                                  BorderThickness="1"
+                                  BorderBrush="{DynamicResource BorderDefaultBrush}"/>
+                    <Button Grid.Column="2"
+                            Content="{Binding SearchButtonText}"
+                            Command="{Binding SearchCommand}"
+                            Padding="16,6"
+                            CornerRadius="{StaticResource RadiusMd}"
+                            Background="{DynamicResource TextAccentBrush}"
+                            Foreground="White"
+                            BorderThickness="0"
+                            FontSize="{StaticResource FontSizeSm}"/>
+                </Grid>
+
+            </StackPanel>
+        </Border>
+
+        <!-- ── Results area (* row) ── -->
+        <Grid Grid.Row="1" RowDefinitions="Auto,*">
+
+            <!-- Result count badge + duplicate disclaimer + searching indicator -->
+            <Grid Grid.Row="0">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="8"
+                            Margin="16,8">
+                    <Border Background="{DynamicResource BackgroundTertiaryBrush}"
+                            CornerRadius="{StaticResource RadiusSm}"
+                            Padding="8,3">
+                        <TextBlock Text="{Binding ResultCount}"
+                                   FontSize="{StaticResource FontSizeXs}"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+                    </Border>
+                    <TextBlock Text="{Binding DuplicateDisclaimerText}"
+                               FontSize="{StaticResource FontSizeSm}"
+                               Foreground="{DynamicResource TextTertiaryBrush}"
+                               VerticalAlignment="Center"
+                               IsVisible="{Binding ShowDuplicateDisclaimer}"/>
+                </StackPanel>
+                <ProgressBar IsIndeterminate="True"
+                             Height="2"
+                             VerticalAlignment="Bottom"
+                             Foreground="{DynamicResource TextAccentBrush}"
+                             Background="Transparent"
+                             IsVisible="{Binding IsSearching}"/>
+            </Grid>
+
+            <!-- Results ScrollViewer (* row, MinHeight="0" per bounded-viewport rule) -->
+            <ScrollViewer Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          MinHeight="0"
+                          Padding="16,8">
+                <StackPanel>
+
+                    <!-- Empty state -->
+                    <TextBlock Text="{Binding NoResultsText}"
+                               FontSize="{StaticResource FontSizeMd}"
+                               Foreground="{DynamicResource TextTertiaryBrush}"
+                               HorizontalAlignment="Center"
+                               Margin="0,32,0,0"
+                               IsVisible="{Binding ResultCount, Converter={StaticResource IntZeroToBoolConverter}}"/>
+
+                    <!-- Result cards grid -->
+                    <ItemsControl ItemsSource="{Binding Results}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="search:SyncedFileResultViewModel">
+
+                                <Border Width="180"
+                                        Margin="0,0,8,8"
+                                        Opacity="{Binding CardOpacity}"
+                                        Background="{DynamicResource BackgroundSecondaryBrush}"
+                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="{StaticResource RadiusLg}"
+                                        Padding="10">
+
+                                    <StackPanel Spacing="6">
+
+                                        <!-- Thumbnail / placeholder -->
+                                        <Border Width="150" Height="150"
+                                                HorizontalAlignment="Center"
+                                                Background="{DynamicResource BackgroundTertiaryBrush}"
+                                                CornerRadius="{StaticResource RadiusMd}"
+                                                ClipToBounds="True">
+                                            <Image Source="{Binding Thumbnail}"
+                                                   Width="150" Height="150"
+                                                   Stretch="UniformToFill"/>
+                                        </Border>
+
+                                        <!-- Filename -->
+                                        <TextBlock Text="{Binding FileName}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   FontWeight="Medium"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   MaxWidth="160"/>
+
+                                        <!-- Formatted size -->
+                                        <TextBlock Text="{Binding FormattedSize}"
+                                                   FontSize="{StaticResource FontSizeXs}"
+                                                   Foreground="{DynamicResource TextTertiaryBrush}"/>
+
+                                        <!-- Tag name -->
+                                        <TextBlock Text="{Binding TagName}"
+                                                   FontSize="{StaticResource FontSizeXs}"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   MaxWidth="160"
+                                                   IsVisible="{Binding TagName, Converter={StaticResource StringNotEmptyConverter}}"/>
+
+                                        <!-- Open button -->
+                                        <Button Content="Open"
+                                                Command="{Binding OpenFileCommand}"
+                                                HorizontalAlignment="Stretch"
+                                                Padding="8,4"
+                                                FontSize="{StaticResource FontSizeXs}"
+                                                CornerRadius="{StaticResource RadiusSm}"
+                                                BorderThickness="1"
+                                                BorderBrush="{DynamicResource BorderDefaultBrush}"/>
+
+                                    </StackPanel>
+                                </Border>
+
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                </StackPanel>
+            </ScrollViewer>
+
+        </Grid>
+
+    </Grid>
+
+</UserControl>

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Search;
+
+public partial class SyncedFileSearchView : UserControl
+{
+    public SyncedFileSearchView() => InitializeComponent();
+}

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
@@ -5,12 +5,13 @@ using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
+using AStar.Dev.OneDrive.Sync.Client.Localization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Search;
 
-public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repository, IFileOpenerService fileOpenerService, IFileTypeClassifier fileTypeClassifier, IAccountRepository accountRepository, IUiDispatcher dispatcher) : ObservableObject
+public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repository, IFileOpenerService fileOpenerService, IFileTypeClassifier fileTypeClassifier, IAccountRepository accountRepository, IUiDispatcher dispatcher, ILocalizationService loc) : ObservableObject
 {
     private readonly IAccountRepository accountRepository = accountRepository;
     private AccountId? activeAccountId;
@@ -39,6 +40,43 @@ public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repo
     public ObservableCollection<string> AvailableTags { get; } = [];
 
     public bool ShowDuplicateDisclaimer => DuplicatesOnly;
+
+    /// <summary>Localised "Search files" heading.</summary>
+    public string SearchTitleText => loc.GetLocal("Search.Title");
+
+    /// <summary>Localised "Name" field label.</summary>
+    public string NameLabelText => loc.GetLocal("Search.Name.Label");
+
+    /// <summary>Localised placeholder for the name text field.</summary>
+    public string NamePlaceholderText => loc.GetLocal("Search.Name.Placeholder");
+
+    /// <summary>Localised "Min size (bytes)" label.</summary>
+    public string MinSizeLabelText => loc.GetLocal("Search.MinSize.Label");
+
+    /// <summary>Localised "Max size (bytes)" label.</summary>
+    public string MaxSizeLabelText => loc.GetLocal("Search.MaxSize.Label");
+
+    /// <summary>Localised "Tags" label.</summary>
+    public string TagsLabelText => loc.GetLocal("Search.Tags.Label");
+
+    /// <summary>Localised "Duplicates only" toggle label.</summary>
+    public string DuplicatesOnlyLabelText => loc.GetLocal("Search.DuplicatesOnly.Label");
+
+    /// <summary>Localised "Search" button label.</summary>
+    public string SearchButtonText => loc.GetLocal("Search.Button");
+
+    /// <summary>Localised disclaimer shown when DuplicatesOnly is active.</summary>
+    public string DuplicateDisclaimerText => loc.GetLocal("Search.DuplicateDisclaimer");
+
+    /// <summary>Localised "No results found." empty-state message.</summary>
+    public string NoResultsText => loc.GetLocal("Search.NoResults");
+
+    [RelayCommand]
+    private void ToggleTag(string tag)
+    {
+        if (!SelectedTags.Remove(tag))
+            SelectedTags.Add(tag);
+    }
 
     public void SetActiveAccount(AccountId accountId) => activeAccountId = accountId;
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ViewExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ViewExtensions.cs
@@ -2,6 +2,7 @@ using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using AStar.Dev.OneDrive.Sync.Client.Splash;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,7 @@ public static class ViewExtensions
         _ = services.AddSingleton<FilesView>();
         _ = services.AddSingleton<FolderTreeItemView>();
         _ = services.AddSingleton<SettingsView>();
+        _ = services.AddSingleton<SyncedFileSearchView>();
 
         return services;
     }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ViewModelExtensions.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Startup/ViewModelExtensions.cs
@@ -6,6 +6,7 @@ using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using Microsoft.Extensions.DependencyInjection;
 using AccountsViewModel = AStar.Dev.OneDrive.Sync.Client.Accounts.AccountsViewModel;
 using AccountSyncSettingsViewModel = AStar.Dev.OneDrive.Sync.Client.Accounts.AccountSyncSettingsViewModel;
@@ -31,6 +32,7 @@ internal static class ViewModelExtensions
         _ = services.AddSingleton<FileClassificationRulesViewModel>();
         _ = services.AddSingleton<SettingsViewModel>();
         _ = services.AddSingleton<StatusBarViewModel>();
+        _ = services.AddSingleton<SyncedFileSearchViewModel>();
 
         _ = services.AddTransient<AccountSyncSettingsViewModel>();
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.9.1",
+    "ApplicationVersion": "0.10.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
# Summary

Adds the Avalonia XAML search view for the file-search-with-thumbnails feature (Phase 6). Binds to the `SyncedFileSearchViewModel` introduced in Phase 5 and follows the repo's bounded-viewport rule throughout.

## Type of change

- [x] Feature

## Related issues / links

Closes #557

## How was this tested?

- [x] Unit tests added/updated
- [ ] Manual validation
- [ ] Not applicable

## Impacted areas

`apps/desktop/AStar.Dev.OneDrive.Sync.Client`

---

## TDD Checklist (required)

- [x] Builds locally — `dotnet build` 0 errors, 0 warnings
- [x] Tests pass — 1926 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed
- [ ] Documentation updated (if applicable)
- [ ] Not applicable

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit
```

---

## Notes for reviewers

- `SyncedFileSearchView.axaml`: criteria panel in `Auto` row, results `ScrollViewer` in `*` row with `MinHeight="0"` — bounded-viewport rule satisfied.
- Tag CheckBox multi-select fires `ToggleTagCommand` (mutates `SelectedTags`); visual `IsChecked` state is not bidirectionally bound (no suitable converter exists without adding new infrastructure — visual sync is a follow-on concern).
- `SyncedFileResultViewModel.CardOpacity` (1.0 / 0.4) drives disabled card opacity; no new converter needed.
- `ApplicationVersion` bumped `0.9.1 → 0.10.0` per repo convention (feature = minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)