### PR TITLE
fix(onedrive-sync-client): populate AvailableTags and fix tag visibility (#566)

### DIFF
--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Data/Repositories/GivenASyncedItemRepository.cs
@@ -185,4 +185,76 @@ public sealed class GivenASyncedItemRepository
         results[0].TagNames.ShouldContain("Image");
         results[0].TagNames.ShouldContain("Media");
     }
+
+    [Fact]
+    public async Task when_get_distinct_tag_names_is_called_then_distinct_tags_for_account_are_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        var item = FileItem(remotePath: "/photo.jpg");
+        db.SyncedItems.Add(item);
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = item.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = item.Id, Level1 = "Media", TagName = "Media", IsSpecial = false });
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var tags = await repository.GetDistinctTagNamesAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+
+        tags.Count.ShouldBe(2);
+        tags.ShouldContain("Image");
+        tags.ShouldContain("Media");
+    }
+
+    [Fact]
+    public async Task when_get_distinct_tag_names_is_called_for_account_with_no_classifications_then_empty_list_is_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        db.SyncedItems.Add(FileItem(remotePath: "/file.txt"));
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var tags = await repository.GetDistinctTagNamesAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+
+        tags.ShouldNotBeNull();
+        tags.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task when_get_distinct_tag_names_is_called_then_only_tags_for_requested_account_are_returned()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        var itemForAccountOne = FileItem(accountId: "user-1", remotePath: "/photo.jpg");
+        var itemForAccountTwo = FileItem(accountId: "user-2", remotePath: "/video.mp4");
+        db.SyncedItems.AddRange(itemForAccountOne, itemForAccountTwo);
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = itemForAccountOne.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = itemForAccountTwo.Id, Level1 = "Video", TagName = "Video", IsSpecial = false });
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var tags = await repository.GetDistinctTagNamesAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+
+        tags.Count.ShouldBe(1);
+        tags.ShouldContain("Image");
+        tags.ShouldNotContain("Video");
+    }
+
+    [Fact]
+    public async Task when_get_distinct_tag_names_is_called_and_multiple_files_share_the_same_tag_then_tag_appears_once()
+    {
+        var (db, factory) = CreateInMemoryFactory();
+        var repository = new SyncedItemRepository(factory);
+        var firstItem = FileItem(remotePath: "/photo1.jpg");
+        var secondItem = FileItem(remotePath: "/photo2.jpg");
+        db.SyncedItems.AddRange(firstItem, secondItem);
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = firstItem.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        db.SyncedItemClassifications.Add(new SyncedItemClassificationEntity { SyncedItemId = secondItem.Id, Level1 = "Image", TagName = "Image", IsSpecial = false });
+        _ = await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var tags = await repository.GetDistinctTagNamesAsync(new AccountId("user-1"), TestContext.Current.CancellationToken);
+
+        tags.Count.ShouldBe(1);
+        tags[0].ShouldBe("Image");
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Infrastructure/Shell/GivenAnApplicationInitializer.cs
@@ -16,7 +16,9 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Sync.Pipeline;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Theme;
 using AStar.Dev.OneDrive.Sync.Client.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Classifications;
 using AStar.Dev.OneDrive.Sync.Client.Domain;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Infrastructure.Sync.Pipeline;
 using Microsoft.Extensions.Logging;
@@ -58,8 +60,10 @@ public sealed class GivenAnApplicationInitializer
     private ActivityViewModel CreateActivityViewModel() => new(_syncRepository, _syncEventAggregator, new ConflictItemViewModelFactory(_syncService, _localizationService), new ActivityItemViewModelFactory(_localizationService), new InlineUiDispatcher(), _localizationService);
     private SettingsViewModel CreateSettingsViewModel() => new(_settingsService, _themeService, _scheduler, _accountRepository, _localizationService, Substitute.For<IFolderPickerService>());
 
+    private SyncedFileSearchViewModel CreateSearchViewModel() => new(Substitute.For<ISyncedItemRepository>(), Substitute.For<IFileOpenerService>(), Substitute.For<IFileTypeClassifier>(), _accountRepository, new InlineUiDispatcher(), _localizationService);
+
     private ApplicationInitializer CreateSut(AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings)
-        => new(_startupService, _quotaRefreshService, accounts, files, dashboard, activity, settings, Substitute.For<ILogger<ApplicationInitializer>>());
+        => new(_startupService, _quotaRefreshService, accounts, files, dashboard, activity, settings, CreateSearchViewModel(), Substitute.For<ILogger<ApplicationInitializer>>());
 
     private static OneDriveAccount BuildAccount(string id = "acc-1", string email = "user@test.com", bool isActive = false)
         => new() { Id = new AccountId(id), Profile = AccountProfileFactory.Create("Test User", email), IsActive = isActive, SelectedFolderIds = [] };

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Search/GivenASyncedFileSearchViewModel.cs
@@ -184,4 +184,32 @@ public sealed class GivenASyncedFileSearchViewModel
             File.Delete(existingPath);
         }
     }
+
+    [Fact]
+    public async Task when_set_active_account_is_called_then_available_tags_are_populated_from_repository()
+    {
+        repository.SearchAsync(Arg.Any<SyncedItemSearchCriteria>(), Arg.Any<CancellationToken>()).Returns([]);
+        repository.GetDistinctTagNamesAsync(TestAccountId, Arg.Any<CancellationToken>()).Returns(["Image", "Video", "Document"]);
+        var sut = new SyncedFileSearchViewModel(repository, fileOpenerService, fileTypeClassifier, accountRepository, dispatcher, loc);
+
+        sut.SetActiveAccount(TestAccountId);
+        await Task.Yield();
+
+        sut.AvailableTags.ShouldContain("Image");
+        sut.AvailableTags.ShouldContain("Video");
+        sut.AvailableTags.ShouldContain("Document");
+    }
+
+    [Fact]
+    public async Task when_set_active_account_is_called_and_repository_returns_no_tags_then_available_tags_is_empty()
+    {
+        repository.SearchAsync(Arg.Any<SyncedItemSearchCriteria>(), Arg.Any<CancellationToken>()).Returns([]);
+        repository.GetDistinctTagNamesAsync(TestAccountId, Arg.Any<CancellationToken>()).Returns(Array.Empty<string>());
+        var sut = new SyncedFileSearchViewModel(repository, fileOpenerService, fileTypeClassifier, accountRepository, dispatcher, loc);
+
+        sut.SetActiveAccount(TestAccountId);
+        await Task.Yield();
+
+        sut.AvailableTags.ShouldBeEmpty();
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-GB.json
@@ -207,6 +207,7 @@
   "Search.MinSize.Label": "Min size (bytes)",
   "Search.MaxSize.Label": "Max size (bytes)",
   "Search.Tags.Label": "Tags",
+  "Search.Tags.NoClassifications": "No classifications found.",
   "Search.DuplicatesOnly.Label": "Duplicates only",
   "Search.Button": "Search",
   "Search.DuplicateDisclaimer": "Showing duplicate files only.",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Assets/Localization/en-US.json
@@ -207,6 +207,7 @@
   "Search.MinSize.Label": "US-Min size (bytes)",
   "Search.MaxSize.Label": "US-Max size (bytes)",
   "Search.Tags.Label": "US-Tags",
+  "Search.Tags.NoClassifications": "US-No classifications found.",
   "Search.DuplicatesOnly.Label": "US-Duplicates only",
   "Search.Button": "US-Search",
   "Search.DuplicateDisclaimer": "US-Showing duplicate files only.",

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Converters/IntZeroToBoolConverter.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Converters/IntZeroToBoolConverter.cs
@@ -9,7 +9,11 @@ public sealed class IntZeroToBoolConverter : IValueConverter
     public static readonly IntZeroToBoolConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => value is int n && n == 0;
+    {
+        var isZero = value is int n && n == 0;
+
+        return parameter is string s && s == "negate" ? !isZero : isZero;
+    }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/ISyncedItemRepository.cs
@@ -24,4 +24,7 @@ public interface ISyncedItemRepository
 
     /// <summary>Searches synced items for the specified account using the provided criteria.</summary>
     Task<IReadOnlyList<SyncedItemSearchResult>> SearchAsync(SyncedItemSearchCriteria criteria, CancellationToken cancellationToken);
+
+    /// <summary>Returns all distinct tag names for synced items belonging to the specified account.</summary>
+    Task<IReadOnlyList<string>> GetDistinctTagNamesAsync(AccountId accountId, CancellationToken cancellationToken);
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Data/Repositories/SyncedItemRepository.cs
@@ -139,4 +139,17 @@ public sealed class SyncedItemRepository(IDbContextFactory<AppDbContext> dbFacto
 
         return items.Select(i => SyncedItemSearchResultFactory.Create(i.Id, i.AccountId, i.RemoteItemId, i.RemotePath, i.LocalPath, i.RemoteModifiedAt, i.SizeInBytes, i.TagNames)).ToList();
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> GetDistinctTagNamesAsync(AccountId accountId, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        return await db.SyncedItemClassifications
+            .Where(c => c.SyncedItem!.AccountId == accountId)
+            .Select(c => c.TagName)
+            .Distinct()
+            .OrderBy(tag => tag)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Infrastructure/Shell/ApplicationInitializer.cs
@@ -6,13 +6,14 @@ using AStar.Dev.OneDrive.Sync.Client.Dashboard;
 using AStar.Dev.OneDrive.Sync.Client.Home;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Logging;
+using AStar.Dev.OneDrive.Sync.Client.Search;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
 using Microsoft.Extensions.Logging;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Infrastructure.Shell;
 
 /// <inheritdoc />
-public sealed class ApplicationInitializer(IStartupService startupService, IQuotaRefreshService quotaRefreshService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, ILogger<ApplicationInitializer> logger) : IApplicationInitializer
+public sealed class ApplicationInitializer(IStartupService startupService, IQuotaRefreshService quotaRefreshService, AccountsViewModel accounts, FilesViewModel files, DashboardViewModel dashboard, ActivityViewModel activity, SettingsViewModel settings, SyncedFileSearchViewModel search, ILogger<ApplicationInitializer> logger) : IApplicationInitializer
 {
     /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken ct = default)
@@ -45,6 +46,7 @@ public sealed class ApplicationInitializer(IStartupService startupService, IQuot
             {
                 await files.ActivateAccountAsync(activeAccount.Id.Id).ConfigureAwait(false);
                 await activity.SetActiveAccountAsync(activeAccount.Id.Id, activeAccount.Profile.Email).ConfigureAwait(false);
+                search.SetActiveAccount(activeAccount.Id);
             }
 
             try

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchView.axaml
@@ -53,28 +53,38 @@
                     </StackPanel>
                 </Grid>
 
-                <!-- Tags multi-select (visible only when tags are available) -->
-                <StackPanel Spacing="4"
-                            IsVisible="{Binding AvailableTags.Count, Converter={StaticResource IntZeroToBoolConverter}, ConverterParameter=negate}">
+                <!-- Tags multi-select -->
+                <StackPanel Spacing="4">
                     <TextBlock Text="{Binding TagsLabelText}"
                                FontSize="{StaticResource FontSizeXs}"
                                Foreground="{DynamicResource TextTertiaryBrush}"/>
-                    <ItemsControl ItemsSource="{Binding AvailableTags}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal"/>
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type x:String}">
-                                <CheckBox Content="{Binding}"
-                                          Margin="0,0,8,4"
-                                          FontSize="{StaticResource FontSizeSm}"
-                                          Command="{Binding $parent[UserControl].((search:SyncedFileSearchViewModel)DataContext).ToggleTagCommand}"
-                                          CommandParameter="{Binding}"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <TextBlock Text="{Binding TagsNoClassificationsText}"
+                               FontSize="{StaticResource FontSizeSm}"
+                               Foreground="{DynamicResource TextTertiaryBrush}"
+                               FontStyle="Italic"
+                               IsVisible="{Binding AvailableTags.Count, Converter={StaticResource IntZeroToBoolConverter}}"/>
+                    <ScrollViewer MaxHeight="120"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  MinHeight="0"
+                                  IsVisible="{Binding AvailableTags.Count, Converter={StaticResource IntZeroToBoolConverter}, ConverterParameter=negate}">
+                        <ItemsControl ItemsSource="{Binding AvailableTags}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type x:String}">
+                                    <CheckBox Content="{Binding}"
+                                              Margin="0,0,8,4"
+                                              FontSize="{StaticResource FontSizeSm}"
+                                              Command="{Binding $parent[UserControl].((search:SyncedFileSearchViewModel)DataContext).ToggleTagCommand}"
+                                              CommandParameter="{Binding}"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </StackPanel>
 
                 <!-- Duplicates toggle + Search button -->

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/Search/SyncedFileSearchViewModel.cs
@@ -59,6 +59,9 @@ public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repo
     /// <summary>Localised "Tags" label.</summary>
     public string TagsLabelText => loc.GetLocal("Search.Tags.Label");
 
+    /// <summary>Localised message shown when no classifications exist for the active account.</summary>
+    public string TagsNoClassificationsText => loc.GetLocal("Search.Tags.NoClassifications");
+
     /// <summary>Localised "Duplicates only" toggle label.</summary>
     public string DuplicatesOnlyLabelText => loc.GetLocal("Search.DuplicatesOnly.Label");
 
@@ -78,7 +81,11 @@ public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repo
             SelectedTags.Add(tag);
     }
 
-    public void SetActiveAccount(AccountId accountId) => activeAccountId = accountId;
+    public void SetActiveAccount(AccountId accountId)
+    {
+        activeAccountId = accountId;
+        _ = LoadAvailableTagsAsync(accountId);
+    }
 
     [RelayCommand]
     private async Task SearchAsync(CancellationToken cancellationToken)
@@ -114,5 +121,17 @@ public sealed partial class SyncedFileSearchViewModel(ISyncedItemRepository repo
         {
             IsSearching = false;
         }
+    }
+
+    private async Task LoadAvailableTagsAsync(AccountId accountId)
+    {
+        var tags = await repository.GetDistinctTagNamesAsync(accountId, CancellationToken.None).ConfigureAwait(false);
+
+        dispatcher.Post(() =>
+        {
+            AvailableTags.Clear();
+            foreach (var tag in tags)
+                AvailableTags.Add(tag);
+        });
     }
 }

--- a/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
+++ b/apps/desktop/AStar.Dev.OneDrive.Sync.Client/appsettings.json
@@ -7,7 +7,7 @@
     "AuthorityForMicrosoftAccountsOnly": "https://login.microsoftonline.com/consumers"
   },
   "AStarDevOneDriveClient": {
-    "ApplicationVersion": "0.11.0",
+    "ApplicationVersion": "0.11.1",
     "ApplicationName": "AStar Dev OneDrive Sync Client",
     "CacheTag": 1,
     "UserPreferencesPath": "astar-dev/astar-dev-onedrive-client",

--- a/openspec/changes/file-search-with-thumbnails/.openspec.yaml
+++ b/openspec/changes/file-search-with-thumbnails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/file-search-with-thumbnails/design.md
+++ b/openspec/changes/file-search-with-thumbnails/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The OneDrive Sync Client stores synced file metadata in `SyncedItemEntity` (SQLite via EF Core) and classification tags in `SyncedItemClassificationEntity`. The `SyncedItemRepository` currently provides only bulk-load (`GetAllByAccountAsync`) and per-item CRUD operations — there is no query API. File size exists in the domain (`FileDeltaItem.size`, `SyncFileMetadata.FileSize`) but is not persisted. The UI has no search surface; users navigate files only via the folder tree.
+
+The `File.App` desktop app already contains `FileTypeClassifier` (extension → `FileType` enum) and `FileViewerService` (opens a file, tracks view history). Those are in a separate project and tied to `File.App`'s EF model, so they cannot be referenced directly; analogous types will be added to the sync client.
+
+Avalonia's `Bitmap` can load image files from disk, making on-demand thumbnail generation straightforward without a third-party library.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist `SizeInBytes` on `SyncedItemEntity` so it is available for filtering and duplicate detection.
+- Provide an in-process SQLite query via `ISyncedItemRepository.SearchAsync` covering name, size range, classification tag, and duplicate-flag filters.
+- Display results as cards with 150×150 Avalonia `Bitmap` thumbnails for images and SVG/font icons for other types.
+- Open local files in the OS default application on card click.
+- Integrate the search panel into the existing main-window navigation without disrupting other views.
+
+**Non-Goals:**
+- Remote (Graph API) search — all filtering runs against the local SQLite cache only.
+- Full-text content indexing.
+- Thumbnail caching to disk.
+- Bulk file actions (delete, move) from the search panel.
+- Pagination UI controls — virtual scroll (`ItemsRepeater` + `RecyclingElementFactory`) is sufficient for the expected corpus size.
+
+## Decisions
+
+### D1 — Add `SizeInBytes` to `SyncedItemEntity` via EF migration
+
+**Chosen:** New nullable `long? SizeInBytes` column with a default of `null` for pre-existing rows; set to `0` for folders.
+
+**Why:** The column is needed for size-range filtering and duplicate detection. Making it nullable lets the migration succeed without a back-fill pass; search simply treats `null` as "unknown" and excludes those rows when a size filter is active.
+
+**Alternative considered:** Derive size at query time from the local file on disk. Rejected — file may not exist (not yet downloaded), and hitting the file system per row during search is expensive.
+
+### D2 — Filter query implemented as EF Core LINQ in `SyncedItemRepository`
+
+**Chosen:** Build an `IQueryable<SyncedItemEntity>` chain inside `SyncedItemRepository.SearchAsync`, joining to `SyncedItemClassificationEntity` when a tag filter is active, then projecting to a `SyncedItemSearchResult` record.
+
+**Why:** Keeps all data access in the repository layer; EF Core translates LINQ to parameterised SQL, avoiding raw SQL strings. The duplicate filter uses a self-join on `(AccountId, SizeInBytes, derived FileName)` — achievable via a grouped subquery in LINQ.
+
+**Alternative considered:** Pull all rows and filter in memory. Rejected — corpus can be tens of thousands of files; memory cost and latency are unacceptable.
+
+### D3 — Duplicate detection by (FileName + SizeInBytes)
+
+**Chosen:** "Duplicate" means two or more non-folder `SyncedItemEntity` rows for the same account share the same `Path.GetFileName(RemotePath)` value and the same `SizeInBytes`. No hash comparison.
+
+**Why:** Hash storage requires another column and hashing at download time (significant pipeline change). Name+size catches the common case (photo duplicates, re-downloaded files) and is implementable entirely in SQL.
+
+**Limitation:** False positives are possible (different files, same name and size). Documented as a known limitation — acceptable for v1.
+
+### D4 — Thumbnail generation via Avalonia `Bitmap`, loaded on demand in the ViewModel
+
+**Chosen:** `SyncedFileResultViewModel` exposes `IImage? Thumbnail { get; }`. The setter is called lazily when the card scrolls into view (via `Loaded` event or an `IntersectionBehavior`). For image files, load `new Bitmap(localPath)` on a thread-pool thread, then marshal back to UI thread via `Dispatcher.UIThread.InvokeAsync`. Cap loaded dimension at 150px using `Bitmap.DecodeToWidth`.
+
+**Why:** Avalonia `Bitmap.DecodeToWidth` scales during decode, keeping memory low. No third-party library needed.
+
+**Alternative considered:** Use `SkiaSharp` for thumbnail generation (already a transitive dependency via Avalonia). Rejected — overkill; `Bitmap.DecodeToWidth` is sufficient and keeps the dependency surface minimal.
+
+### D5 — File open via new `IFileOpenerService` / `FileOpenerService`
+
+**Chosen:** Single-method service `OpenFile(string localPath)` using the same cross-platform `Process.Start` pattern as the existing `FileManagerService` (`xdg-open` / `open` / `explorer`). Registered as transient in DI.
+
+**Why:** Mirrors the existing pattern; avoids modifying `IFileManagerService` (single-responsibility). The sync client does not have a `FileViewerService` equivalent yet, and unlike `File.App`'s version there is no view-history database to update.
+
+### D6 — New `SyncedFileSearchView` as a top-level navigation destination
+
+**Chosen:** Add a "Search" entry to `MainWindowViewModel`'s navigation list alongside Accounts, Files, Activity, Settings. The view contains a criteria panel (top, `Auto` row) and a results `ScrollViewer` + `ItemsRepeater` (`*` row) per the Avalonia ScrollViewer bounded-viewport rule.
+
+**Why:** Keeps navigation consistent with existing patterns; the view is self-contained and doesn't depend on account tab state.
+
+## Risks / Trade-offs
+
+- **Migration on large existing databases** — adding a nullable column to `SyncedItems` is an instant DDL operation in SQLite (no table rewrite). `SizeInBytes` will be `null` for all pre-existing rows; duplicate filter and size filter silently exclude them until the next full sync populates the column. → Acceptable degraded-mode behaviour; no data loss.
+- **Thumbnail load latency** — large RAW/HEIC files can take seconds to decode even with `DecodeToWidth`. → Load on background thread; show a spinner placeholder until done.
+- **`SizeInBytes` for upload jobs** — `CreateFromUploadJob` derives size from `IFileSystem.FileInfo.New(localPath).Length`, which requires the file to exist locally at registration time. This is always true for uploads. → No risk.
+- **False-positive duplicates** — name+size matching is not collision-resistant. → Display a warning in the UI: "Duplicates are identified by name and size. Verify before deleting."
+- **SQLite `Path.GetFileName` in LINQ** — EF Core cannot translate `Path.GetFileName(e.RemotePath)` to SQL. → Use `e.RemotePath.Substring(e.RemotePath.LastIndexOf('/') + 1)` or load candidate rows into memory after a name-prefix pre-filter.
+
+## Migration Plan
+
+1. Add EF Core migration `AddSizeInBytesToSyncedItems` — adds nullable `SizeInBytes long` column, index on `(AccountId, SizeInBytes)`.
+2. Existing rows get `null`; no back-fill required.
+3. `SyncedItemEntityFactory` updated — future syncs populate `SizeInBytes`.
+4. New UI views and services registered — no breaking changes to existing navigation or sync pipeline.
+5. Rollback: revert migration (`dotnet ef database update <previous>`); remove new column.
+
+## Open Questions
+
+- Should the search panel be per-account (scoped to the active tab's `AccountId`) or global across all accounts? → Assumed global (all accounts) for v1; an account filter can be added later.
+- Virtual scroll vs. explicit pagination — `ItemsRepeater` with `RecyclingElementFactory` is preferred but adds complexity. If a 500-item result set is the realistic ceiling, a simple `ListBox` may suffice. → Decide at implementation time based on profiling.

--- a/openspec/changes/file-search-with-thumbnails/proposal.md
+++ b/openspec/changes/file-search-with-thumbnails/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Users have no way to locate specific synced files without browsing the folder tree; there is no search, no size filter, and no way to spot duplicates. A dedicated search panel with visual previews closes that gap and makes the synced-file corpus immediately navigable.
+
+## What Changes
+
+- Add a **Search** navigation entry to the OneDrive Sync Client main window.
+- Add a `SizeInBytes` column to `SyncedItemEntity` and a corresponding EF Core migration.
+- Populate `SizeInBytes` in `SyncedItemEntityFactory` from the already-available `FileDeltaItem.size` / `SyncFileMetadata.FileSize` values.
+- Extend `ISyncedItemRepository` with a `SearchAsync` method that accepts a filter criteria record and returns a paged list of matching entities with their classifications.
+- Add `IFileOpenerService` / `FileOpenerService` to open a local file in the OS default application (mirrors the existing `FileManagerService` pattern using `xdg-open` / `open` / `explorer`).
+- Add `SyncedFileSearchViewModel`, `SyncedFileResultViewModel`, and `SyncedFileSearchView` (Avalonia) implementing the search UI.
+- Register all new types in DI; wire the new view into the navigator.
+
+## Capabilities
+
+### New Capabilities
+
+- `synced-file-search`: Multi-criteria filter panel for synced files. Criteria — name (partial, case-insensitive), size range (min bytes, max bytes), one or more classification tags, and a "duplicates only" toggle. All active criteria are AND-joined. Results display in a scrollable grid with a count badge. Paging or virtual scroll keeps memory bounded.
+- `file-result-display`: Each search result card shows a 150×150 px thumbnail (loaded from `LocalPath`) for image files, and a file-type icon (derived from `FileTypeClassifier`-equivalent extension mapping) for all other types. Clicking the card opens the local file via the OS default application. Unavailable local files (not yet downloaded) show a placeholder icon and disable click-to-open.
+
+### Modified Capabilities
+
+- `file-classification`: No requirement changes — classification data is read-only in this feature. The existing `SyncedItemClassificationEntity` rows are the source for the tag filter.
+
+## Impact
+
+- **`SyncedItemEntity`** — new `SizeInBytes long` column; requires EF migration.
+- **`SyncedItemEntityFactory`** — all three `Create`/`CreateFromDownloadJob`/`CreateFromUploadJob` overloads must set `SizeInBytes` (available via `FileDeltaItem.size`, `SyncFileMetadata.FileSize`, and `IFileSystem.FileInfo` respectively).
+- **`ISyncedItemRepository` / `SyncedItemRepository`** — new `SearchAsync(SyncedItemSearchCriteria, CancellationToken)` returning `IReadOnlyList<SyncedItemSearchResult>` (entity + classifications joined).
+- **New `IFileOpenerService` / `FileOpenerService`** — single `OpenFile(string localPath)` method; cross-platform via `Process.Start`.
+- **New search ViewModel/View layer** — `SyncedFileSearchViewModel`, `SyncedFileResultViewModel`, `SyncedFileSearchView.axaml`.
+- **`MainWindowViewModel`** — add Search nav item.
+- **`ViewModelExtensions`** — register new services and ViewModels.
+- **No changes to sync pipeline, classification rules, or authentication.**

--- a/openspec/changes/file-search-with-thumbnails/specs/file-result-display/spec.md
+++ b/openspec/changes/file-search-with-thumbnails/specs/file-result-display/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Image thumbnail
+For files whose extension maps to `FileType.Image`, the system SHALL display a 150×150 px thumbnail decoded from the file at `LocalPath`. The thumbnail SHALL be decoded at the target width (using `Bitmap.DecodeToWidth(150)`) to avoid loading full-resolution data into memory. Thumbnail decoding SHALL occur on a background thread; the UI SHALL display a loading placeholder until decoding completes.
+
+#### Scenario: Image file with local copy present
+- **WHEN** the result is an image file and `LocalPath` points to an existing file
+- **THEN** a 150×150 thumbnail decoded from that file is displayed
+
+#### Scenario: Image file not yet downloaded
+- **WHEN** the result is an image file but `LocalPath` does not exist on disk
+- **THEN** a generic image placeholder icon is displayed and click-to-open is disabled
+
+#### Scenario: Thumbnail loads on background thread
+- **WHEN** the card scrolls into view
+- **THEN** the thumbnail begins decoding on a background thread, and the UI remains responsive until decoding completes
+
+### Requirement: File type icon
+For files whose extension does not map to `FileType.Image`, the system SHALL display a 150×150 icon representative of the file type (e.g. document, spreadsheet, video, audio, archive, code, unknown). The icon SHALL be a vector or high-resolution asset and SHALL NOT require access to `LocalPath`.
+
+#### Scenario: Document file
+- **WHEN** the result has extension `.pdf`, `.docx`, or `.txt`
+- **THEN** a document-type icon is displayed
+
+#### Scenario: Video file
+- **WHEN** the result has extension `.mp4`, `.mkv`, or `.mov`
+- **THEN** a video-type icon is displayed
+
+#### Scenario: Unknown extension
+- **WHEN** the result has an extension not in the recognised set
+- **THEN** a generic file icon is displayed
+
+### Requirement: Click to open
+Clicking the result card SHALL open the file at `LocalPath` in the OS default application. The system SHALL use the platform-appropriate launcher (`xdg-open` on Linux, `open` on macOS, `explorer` on Windows). If `LocalPath` does not exist on disk the click SHALL be a no-op and the card SHALL appear visually disabled.
+
+#### Scenario: Local file exists
+- **WHEN** the user clicks a result card whose `LocalPath` exists on disk
+- **THEN** the OS default application for that file type launches with the file
+
+#### Scenario: Local file missing
+- **WHEN** the user clicks a result card whose `LocalPath` does not exist on disk
+- **THEN** no application is launched and the card appears disabled
+
+#### Scenario: Cross-platform launcher
+- **WHEN** the application runs on Linux
+- **THEN** `xdg-open <LocalPath>` is invoked
+- **WHEN** the application runs on macOS
+- **THEN** `open <LocalPath>` is invoked
+- **WHEN** the application runs on Windows
+- **THEN** `explorer <LocalPath>` is invoked
+
+### Requirement: Result card metadata
+Each result card SHALL display the filename, formatted file size, and the most-specific classification tag alongside the thumbnail or icon.
+
+#### Scenario: Metadata displayed
+- **WHEN** a search result card is rendered
+- **THEN** it shows the filename (final segment of `RemotePath`), the formatted size (e.g. `"4.2 MB"`), and the `TagName` of the first associated classification (or `"Unclassified"` if none)
+
+### Requirement: Duplicate warning
+When the duplicates-only filter is active the system SHALL display a disclaimer stating that duplicates are identified by name and size only and that verification is recommended before taking action.
+
+#### Scenario: Disclaimer visible with duplicates filter
+- **WHEN** the duplicates-only toggle is active
+- **THEN** the disclaimer text is visible in the results panel
+
+#### Scenario: Disclaimer hidden without duplicates filter
+- **WHEN** the duplicates-only toggle is inactive
+- **THEN** the disclaimer text is not shown

--- a/openspec/changes/file-search-with-thumbnails/specs/synced-file-search/spec.md
+++ b/openspec/changes/file-search-with-thumbnails/specs/synced-file-search/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Name filter
+The system SHALL filter synced file results to those whose filename (the final path segment of `RemotePath`) contains the supplied name fragment, case-insensitively. When no name fragment is provided the name filter SHALL be inactive.
+
+#### Scenario: Partial name match
+- **WHEN** the user enters `"holiday"` in the name field
+- **THEN** only files whose filename contains `"holiday"` (case-insensitive) appear in results
+
+#### Scenario: Empty name field
+- **WHEN** the name field is empty
+- **THEN** the name filter is inactive and does not restrict results
+
+#### Scenario: No matches
+- **WHEN** the user enters a name fragment that matches no synced filenames
+- **THEN** the results list is empty and a "No results" message is shown
+
+### Requirement: Size range filter
+The system SHALL filter results to files whose `SizeInBytes` falls within an inclusive [min, max] range. Either bound MAY be left blank, in which case that bound is unbounded. Files with `SizeInBytes` of `null` (not yet populated) SHALL be excluded when any size bound is active.
+
+#### Scenario: Minimum size only
+- **WHEN** the user sets minimum size to 10 MB and leaves maximum blank
+- **THEN** only files with `SizeInBytes >= 10,485,760` are returned
+
+#### Scenario: Maximum size only
+- **WHEN** the user sets maximum size to 1 MB and leaves minimum blank
+- **THEN** only files with `SizeInBytes <= 1,048,576` are returned
+
+#### Scenario: Both bounds set
+- **WHEN** the user sets minimum to 1 MB and maximum to 10 MB
+- **THEN** only files with `1,048,576 <= SizeInBytes <= 10,485,760` are returned
+
+#### Scenario: Null size excluded when filter active
+- **WHEN** any size bound is set
+- **THEN** files with `SizeInBytes = null` do not appear in results
+
+### Requirement: Classification tag filter
+The system SHALL filter results to files that carry at least one `SyncedItemClassificationEntity` row whose `TagName` matches any of the selected tags. When no tags are selected the classification filter SHALL be inactive.
+
+#### Scenario: Single tag selected
+- **WHEN** the user selects the tag `"Holiday"`
+- **THEN** only files that have a classification with `TagName = "Holiday"` are returned
+
+#### Scenario: Multiple tags selected (OR within tag filter)
+- **WHEN** the user selects tags `"Holiday"` and `"Work"`
+- **THEN** files that have a classification matching `"Holiday"` OR `"Work"` are returned
+
+#### Scenario: No tags selected
+- **WHEN** no tags are selected
+- **THEN** the classification filter is inactive and does not restrict results
+
+### Requirement: Duplicates-only filter
+The system SHALL identify duplicate files as two or more non-folder `SyncedItemEntity` rows belonging to the same account that share identical filename (final segment of `RemotePath`) and `SizeInBytes`. When the "duplicates only" toggle is active only such files SHALL appear in results.
+
+#### Scenario: Toggle on — duplicates present
+- **WHEN** the duplicates toggle is active and two files share the same name and size
+- **THEN** both files appear in results
+
+#### Scenario: Toggle on — no duplicates
+- **WHEN** the duplicates toggle is active and no files share a name and size
+- **THEN** the results list is empty
+
+#### Scenario: Toggle off
+- **WHEN** the duplicates toggle is inactive
+- **THEN** the duplicate condition does not restrict results
+
+### Requirement: Combined filter (AND semantics)
+The system SHALL apply all active criteria simultaneously using AND logic: a file appears in results only when it satisfies every active filter.
+
+#### Scenario: Name and classification combined
+- **WHEN** the user enters name `"beach"` and selects tag `"Holiday"`
+- **THEN** only files whose filename contains `"beach"` AND that carry a `"Holiday"` classification are returned
+
+#### Scenario: Size and duplicates combined
+- **WHEN** the user sets minimum size to 5 MB and enables the duplicates toggle
+- **THEN** only files that are duplicates AND have `SizeInBytes >= 5,242,880` are returned
+
+### Requirement: Result count badge
+The system SHALL display the count of matching results adjacent to the search criteria panel. The count SHALL update each time the active criteria change and after each search execution.
+
+#### Scenario: Count reflects filter results
+- **WHEN** a search returns 42 files
+- **THEN** the badge displays `"42"`
+
+#### Scenario: Count on empty results
+- **WHEN** no files match the active criteria
+- **THEN** the badge displays `"0"`
+
+### Requirement: Folder exclusion
+The system SHALL exclude folder entries (`IsFolder = true`) from all search results regardless of other filter criteria.
+
+#### Scenario: Folders not returned
+- **WHEN** the user searches with no filters active
+- **THEN** `SyncedItemEntity` rows where `IsFolder = true` do not appear in results

--- a/openspec/changes/file-search-with-thumbnails/tasks.md
+++ b/openspec/changes/file-search-with-thumbnails/tasks.md
@@ -1,0 +1,63 @@
+## 1. Data Layer — SizeInBytes Column
+
+- [x] 1.1 Write failing unit tests for all three `SyncedItemEntityFactory` overloads asserting `SizeInBytes` is set correctly (RED commit)
+- [x] 1.2 Add `SizeInBytes long?` property to `SyncedItemEntity`
+- [x] 1.3 Add EF Core migration `AddSizeInBytesToSyncedItems` (nullable column + index on `AccountId, SizeInBytes`)
+- [x] 1.4 Update `SyncedItemEntityConfiguration` if needed for the new column
+- [x] 1.5 Update `SyncedItemEntityFactory.Create(AccountId, FileDeltaItem, ...)` to set `SizeInBytes = item.Size`
+- [x] 1.6 Update `SyncedItemEntityFactory.CreateFromDownloadJob` to set `SizeInBytes` from `SyncFileMetadata.FileSize`
+- [x] 1.7 Update `SyncedItemEntityFactory.CreateFromUploadJob` to set `SizeInBytes` from `IFileSystem.FileInfo.New(localPath).Length`
+- [x] 1.8 Verify all 1.1 tests pass (GREEN)
+
+## 2. Repository — Search Query
+
+- [x] 2.1 Define `SyncedItemSearchCriteria` record (NameFragment, MinBytes, MaxBytes, Tags, DuplicatesOnly, AccountId)
+- [x] 2.2 Define `SyncedItemSearchResult` record (entity fields needed for display + list of TagNames)
+- [x] 2.3 Write failing unit tests for `SyncedItemRepository.SearchAsync` covering: name filter, size range, tag filter, duplicates toggle, combined criteria, folder exclusion, null-size exclusion when size filter active (RED commit)
+- [x] 2.4 Add `SearchAsync(SyncedItemSearchCriteria, CancellationToken)` to `ISyncedItemRepository`
+- [x] 2.5 Implement `SearchAsync` in `SyncedItemRepository` with LINQ query chain (name, size range, tag join, duplicate sub-query, folder exclusion)
+- [x] 2.6 Verify all 2.3 tests pass (GREEN)
+
+## 3. File Opener Service
+
+- [x] 3.1 Define `IFileOpenerService` with `OpenFile(string localPath)` method
+- [x] 3.2 Write failing unit tests for `FileOpenerService` verifying cross-platform launcher selection and no-op when file missing (RED commit)
+- [x] 3.3 Implement `FileOpenerService` using cross-platform `Process.Start` (mirrors `FileManagerService`)
+- [x] 3.4 Register `IFileOpenerService` / `FileOpenerService` as transient in DI
+- [x] 3.5 Verify all 3.2 tests pass (GREEN)
+
+## 4. File Type Classification (OneDrive Client)
+
+- [x] 4.1 Define `IFileTypeClassifier` interface in the OneDrive sync client
+- [x] 4.2 Write failing unit tests for `SyncClientFileTypeClassifier` covering image, document, video, audio, archive, code, unknown extensions (RED commit)
+- [x] 4.3 Implement `SyncClientFileTypeClassifier` mapping extensions to `FileType` enum (same extension map as `File.App`'s `FileTypeClassifier`)
+- [x] 4.4 Register `IFileTypeClassifier` / `SyncClientFileTypeClassifier` in DI
+- [x] 4.5 Verify all 4.2 tests pass (GREEN)
+
+## 5. Search ViewModel
+
+- [x] 5.1 Define `SyncedFileResultViewModel` and `SyncedFileSearchViewModel` skeletons (properties only, no behaviour)
+- [x] 5.2 Write failing unit tests for `SyncedFileSearchViewModel`: criteria building, result mapping, `ResultCount` updates, `ShowDuplicateDisclaimer` toggling, disabled open when local file missing (RED commit)
+- [x] 5.3 Implement `SyncedFileResultViewModel` with properties: FileName, FormattedSize, TagName, LocalPath, FileType, IsLocalPresent, Thumbnail (`IImage?`)
+- [x] 5.4 Implement lazy thumbnail loading in `SyncedFileResultViewModel`: decode on background thread via `Bitmap.DecodeToWidth(150)`, marshal to UI thread, placeholder while loading
+- [x] 5.5 Implement `SyncedFileSearchViewModel` with: criteria properties (NameFragment, MinSize, MaxSize, SelectedTags, DuplicatesOnly), `SearchCommand`, `Results`, `ResultCount`, `AvailableTags`, `IsSearching`, `ShowDuplicateDisclaimer`
+- [x] 5.6 Implement `SearchCommand` handler: build criteria, call `SearchAsync`, map to `SyncedFileResultViewModel` list
+- [x] 5.7 Implement `OpenFileCommand` on `SyncedFileResultViewModel` calling `IFileOpenerService.OpenFile` when `IsLocalPresent`
+- [x] 5.8 Verify all 5.2 tests pass (GREEN)
+
+## 6. Search View (Avalonia XAML)
+
+- [x] 6.1 Create `SyncedFileSearchView.axaml` with criteria panel (`Auto` row) and results `ScrollViewer` + `ItemsRepeater` (`*` row) per bounded-viewport rule
+- [x] 6.2 Add name text field, size min/max numeric fields, tag multi-select, duplicates toggle, Search button to criteria panel
+- [x] 6.3 Add result card `DataTemplate` showing thumbnail/icon (150×150), filename, formatted size, tag name
+- [x] 6.4 Add result count badge bound to `ResultCount`
+- [x] 6.5 Add duplicate disclaimer `TextBlock` bound to `ShowDuplicateDisclaimer`
+- [x] 6.6 Style disabled card state when `IsLocalPresent = false`
+- [x] 6.7 Register `SyncedFileSearchView` / `SyncedFileSearchViewModel` pair in `ViewLocator`
+
+## 7. Navigation Integration
+
+- [x] 7.1 Write failing unit/integration test asserting Search nav entry exists in `MainWindowViewModel` (RED commit)
+- [x] 7.2 Add `Search` navigation entry to `MainWindowViewModel` nav list
+- [x] 7.3 Register `SyncedFileSearchViewModel` in DI (`ViewModelExtensions`)
+- [x] 7.4 Verify all 7.1 tests pass and existing nav items unaffected (GREEN)


### PR DESCRIPTION
# Summary

Fixes three layered bugs that prevented tags from ever appearing in the Search page filter, and improves the UX when no classifications exist.

**Bug A — startup path never triggered tag load:** `ApplicationInitializer` restored the active account for `FilesViewModel` and `ActivityViewModel` but never called `SetActiveAccount` on `SyncedFileSearchViewModel`, so `AvailableTags` stayed empty for the lifetime of the session.

**Bug B — missing repository method:** `ISyncedItemRepository` had no `GetDistinctTagNamesAsync`; `SyncedFileSearchViewModel` had no way to query tags. Added interface method + EF Core implementation using a navigation-property predicate (`c.SyncedItem!.AccountId == accountId`).

**Bug C — converter ignored `ConverterParameter`:** `IntZeroToBoolConverter.Convert` returned `value is int n && n == 0` regardless of `parameter`. `ConverterParameter=negate` had zero effect, so the tags `ItemsControl` was hidden whenever `AvailableTags` was non-empty — the exact opposite of intended.

**UX improvement:** Tags section is now always visible. Shows italic _"No classifications found."_ when `AvailableTags` is empty; scrollable checkbox list (bounded by `MaxHeight="120"` per Avalonia bounded-viewport rule) when tags are populated.

Also adds openspec design artefacts (`openspec/changes/file-search-with-thumbnails/`) that were used to design this feature set.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] CI/CD
- [ ] Documentation
- [ ] Maintenance

## Related issues / links

Closes #566
Relates to #556

## How was this tested?

- [x] Unit tests added/updated
- [x] Manual validation

## Impacted areas

- `apps/desktop/AStar.Dev.OneDrive.Sync.Client`
- `apps/desktop/AStar.Dev.OneDrive.Sync.Client.Tests.Unit`
- `openspec/changes/file-search-with-thumbnails/`

---

## TDD Checklist (required)

- [x] Builds locally — `dotnet build`: 0 errors, 0 warnings
- [x] Tests pass (`dotnet test`) — 1933/1933 passed, 0 failed
- [x] No new analyzer warnings
- [x] Public API changes reviewed (`ISyncedItemRepository` + `IntZeroToBoolConverter`)
- [ ] Documentation updated (if applicable)

---

## How to run tests locally

```bash
dotnet restore AStar.Dev.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- `IntZeroToBoolConverter` change is safe: only `SyncedFileSearchView.axaml:67` used `ConverterParameter=negate`; other two usages (`DashboardView.axaml:304`, `SyncedFileSearchView.axaml:152`) pass no parameter and continue to receive `isZero` unchanged.
- `SetActiveAccount` is fire-and-forget (`_ = LoadAvailableTagsAsync(...)`); UI updates are marshalled back via `IUiDispatcher.Post` — no UI-thread violations.
- Tags `ScrollViewer` uses `MaxHeight="120"` rather than a `*` Grid row because it lives inside the `Auto` criteria panel; `MaxHeight` provides the bounded viewport Avalonia requires for scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)