### PR TITLE
feat(onedrive-sync-client): wire Search into main window navigation

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -161,4 +161,14 @@ public sealed class GivenAMainWindowViewModel
 
         await _initializer.Received(1).InitializeAsync(Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public void when_navigate_to_search_then_is_search_active_is_true()
+    {
+        var sut = CreateSut();
+
+        sut.NavigateCommand.Execute(NavSection.Search);
+
+        sut.IsSearchActive.ShouldBeTrue();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Home/GivenAMainWindowViewModel.cs
@@ -18,6 +18,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Extensions.Logging;
@@ -62,12 +63,13 @@ public sealed class GivenAMainWindowViewModel
     }
 
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());
+    private SyncedFileSearchViewModel CreateSearchViewModel() => new(Substitute.For<ISyncedItemRepository>(), Substitute.For<IFileOpenerService>(), Substitute.For<IFileTypeClassifier>(), _accountRepository, Substitute.For<IUiDispatcher>(), _localizationService);
 
     private MainWindowViewModel CreateSut()
     {
         var accountsVm = CreateAccountsViewModel();
 
-        return new(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), CreateClassificationRulesViewModel(), new StatusBarViewModel(accountsVm, _localizationService), _localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
+        return new(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), CreateClassificationRulesViewModel(), CreateSearchViewModel(), new StatusBarViewModel(accountsVm, _localizationService), _localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     [Fact]
@@ -135,7 +137,7 @@ public sealed class GivenAMainWindowViewModel
         const string accountIdStr = "active-account-123";
         var accountsVm = CreateAccountsViewModel();
         accountsVm.ActiveAccount = new AccountCardViewModel(new OneDriveAccount { Id = new AccountId(accountIdStr), Profile = AccountProfileFactory.Create("Test User", "test@example.com") }, _localizationService);
-        var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), CreateClassificationRulesViewModel(), new StatusBarViewModel(accountsVm, _localizationService), _localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
+        var sut = new MainWindowViewModel(_initializer, _scheduler, accountsVm, CreateFilesViewModel(), CreateDashboardViewModel(), CreateActivityViewModel(), CreateSettingsViewModel(), CreateClassificationRulesViewModel(), CreateSearchViewModel(), new StatusBarViewModel(accountsVm, _localizationService), _localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
 
         await sut.SyncNowCommand.ExecuteAsync(null);
 

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnAppBootstrapper.cs
@@ -20,6 +20,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Data.Sqlite;
@@ -88,7 +89,7 @@ public sealed class GivenAnAppBootstrapper : IAsyncDisposable
         var settings = new SettingsViewModel(settingsServiceForViewModel, themeServiceForViewModel, schedulerForViewModel, accountRepository, localizationService, Substitute.For<IFolderPickerService>());
         var statusBar = new StatusBarViewModel(accounts, localizationService);
 
-        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localizationService, fileSystem), statusBar, localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
+        return new MainWindowViewModel(applicationInitializer, syncScheduler, accounts, files, dashboard, activity, settings, new FileClassificationRulesViewModel(classificationRepo, Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localizationService, fileSystem), new SyncedFileSearchViewModel(Substitute.For<ISyncedItemRepository>(), Substitute.For<IFileOpenerService>(), Substitute.For<IFileTypeClassifier>(), accountRepository, new InlineUiDispatcher(), localizationService), statusBar, localizationService, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     private AppBootstrapper CreateSut() => new(dbContextFactory, settingsService, themeService, localizationService, syncScheduler, CreateMainWindowViewModel(), Substitute.For<ILogger<AppBootstrapper>>());

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenAccountsViewDisplay.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Views/GivenAccountsViewDisplay.cs
@@ -18,6 +18,7 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Onboarding;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using Microsoft.Extensions.Logging;
 using System.IO.Abstractions;
@@ -53,7 +54,7 @@ public sealed class GivenAccountsViewDisplay
         var classificationRules = new FileClassificationRulesViewModel(Substitute.For<IFileClassificationRepository>(), Substitute.For<IFileClassificationExportImportService>(), Substitute.For<IFilePickerService>(), Substitute.For<IConfirmationDialogService>(), localization, Substitute.For<IFileSystem>());
         var statusBar = new StatusBarViewModel(accounts, localization);
 
-        return new MainWindowViewModel(Substitute.For<IApplicationInitializer>(), Substitute.For<ISyncScheduler>(), accounts, files, dashboard, activity, settings, classificationRules, statusBar, localization, Substitute.For<ILogger<MainWindowViewModel>>());
+        return new MainWindowViewModel(Substitute.For<IApplicationInitializer>(), Substitute.For<ISyncScheduler>(), accounts, files, dashboard, activity, settings, classificationRules, new SyncedFileSearchViewModel(Substitute.For<ISyncedItemRepository>(), Substitute.For<IFileOpenerService>(), Substitute.For<IFileTypeClassifier>(), Substitute.For<IAccountRepository>(), Substitute.For<IUiDispatcher>(), localization), statusBar, localization, Substitute.For<ILogger<MainWindowViewModel>>());
     }
 
     private static AccountsView CreateViewWithViewModel(MainWindowViewModel viewModel)

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -13,6 +13,7 @@
   "Nav.Tooltip.Accounts": "Accounts — add or remove OneDrive accounts",
   "Nav.Tooltip.Classifications": "Classifications — manage keyword rules",
   "Nav.Tooltip.Settings": "Settings — theme, language and sync policy",
+  "Nav.Tooltip.Search": "Search — find synced files by name, size, or tags",
   "StatusBar.Synced": "Synced",
   "StatusBar.Syncing": "Syncing…",
   "StatusBar.Pending": "{0} pending",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
@@ -13,6 +13,7 @@
   "Nav.Tooltip.Accounts": "US-Accounts — add or remove OneDrive accounts",
   "Nav.Tooltip.Classifications": "US-Classifications — manage keyword rules",
   "Nav.Tooltip.Settings": "US-Settings — theme, language and sync policy",
+  "Nav.Tooltip.Search": "US-Search — find synced files by name, size, or tags",
   "StatusBar.Synced": "US-Synced",
   "StatusBar.Syncing": "US-Syncing…",
   "StatusBar.Pending": "US-{0} pending",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindow.axaml
@@ -65,6 +65,19 @@
             C8.4,10.02 10.02,8.4 12,8.4 C13.98,8.4 15.6,10.02 15.6,12
             C15.6,13.98 13.98,15.6 12,15.6 Z
         </Geometry>
+        <Geometry x:Key="IconSearch">
+            M15.5,14 L14.71,14 L14.43,13.73
+            C15.41,12.59 16,11.11 16,9.5
+            C16,5.91 13.09,3 9.5,3
+            C5.91,3 3,5.91 3,9.5
+            C3,13.09 5.91,16 9.5,16
+            C11.11,16 12.59,15.41 13.73,14.43
+            L14,14.71 L14,15.5 L19,20.49 L20.49,19 L15.5,14 Z
+            M9.5,14 C7.01,14 5,11.99 5,9.5
+            C5,7.01 7.01,5 9.5,5
+            C11.99,5 14,7.01 14,9.5
+            C14,11.99 11.99,14 9.5,14 Z
+        </Geometry>
         <Geometry x:Key="IconClassifications">
             M7,5 L10,8 L19,8 L19,10 L10,10 L7,13 Z
             M7,11 L10,14 L19,14 L19,16 L10,16 L7,19 Z
@@ -126,6 +139,12 @@
                             IsActive="{Binding IsActivityActive}"
                             Command="{Binding NavigateCommand}"
                             CommandParameter="{x:Static local:NavSection.Activity}"/>
+                        <controls:IconRailButton
+                            IconData="{StaticResource IconSearch}"
+                            TooltipLabel="{Binding NavTooltipSearchText}"
+                            IsActive="{Binding IsSearchActive}"
+                            Command="{Binding NavigateCommand}"
+                            CommandParameter="{x:Static local:NavSection.Search}"/>
                         <controls:IconRailButton
                             IconData="{StaticResource IconAccounts}"
                             TooltipLabel="{Binding NavTooltipAccountsText}"

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Home/MainWindowViewModel.cs
@@ -3,10 +3,12 @@ using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Dashboard;
+using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -19,7 +21,7 @@ using SettingsViewModel = AStar.Dev.OneDrive.Sync.Client.Settings.SettingsViewMo
 
 namespace AStar.Dev.OneDrive.Sync.Client.Home;
 
-public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, FileClassificationRulesViewModel classificationRules, StatusBarViewModel statusBar, ILocalizationService localizationService, ILogger<MainWindowViewModel> logger) : ObservableObject
+public sealed partial class MainWindowViewModel(IApplicationInitializer initializer, ISyncScheduler scheduler, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, FileClassificationRulesViewModel classificationRules, SyncedFileSearchViewModel search, StatusBarViewModel statusBar, ILocalizationService localizationService, ILogger<MainWindowViewModel> logger) : ObservableObject
 {
     private readonly ILogger<MainWindowViewModel> logger = logger;
 
@@ -30,6 +32,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
     [NotifyPropertyChangedFor(nameof(IsAccountsActive))]
     [NotifyPropertyChangedFor(nameof(IsClassificationsActive))]
     [NotifyPropertyChangedFor(nameof(IsSettingsActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(ActiveView))]
     public partial NavSection ActiveSection { get; set; } = NavSection.Dashboard;
 
@@ -39,6 +42,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
     public bool IsAccountsActive => ActiveSection == NavSection.Accounts;
     public bool IsClassificationsActive => ActiveSection == NavSection.Classifications;
     public bool IsSettingsActive => ActiveSection == NavSection.Settings;
+    public bool IsSearchActive => ActiveSection == NavSection.Search;
 
     /// <summary>Localised "Accounts" panel heading.</summary>
     public string AccountsPanelHeading => localizationService.GetLocal("MainWindow.Accounts");
@@ -94,6 +98,9 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
     /// <summary>Localised tooltip for the Settings nav rail button.</summary>
     public string NavTooltipSettingsText => localizationService.GetLocal("Nav.Tooltip.Settings");
 
+    /// <summary>Localised tooltip for the Search nav rail button.</summary>
+    public string NavTooltipSearchText => localizationService.GetLocal("Nav.Tooltip.Search");
+
     [RelayCommand]
     private void Navigate(NavSection section) => ActiveSection = section;
 
@@ -105,6 +112,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
         NavSection.Accounts => AccountsViewInstance,
         NavSection.Classifications => FileClassificationsViewInstance,
         NavSection.Settings => SettingsViewInstance,
+        NavSection.Search => SearchViewInstance,
         _ => null
     };
 
@@ -168,6 +176,16 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
         }
     }
 
+    private SyncedFileSearchView SearchViewInstance
+    {
+        get
+        {
+            field ??= new SyncedFileSearchView { DataContext = search };
+
+            return field;
+        }
+    }
+
     public AccountsViewModel Accounts => accounts;
 
     public FilesViewModel Files => files;
@@ -217,6 +235,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
             await Try.RunAsync(async () =>
                 {
                     ActiveSection = NavSection.Files;
+                    search.SetActiveAccount(new AccountId(card.Id));
                     await files.ActivateAccountAsync(card.Id);
                     await activity.SetActiveAccountAsync(card.Id, card.Email);
                     return Unit.Default;
@@ -238,6 +257,7 @@ public sealed partial class MainWindowViewModel(IApplicationInitializer initiali
                     files.AddAccount(account);
                     dashboard.AddAccount(account);
                     settings.AddAccount(account);
+                    search.SetActiveAccount(account.Id);
                     ActiveSection = NavSection.Files;
                     await files.ActivateAccountAsync(account.Id.Id);
                     await activity.SetActiveAccountAsync(account.Id.Id, account.Profile.Email);

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/NavSection.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/NavSection.cs
@@ -14,5 +14,6 @@ public enum NavSection
     Accounts = 5,
     Classifications = 6,
     Settings = 7,
-    Help = 8
+    Help = 8,
+    Search = 9
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.10.0",
+    "ApplicationVersion": "0.11.0",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",


### PR DESCRIPTION
## Summary

- Closes #558 — Phase 7: Navigation Integration
- Adds `NavSection.Search` enum value and wires `SyncedFileSearchViewModel` into `MainWindowViewModel` as a full nav entry
- Search icon rail button now visible in the running app; existing nav items (Dashboard, Files, Activity, Accounts, Classifications, Settings) unaffected
- Bumps `ApplicationVersion` 0.10.0 → 0.11.0 (minor feature bump)

## Changes

| File | Change |
|---|---|
| `NavSection.cs` | Add `Search = 9` |
| `MainWindowViewModel.cs` | Add `search` param; `IsSearchActive`; `NavTooltipSearchText`; `SearchViewInstance`; wire `SetActiveAccount` on account selected/added |
| `MainWindow.axaml` | `IconSearch` geometry; `IconRailButton` for Search in top nav rail |
| `en-GB.json` / `en-US.json` | `Nav.Tooltip.Search` localisation key |
| `appsettings.json` | Version bump 0.10.0 → 0.11.0 |
| Test files (×3) | Updated `MainWindowViewModel` call sites to pass `SyncedFileSearchViewModel`; new `when_navigate_to_search_then_is_search_active_is_true` test |

## Definition of Done

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1927 passed, 0 failed, 0 new failures
- [x] `IsSearchActive` test GREEN; all existing nav tests unaffected
- [x] `SyncedFileSearchViewModel` already registered in DI (`ViewModelExtensions` — done in prior phase)

## Test plan

- [ ] Launch app; confirm Search icon appears in the nav rail between Activity and Accounts
- [ ] Click Search icon; confirm `SyncedFileSearchView` loads in the main content area
- [ ] Navigate to each other section; confirm they still load correctly
- [ ] Select an account; confirm `search.SetActiveAccount` is called (SearchAsync will then work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)